### PR TITLE
convert repeat keys into lists when parsing headers

### DIFF
--- a/edgar/filingheader.py
+++ b/edgar/filingheader.py
@@ -633,7 +633,7 @@ class FilingHeader:
             
         # Convert all lists to strings
         for key, value in data.items():
-            if isinstance(value, list):
+            if isinstance(value, list) and all(isinstance(item, str) for item in value):
                 data[key] = ', '.join(value)
 
         # Create a dict of the values in data that are not nested dicts

--- a/edgar/filingheader.py
+++ b/edgar/filingheader.py
@@ -407,7 +407,16 @@ class FilingHeader:
                     # The line looks like this <KEY>VALUE
                     key, value = line.split('>')
                     # Strip the leading '<' from the key
-                    data[key[1:]] = value
+                    key = key[1:]
+                    
+                    # If the key already exists, we should convert it to a list
+                    if key in data:
+                        if isinstance(data[key], list):
+                            data[key].append(value)
+                        else:
+                            data[key] = [data[key], value]
+                    else:
+                        data[key] = value
                 elif ':' in line:
                     parts = line.strip().split(':')
                     if len(parts) == 2:
@@ -416,7 +425,14 @@ class FilingHeader:
                         key, value = parts[0], ":".join(parts[1:])
                     value = value.strip()
                     if not current_header:
-                        data[key] = value
+                        # If the key already exists, we should convert it to a list
+                        if key in data:
+                            if isinstance(data[key], list):
+                                data[key].append(value)
+                            else:
+                                data[key] = [data[key], value]
+                        else:
+                            data[key] = value
                     elif not current_subheader:
                         continue
                     else:

--- a/edgar/filingheader.py
+++ b/edgar/filingheader.py
@@ -630,6 +630,11 @@ class FilingHeader:
                 if 'FORMER COMPANY' in subject_company_values else None
             )
             subject_companies.append(subject_company)
+            
+        # Convert all lists to strings
+        for key, value in data.items():
+            if isinstance(value, list):
+                data[key] = ', '.join(value)
 
         # Create a dict of the values in data that are not nested dicts
         filing_metadata = {key: value

--- a/tests/test_filing_header.py
+++ b/tests/test_filing_header.py
@@ -383,3 +383,22 @@ def test_get_header_for_filing_with_no_reportingowner_entity():
                     accession_no='0001127602-24-022866')
     header = filing.header
     assert header
+
+def test_get_header_for_list_fields():
+    filing = Filing(form='SC 13G', filing_date='2024-09-06', company='BioCardia, Inc.', cik=925741,
+                    accession_no='0001213900-24-076658')
+    
+    members = filing.header.filing_metadata.get("GROUP MEMBERS") 
+    assert members == "DANIEL B. ASHER, MITCHELL P. KOPIN"
+
+def test_get_header_for_list_fields_with_multiple_entries():
+    # Inject a new field with multiple entries
+    header_content = Path('data/secheader.424B5.abeona.txt').read_text()
+    header_content = f"""{header_content[:-len('</SEC-HEADER>')]}
+<TEST-FIELD>foo
+<TEST-FIELD>bar
+</SEC-HEADER>"""
+
+    filing_header = FilingHeader.parse_from_sgml_text(header_content)
+    
+    assert filing_header.filing_metadata.get("TEST-FIELD") == "foo, bar"


### PR DESCRIPTION
This PR aims to improve filing headers for duplicate keys. 

Example:
```
<SEC-DOCUMENT>0001213900-24-076658.txt : 20240906
<SEC-HEADER>0001213900-24-076658.hdr.sgml : 20240906
<ACCEPTANCE-DATETIME>20240906194548
ACCESSION NUMBER:		0001213900-24-076658
CONFORMED SUBMISSION TYPE:	SC 13G
PUBLIC DOCUMENT COUNT:		2
FILED AS OF DATE:		20240906
DATE AS OF CHANGE:		20240906
GROUP MEMBERS:		DANIEL B. ASHER
GROUP MEMBERS:		MITCHELL P. KOPIN       <-- Appears twice
```

Previously the following would be parsed;
<img width="659" alt="Screenshot 2024-09-07 at 9 10 43 PM" src="https://github.com/user-attachments/assets/ba780016-c964-4db2-9819-45c40c1ef340">

This PR adds support for the following;
<img width="814" alt="Screenshot 2024-09-07 at 9 11 38 PM" src="https://github.com/user-attachments/assets/81a86a07-ceb3-4a85-9175-8cb332c3c13b">
