### PR TITLE
add entity icons from ticker

### DIFF
--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -18,6 +18,7 @@ from edgar.entities import (Company,
                             get_entity,
                             get_company_facts,
                             get_company_tickers,
+                            get_icon_from_ticker,
                             get_entity_submissions,
                             get_ticker_to_cik_lookup,
                             get_cik_lookup_data)

--- a/edgar/entities.py
+++ b/edgar/entities.py
@@ -27,7 +27,7 @@ from edgar.core import (log, Result, display_size,
                         filter_by_date, IntString, InvalidDateException, reverse_name, get_edgar_data_directory)
 from edgar.httprequests import download_json, download_text, download_bulk_data
 from edgar.reference import states
-from edgar.reference.tickers import get_company_tickers
+from edgar.reference.tickers import get_company_tickers, get_icon_from_ticker
 from edgar.search.datasearch import FastSearch, company_ticker_preprocess, company_ticker_score
 
 __all__ = [
@@ -395,6 +395,14 @@ class EntityData:
     @property
     def is_company(self) -> bool:
         return not self.is_individual
+    
+    @property
+    def icon(self) -> bytes | None:
+        # If there are no tickers, we can't get an icon
+        if len(self.tickers) == 0:
+            return None
+        # Get the icon for the first ticker, if it exists.
+        return get_icon_from_ticker(self.tickers[0])
 
     @property
     # Companies have a ein, individuals do not. Oddly Warren Buffet has an EIN but not a state of incorporation

--- a/edgar/reference/__init__.py
+++ b/edgar/reference/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 from edgar.reference.forms import describe_form
-from edgar.reference.tickers import get_ticker_from_cusip, cusip_ticker_mapping
+from edgar.reference.tickers import get_ticker_from_cusip, get_icon_from_ticker, cusip_ticker_mapping
 
 
 # A dict of state abbreviations and their full names

--- a/edgar/reference/tickers.py
+++ b/edgar/reference/tickers.py
@@ -4,8 +4,10 @@ from typing import Union
 
 import pandas as pd
 import pyarrow as pa
+from httpx import HTTPStatusError
 
-from edgar.httprequests import download_json
+
+from edgar.httprequests import download_file, download_json
 from edgar.reference.data.common import read_parquet_from_package
 
 __all__ = ['cusip_ticker_mapping', 'get_ticker_from_cusip', 'get_company_tickers']
@@ -89,3 +91,29 @@ def get_company_tickers(as_dataframe: bool = True,
     table = pa.Table.from_pylist(data, schema=schema)
 
     return table
+
+
+@lru_cache(maxsize=4)
+def get_icon_from_ticker(ticker: str) -> bytes | None:
+    """
+    Download an icon for a given ticker as a PNG image, if available.
+
+    WARNING: This function uses the nvstly/icons repository on GitHub to fetch the icons.
+    The icons are not guaranteed to be available for all tickers.
+    """
+
+    if not isinstance(ticker, str):
+        raise ValueError("The ticker must be a valid string.")
+
+    if not ticker.isalpha():
+        raise ValueError("The ticker must only contain alphabetic characters.")
+
+    try:
+        downloaded = download_file(f"https://raw.githubusercontent.com/nvstly/icons/main/ticker_icons/{ticker.upper()}.png", as_text=False)
+        return downloaded
+    except HTTPStatusError as e:
+        # If the status code is 404, the icon is not available
+        if e.response.status_code == 404:
+            return None
+        else:
+            raise

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -65,3 +65,16 @@ def test_insider_transaction_for_entity():
     assert not entity.insider_transaction_for_issuer_exists
     assert entity.insider_transaction_for_owner_exists
     assert entity.name == "DeNunzio Jeffrey"
+
+def test_ticker_icon():
+    entity: Entity = Entity(320193)
+    assert entity.tickers[0] == "AAPL"
+    icon = entity.icon
+    assert icon is not None
+    assert isinstance(icon, bytes)
+    assert icon[:8] == b"\x89PNG\r\n\x1a\n"
+
+    entity: Entity = Entity(1465740)
+    assert entity.tickers[0] == "TWO"
+    icon = entity.icon
+    assert icon is None

--- a/tests/test_tickers.py
+++ b/tests/test_tickers.py
@@ -1,7 +1,8 @@
 
-from edgar.reference.tickers import cusip_ticker_mapping, get_ticker_from_cusip, get_company_tickers, clean_company_suffix
+from edgar.reference.tickers import cusip_ticker_mapping, get_ticker_from_cusip, get_company_tickers, get_icon_from_ticker, clean_company_suffix
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 
 def test_get_tickers():
@@ -22,3 +23,29 @@ def test_clean_company_suffix():
     assert clean_company_suffix('SOUTHERN COPPER CORP') == 'SOUTHERN COPPER'
     assert clean_company_suffix('ANZ GROUP HOLDINGS LIMITED') == 'ANZ GROUP HOLDINGS'
     #assert clean_company_suffix('ENTERPRISE PRODUCTS PARTNERS L.P.') == 'ENTERPRISE PRODUCTS PARTNERS'
+
+def test_get_icon_valid_ticker():
+    icon = get_icon_from_ticker("AAPL")
+    assert icon is not None
+    assert isinstance(icon, bytes)
+    assert icon[:8] == b"\x89PNG\r\n\x1a\n"
+
+def test_get_icon_invalid_ticker():
+    icon = get_icon_from_ticker("INVALID")
+    assert icon is None
+
+def test_get_icon_bad_ticker():
+    with pytest.raises(ValueError):
+        icon = get_icon_from_ticker("A.!@#$%^&*()")
+
+    with pytest.raises(ValueError):
+        icon = get_icon_from_ticker("AAPL 123")
+
+    with pytest.raises(ValueError):
+        icon = get_icon_from_ticker("")
+
+    with pytest.raises(ValueError):
+        icon = get_icon_from_ticker(None)
+
+    with pytest.raises(ValueError):
+        icon = get_icon_from_ticker(123)


### PR DESCRIPTION
Adds the ability to get a company's logo if exists based on their ticker.

```py
apple_logo = get_icon_from_ticker("aapl")  # Returns a PNG in bytes
```

Or from the entity direct;

```py
apple_logo = Entity("AAPL").icon # Returns a PNG in bytes
``` 