### PR TITLE
Fix download_edgar_data

### DIFF
--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -600,11 +600,9 @@ async def download_bulk_data(data_url: str) -> Path:
     if not download_path.exists():
         download_path.mkdir()
 
-    as_text = data_url.endswith('.zip')
-
     if filename.endswith(".zip"):
         # Now stream the file to the data directory
-        await stream_file(data_url, as_text=as_text, path=download_path)
+        await stream_file(data_url, path=download_path)
         # Unzip the file to the data directory / file
         with zipfile.ZipFile(download_filename, 'r') as z:
             z.extractall(download_path)


### PR DESCRIPTION
Currently `download_edgar_data` will fail with:

```bash
>>> download_edgar_data()
[15:50:20] INFO     Downloading Company submissions  entities.py:937
                    to                                              
                    /home/user/.edgar/submissions                  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/edgar/venv/lib/python3.12/site-packages/edgar/core.py", line 251, in download_edgar_data
    download_submissions()
  File "/edgar/venv/lib/python3.12/site-packages/edgar/entities.py", line 945, in download_submissions
    return asyncio.run(download_submissions_async())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/edgar/venv/lib/python3.12/site-packages/edgar/entities.py", line 938, in download_submissions_async
    return await download_bulk_data("https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edgar/venv/lib/python3.12/site-packages/edgar/httprequests.py", line 607, in download_bulk_data
    await stream_file(data_url, as_text=as_text, path=download_path)
  File "/edgar/venv/lib/python3.12/site-packages/edgar/httprequests.py", line 491, in stream_file
    content = await response.text()
                    ^^^^^^^^^^^^^
  File "/edgar/venv/lib/python3.12/site-packages/httpx/_models.py", line 578, in text
    content = self.content
              ^^^^^^^^^^^^
  File "/edgar/venv/lib/python3.12/site-packages/httpx/_models.py", line 572, in content
    raise ResponseNotRead()
httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```

Due to `as_text` being improperly set to `True`.

This PR fixes that.
