### PR TITLE
chore: logging namespace to __name__ and defer logging initialization

### DIFF
--- a/edgar/core.py
+++ b/edgar/core.py
@@ -25,24 +25,13 @@ from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
 from rich.prompt import Prompt
 
-# Rich logging
-logging.basicConfig(
-    level="INFO",
-    format="%(message)s",
-    datefmt="[%X]",
-    handlers=[RichHandler(rich_tracebacks=True)]
-)
-
-log = logging.getLogger("rich")
+log = logging.getLogger(__name__)
 
 # Pandas version
 pandas_version = tuple(map(int, pd.__version__.split('.')))
 
 # sys version
 python_version = tuple(map(int, sys.version.split()[0].split('.')))
-
-# Turn down 3rd party logging
-logging.getLogger("httpx").setLevel(logging.WARNING)
 
 __all__ = [
     'log',
@@ -932,3 +921,16 @@ def has_html_content(content: str) -> bool:
             return True
 
     return False
+
+
+def initialize_rich_logging():
+    # Rich logging
+    logging.basicConfig(
+        level="INFO",
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(rich_tracebacks=True)]
+    )
+
+    # Turn down 3rd party logging
+    logging.getLogger("httpx").setLevel(logging.WARNING)


### PR DESCRIPTION
Fixes #190

- Change core.py logger to use `__name__` namespace, not "rich". 
- Move logger initialization and any additional log defaults, such as changing httpx log level, to `initialize_rich_logging`

This is consistent with recommendations from https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library:
- "use a logger with a unique and easily identifiable name, such as the `__name__` for your library’s top-level package or module."
- "Note It is strongly advised that you do not add any handlers other than [NullHandler](https://docs.python.org/3/library/logging.handlers.html#logging.NullHandler) to your library’s loggers." 
