### PR TITLE
fix: handle `float` voting authority values in `ThirteenF`

### DIFF
--- a/edgar/thirteenf.py
+++ b/edgar/thirteenf.py
@@ -314,9 +314,9 @@ class ThirteenF:
 
             # Voting authority
             voting_auth_tag = info_tag.find("votingAuthority")
-            info_table['SoleVoting'] = int(child_text(voting_auth_tag, "Sole"))
-            info_table['SharedVoting'] = int(child_text(voting_auth_tag, "Shared"))
-            info_table['NonVoting'] = int(child_text(voting_auth_tag, "None"))
+            info_table['SoleVoting'] = int(float(child_text(voting_auth_tag, "Sole")))
+            info_table['SharedVoting'] = int(float(child_text(voting_auth_tag, "Shared")))
+            info_table['NonVoting'] = int(float(child_text(voting_auth_tag, "None")))
             rows.append(info_table)
 
         table = pd.DataFrame(rows)


### PR DESCRIPTION
### Goal

Ensure filing objects can be parsed even if `votingAuthority` fields are submitted as floating point numbers instead of integers.

### Fixed Error

Minimal reproduction of the error this PR fixes:

```python
import edgar

edgar.set_identity('Hello there@world.com')
edgar.get_by_accession_number('0001223779-20-000001').obj().infotable
```

Error:

```text
File ~/Library/Application Support/hatch/env/virtual/mypk/5K67ojG_/mypk/lib/python3.11/site-packages/edgar/thirteenf.py:318, in ThirteenF.parse_infotable_xml(infotable_xml)
    316 voting_auth_tag = info_tag.find(\"votingAuthority\")
    317 info_table['SoleVoting'] = int(child_text(voting_auth_tag, \"Sole\"))
--> 318 info_table['SharedVoting'] = int(child_text(voting_auth_tag, \"Shared\"))
    319 info_table['NonVoting'] = int(child_text(voting_auth_tag, \"None\"))
    320 rows.append(info_table)

ValueError: invalid literal for int() with base 10: '0.0'"
```