### PR TITLE
Minor refactor of regex patterns to use raw strings.

### DIFF
--- a/edgar/documents.py
+++ b/edgar/documents.py
@@ -626,7 +626,7 @@ def decompose_toc_links(start_element: Tag):
 
 
 def decompose_page_numbers(start_element: Tag):
-    span_tags_with_numbers = start_element.find_all('span', string=re.compile('^\d{1,3}$'))
+    span_tags_with_numbers = start_element.find_all('span', string=re.compile(r'^\d{1,3}$'))
     sequences = []  # To store the sequences of tags for potential review
     current_sequence = []
     previous_number = None

--- a/edgar/documents.py
+++ b/edgar/documents.py
@@ -626,7 +626,7 @@ def decompose_toc_links(start_element: Tag):
 
 
 def decompose_page_numbers(start_element: Tag):
-    span_tags_with_numbers = start_element.find_all('span', string=re.compile(r'^\d{1,3}$'))
+    span_tags_with_numbers = start_element.find_all('span', string=re.compile('^\d{1,3}$'))
     sequences = []  # To store the sequences of tags for potential review
     current_sequence = []
     previous_number = None

--- a/edgar/funds.py
+++ b/edgar/funds.py
@@ -375,7 +375,7 @@ def get_fund_with_filings(contract_or_series_id: str):
        to get the fund class or series including the filings
 
     """
-    if not re.match("[CS]\d+", contract_or_series_id):
+    if not re.match(r"[CS]\d+", contract_or_series_id):
         return None
     search_url = fund_class_or_series_search_url.format(contract_or_series_id)
 

--- a/edgar/funds.py
+++ b/edgar/funds.py
@@ -375,7 +375,7 @@ def get_fund_with_filings(contract_or_series_id: str):
        to get the fund class or series including the filings
 
     """
-    if not re.match(r"[CS]\d+", contract_or_series_id):
+    if not re.match("[CS]\d+", contract_or_series_id):
         return None
     search_url = fund_class_or_series_search_url.format(contract_or_series_id)
 

--- a/edgar/htmltools.py
+++ b/edgar/htmltools.py
@@ -328,7 +328,7 @@ class ChunkedDocument:
         chunk_df = self._chunked_data
 
         # Handle cases where the item has the decimal point e.g. 5.02
-        item_or_part = item_or_part.replace('.', r'\.')
+        item_or_part = item_or_part.replace('.', '\.')
         pattern = re.compile(rf'^{item_or_part}$', flags=re.IGNORECASE)
 
         col_mask = chunk_df[col].str.match(pattern)

--- a/edgar/htmltools.py
+++ b/edgar/htmltools.py
@@ -328,7 +328,7 @@ class ChunkedDocument:
         chunk_df = self._chunked_data
 
         # Handle cases where the item has the decimal point e.g. 5.02
-        item_or_part = item_or_part.replace('.', '\.')
+        item_or_part = item_or_part.replace('.', r'\.')
         pattern = re.compile(rf'^{item_or_part}$', flags=re.IGNORECASE)
 
         col_mask = chunk_df[col].str.match(pattern)


### PR DESCRIPTION
Updated regex patterns in documents.py, funds.py, and htmltools.py to use raw strings with an 'r' prefix to prevent escape sequence issues and improve clarity.