### PR TITLE
Add support for reading company ticker data from local

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,11 +400,12 @@ The data is stored by default in the `~/.edgar` directory. You can change this b
 ```bash
 
 ```python
-def download_edgar_data(submissions: bool = True, facts: bool = True):
+def download_edgar_data(submissions: bool = True, facts: bool = True, reference: bool = True):
     """
     Download all the company data from Edgar
     :param submissions: Download all the company submissions
     :param facts: Download all the company facts
+    :param reference: Download reference data
     """
 download_edgar_data()
 

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -252,6 +252,9 @@ def download_edgar_data(submissions: bool = True,
     if facts:
         from edgar.entities import download_facts
         download_facts()
+    if reference:
+        from edgar.reference import download_reference_data
+        download_reference_data()
 
 
 class InvalidDateException(Exception):


### PR DESCRIPTION
This PR adds support for reading company ticker data locally (without needing to ping SEC).

 * Adds support for downloading reference data in `download_edgar_data()`
 * Adds support for reading the local reference data in `get_cik_tickers_from_ticker_txt` and `get_company_tickers`.

