### PR TITLE
Added support for press releases in EX-99 attachments.

### DIFF
--- a/edgar/company_reports.py
+++ b/edgar/company_reports.py
@@ -491,14 +491,14 @@ class EightK():
     @property
     def has_press_release(self):
         attachments: Attachments = self._filing.attachments
-        # press release is Type EX-99.1
-        return attachments.query("Type=='EX-99.1'") is not None
+        # press release is Type EX-99 or EX-99.1
+        return attachments.query("Type=='EX-99' | Type=='EX-99.1'") is not None
 
     @property
     def press_release(self):
         attachments: Attachments = self._filing.attachments
-        # press release is Type EX-99.1
-        press_release_results = attachments.query("Type=='EX-99.1' & Document.str.contains('htm')")
+        # press release is Type EX-99 or EX-99.1
+        press_release_results = attachments.query("(Type=='EX-99' | Type=='EX-99.1') & Document.str.contains('htm')")
         if press_release_results:
             if isinstance(press_release_results, Attachment):
                 return PressRelease(press_release_results)
@@ -572,7 +572,7 @@ class EightK():
 class PressRelease:
     """
     Represents a press release attachment from an 8-K filing
-    With the Type EX-99.1
+    With the Type EX-99 or EX-99.1
     """
 
     def __init__(self, attachment: Attachment):

--- a/tests/test_company_reports.py
+++ b/tests/test_company_reports.py
@@ -197,6 +197,16 @@ def test_create_eightk_obj_and_find_items():
 
 
 def test_get_press_release():
+    # With EX-99
+    filing = Filing(form="8-K", filing_date="2024-03-21", company="Accenture plc", cik=1467373, accession_no="0001467373-24-000106")
+    eightk = filing.obj()
+    assert eightk.has_press_release
+    press_release: PressRelease = eightk.press_release
+    assert press_release.document == "fy24q2earnings8-kexhibit.htm"
+    assert isinstance(press_release, PressRelease)
+    assert "Accenture Reports Second-Quarter Fiscal 2024 Results" in press_release.text()
+
+    # With EX-99.1
     filing = Filing(form='8-K', filing_date='2024-03-08', company='3M CO', cik=66740,
                     accession_no='0000066740-24-000023')
     eightk = filing.obj()


### PR DESCRIPTION
A fix for Issue https://github.com/dgunning/edgartools/issues/34

Added `EX-99` as a second type of valid attachment for press releases.

All tests are passing, except for `test_form4_to_markdown()` which fails on line 35, but that is unrelated to my changes.