### PR TITLE
Minor cleanup in FinancialStatements.ipynb

### DIFF
--- a/notebooks/FinancialStatements.ipynb
+++ b/notebooks/FinancialStatements.ipynb
@@ -254,10 +254,7 @@
     }
    },
    "cell_type": "code",
-   "source": [
-    "financials = Financials(xb)\n",
-    "financials"
-   ],
+   "source": "financials",
    "id": "1db8c74ee35f7137",
    "outputs": [
     {


### PR DESCRIPTION
Potentially remove line in notebook. `xb` is not defined in the notebook, and I can't tell what the intent with this line is or was. **Please reject this commit if I am missing something,** but at the moment it's confusing me. Referencing the `financials` object directly seems to work as intended.