### PR TITLE
chore: Consolidate httpx.Client and httpx.AsyncClient creation to a single module

### DIFF
--- a/edgar/core.py
+++ b/edgar/core.py
@@ -452,29 +452,6 @@ def filter_by_ticker(data: pa.Table,
 def client_headers():
     return {'User-Agent': get_identity()}
 
-
-def http_client():
-    return httpx.Client(headers=client_headers(),
-                        timeout=edgar_mode.http_timeout,
-                        limits=edgar_mode.limits,
-                        default_encoding="utf-8")
-
-
-def async_http_client():
-    return httpx.AsyncClient(headers=client_headers(),
-                             timeout=edgar_mode.http_timeout,
-                             limits=edgar_mode.limits,
-                             default_encoding='utf-8')
-
-
-def get_json(data_url: str):
-    with http_client() as client:
-        r = client.get(data_url)
-        if r.status_code == 200:
-            return r.json()
-        r.raise_for_status()
-
-
 def decode_content(content: bytes):
     try:
         return content.decode('utf-8')

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,0 +1,30 @@
+import httpx
+import logging
+
+from contextlib import contextmanager, asynccontextmanager
+
+from edgar.core import edgar_mode
+
+log = logging.getLogger(__name__)
+
+@contextmanager
+def http_client():
+    """
+    Context manager for synchronous HTTP client usage.
+    
+    This design is intended to make it easy to swap in and override the httpxclient initialization.
+    """
+    with httpx.Client(timeout=edgar_mode.http_timeout) as client:
+        yield client
+
+
+
+@asynccontextmanager
+async def ahttp_client():
+    """
+    Async context manager for the HTTP client.
+
+    This design is intended to make it easy to swap in and override the httpxclient initialization.
+    """
+    async with httpx.AsyncClient(timeout=edgar_mode.http_timeout) as client:
+        yield client


### PR DESCRIPTION
The current `httprequests` implementation creates httpx.Client and httpx.AsyncClient instances at multiple points. This scattered initialization makes it challenging, if not impossible, for downstream applications to customize httpx client behavior. 

This PR introduces a minimal change by consolidating all client initialization into a single location within a new `httpclient` module. This centralization simplifies the code and paves the way for downstream users to override or extend client functionality.

Examples of possible downstream changes include enabling client reuse, using [http2](https://www.python-httpx.org/http2/), implementing [caching](https://hishel.com/userguide/), handling custom responses, or supporting alternative rate-limiter implementations. 

I am proposing a minimal, non-disruptive change that doesn't change the current behavior. That said, client reuse has shown **significant** performance benefits for my use cases.