### PR TITLE
fix: allow for non breaking spaces in item pattern

### DIFF
--- a/edgar/files/htmltools.py
+++ b/edgar/files/htmltools.py
@@ -97,8 +97,8 @@ def chunk(html: str):
     return list(document.generate_chunks())
 
 
-int_item_pattern = r"^(Item [0-9]{1,2}[A-Z]?)\.?"
-decimal_item_pattern = r"^(Item [0-9]{1,2}\.[0-9]{2})\.?"
+int_item_pattern = r"^(Item\s{1,3}[0-9]{1,2}[A-Z]?)\.?"
+decimal_item_pattern = r"^(Item\s{1,3}[0-9]{1,2}\.[0-9]{2})\.?"
 
 
 def detect_table_of_contents(text: str):

--- a/edgar/files/htmltools.py
+++ b/edgar/files/htmltools.py
@@ -282,6 +282,9 @@ def chunks2df(chunks: List[List[Block]],
     # Fill the Item column with "" then set to title case
     chunk_df.Item = chunk_df.Item.fillna("").str.title()
 
+    # Normalize spaces in item
+    chunk_df.Item = chunk_df.Item.apply(lambda item: re.sub(r'\s+', ' ', item))
+
     # Finalize the colums
     chunk_df = chunk_df[['Text', 'Table', 'Chars', 'Signature', 'TocLink', 'Toc', 'Empty', 'Item']]
     return chunk_df


### PR DESCRIPTION
Hi!

I came across an edge case where the library was not correctly detecting the first item of a 10-K (the latest 10-K of LMT). The issue is that the 10-K has a non breaking space after the word 'Item'.

Here the HTML from the filing:

```html
<span style="color:#000000;font-family:\'Times New Roman\',sans-serif;font-size:10pt;font-weight:700;line-height:120%">ITEM&#160; 1.</span>
```
I've adjusted the pattern to allow for non breaking spaces and to allow a few spaces. Now on my side the Item gets detected.