### PR TITLE
Update method name to 'balance_sheet'

### DIFF
--- a/notebooks/FinancialStatements.ipynb
+++ b/notebooks/FinancialStatements.ipynb
@@ -107,7 +107,7 @@
     }
    },
    "cell_type": "code",
-   "source": "financials.balance",
+   "source": "financials.balance_sheet",
    "id": "8eca6ef94b026756",
    "outputs": [
     {


### PR DESCRIPTION
Minor refactor. Appears method named 'balance' was updated to 'balance_sheet.'