### PR TITLE
feat: Implement httpx client persistence / reuse

### DIFF
--- a/edgar/core.py
+++ b/edgar/core.py
@@ -25,6 +25,8 @@ from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
 from rich.prompt import Prompt
 
+from edgar.httpclient import close_clients
+
 log = logging.getLogger(__name__)
 
 # Pandas version
@@ -171,6 +173,8 @@ def set_identity(user_identity: str):
     """
     os.environ[edgar_identity] = user_identity
     log.info(f"Identity of the Edgar REST client set to [{user_identity}]")
+
+    close_clients() # close any httpx clients, to reset the identity. 
 
 
 identity_prompt = """

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -25,8 +25,6 @@ from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
 from rich.prompt import Prompt
 
-from edgar.httpclient import close_clients
-
 log = logging.getLogger(__name__)
 
 # Pandas version
@@ -174,6 +172,7 @@ def set_identity(user_identity: str):
     os.environ[edgar_identity] = user_identity
     log.info(f"Identity of the Edgar REST client set to [{user_identity}]")
 
+    from edgar.httpclient import close_clients
     close_clients() # close any httpx clients, to reset the identity. 
 
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -10,15 +10,15 @@ from edgar.core import client_headers, edgar_mode
 
 log = logging.getLogger(__name__)
 
-REUSE_CLIENTS = False
+REUSE_CLIENT = False
 
 def _http_client_closure():
-    """When REUSE_CLIENTS, creates and reuses a single client."""
+    """When REUSE_CLIENT, creates and reuses a single client."""
     client = None
 
     @contextmanager
     def _get_client( **kwargs):
-        if REUSE_CLIENTS:
+        if REUSE_CLIENT:
 
             nonlocal client
             if client is None:
@@ -60,7 +60,7 @@ def _ahttp_client_closure():
     @asynccontextmanager
     async def _get_client(**kwargs):
 
-        if REUSE_CLIENTS:
+        if REUSE_CLIENT:
             async with lock:
                 tl = threading.local()
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,32 +1,30 @@
-import httpx
 import logging
-from asyncio import Lock
-from contextlib import contextmanager, asynccontextmanager
-from functools import partial
-from edgar.core import edgar_mode, client_headers
-from contextvars import ContextVar
 import threading
+from asyncio import Lock
+from contextlib import asynccontextmanager, contextmanager
+
+import httpx
+
+from edgar.core import client_headers, edgar_mode
+
 
 log = logging.getLogger(__name__)
 
 REUSE_CLIENTS = False
 
 def _http_client_closure():
-    """
-    When REUSE_CLIENTS, creates and reuses a single client.
-    """
-
+    """When REUSE_CLIENTS, creates and reuses a single client."""
     client = None
 
     @contextmanager
-    def _get_client(**kwargs):
+    def _get_client( **kwargs):
         if REUSE_CLIENTS:
 
             nonlocal client
             if client is None:
 
                 log.info("Creating new HTTP Client")
-                
+
                 client = httpx.Client(headers=client_headers(),
                                     timeout=edgar_mode.http_timeout,
                                     limits=edgar_mode.limits,
@@ -41,7 +39,7 @@ def _http_client_closure():
                                     default_encoding="utf-8",
                                     **kwargs) as _client:
                 yield _client
-    
+
     def _close_client():
         nonlocal client
 
@@ -50,25 +48,20 @@ def _http_client_closure():
                 client.close()
             except Exception:
                 log.exception("Exception closing client")
-            
+
             client = None
 
     return _get_client, _close_client
 
 def _ahttp_client_closure():
-    """
-    Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops.
-    """
-    
+    """Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops."""
     lock = Lock()
 
     @asynccontextmanager
     async def _get_client(**kwargs):
 
         if REUSE_CLIENTS:
-             
             async with lock:
-                # Creates 
                 tl = threading.local()
 
                 client = getattr(tl, "edgar_httpclient_aclient", None)
@@ -76,22 +69,22 @@ def _ahttp_client_closure():
                 if client is None:
                     log.info("Creating new Async HTTP Client")
                     client = httpx.AsyncClient(
-                        headers=client_headers(), 
+                        headers=client_headers(),
                         timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits, 
-                        **kwargs
+                        limits=edgar_mode.limits,
+                        **kwargs,
                     )
-                setattr(tl, "edgar_httpclient_aclient", client)
+                tl.edgar_httpclient_aclient = client
 
             yield client
 
         else:
             # Create a new client per request
             async with httpx.AsyncClient(
-                        headers=client_headers(), 
-                        timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits, 
-                        **kwargs
+                        headers=client_headers(),
+                        timeout=edgar_mode.http_timeout,
+                        limits=edgar_mode.limits,
+                        **kwargs,
                     ) as _client:
                 yield _client
 
@@ -105,8 +98,9 @@ def _ahttp_client_closure():
                 client.close()
             except Exception:
                 log.exception("Exception closing client")
-            
-            client = setattr(tl, "edgar_httpclient_aclient", None)
+
+            tl.edgar_httpclient_aclient = None
+            client = None
 
     return _get_client, _aclose_client
 
@@ -115,9 +109,6 @@ http_client, _close_client = _http_client_closure()
 ahttp_client, _aclose_client = _ahttp_client_closure()
 
 def close_clients():
-    """
-    Closes and invalidates existing client sessions
-    """
-
+    """Closes and invalidates existing client sessions."""
     _close_client()
     _aclose_client()

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from asyncio import Lock
+import asyncio
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
@@ -10,34 +10,51 @@ from edgar.core import client_headers, edgar_mode
 
 log = logging.getLogger(__name__)
 
-REUSE_CLIENT = False
+REUSE_CLIENT = True
+
+DEFAULT_PARAMS = {
+    "timeout": edgar_mode.http_timeout,
+    "limits": edgar_mode.limits,
+    "default_encoding": "utf-8",
+}
+
+def _client_params(async_client: bool = False, **kwargs) -> dict:
+    """Merges defaults and additional kw args for httpx Client initialization.
+
+    Args:
+        async_client (bool, optional): Indicates whether this is used for a httpx.AsyncClient, as some options 
+        may be specific to particular modes, such as httpx Transports. Defaults to False.
+
+    Returns:
+        dict: _description_
+    """
+
+    params = DEFAULT_PARAMS.copy()
+    params["headers"] =  client_headers()
+    params.update(kwargs)
+
+    return params
 
 def _http_client_closure():
     """When REUSE_CLIENT, creates and reuses a single client."""
     client = None
+    lock = threading.Lock()
 
     @contextmanager
     def _get_client( **kwargs):
         if REUSE_CLIENT:
-
             nonlocal client
+
             if client is None:
+                with lock:
+                    if client is None: 
+                        log.info("Creating new HTTP Client")
 
-                log.info("Creating new HTTP Client")
-
-                client = httpx.Client(headers=client_headers(),
-                                    timeout=edgar_mode.http_timeout,
-                                    limits=edgar_mode.limits,
-                                    default_encoding="utf-8",
-                                    **kwargs)
+                        client = httpx.Client(**_client_params(async_client = False, **kwargs))
             yield client
         else:
             # Create a new client per request
-            with httpx.Client(headers=client_headers(),
-                                    timeout=edgar_mode.http_timeout,
-                                    limits=edgar_mode.limits,
-                                    default_encoding="utf-8",
-                                    **kwargs) as _client:
+            with httpx.Client(**_client_params(async_client = False, **kwargs)) as _client:
                 yield _client
 
     def _close_client():
@@ -55,43 +72,43 @@ def _http_client_closure():
 
 def _ahttp_client_closure():
     """Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops."""
-    lock = Lock()
+    
+    asynciolock = asyncio.Lock()
+    threadlock = threading.Lock()
+
+    tl = threading.local()  # Shared thread-local storage per thread
+
+    def _local_client():
+        return getattr(tl, "edgar_httpclient_asyncclient", None)
+
+    def _set_client(client):
+        tl.edgar_httpclient_asyncclient = client
 
     @asynccontextmanager
     async def _get_client(**kwargs):
 
-        if REUSE_CLIENT:
-            async with lock:
-                tl = threading.local()
-
-                client = getattr(tl, "edgar_httpclient_aclient", None)
-
-                if client is None:
-                    log.info("Creating new Async HTTP Client")
-                    client = httpx.AsyncClient(
-                        headers=client_headers(),
-                        timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits,
-                        **kwargs,
-                    )
-                tl.edgar_httpclient_aclient = client
-
+        client = _local_client()
+        if client is not None:
             yield client
+        elif REUSE_CLIENT:
+            with threadlock: 
+                async with asynciolock:
+                    if client is None:
+                        log.info("Creating new Async HTTP Client")
+                        client = httpx.AsyncClient(**_client_params(async_client = True, **kwargs)
+                        )
+                    _set_client(client)
 
+                yield client
         else:
             # Create a new client per request
             async with httpx.AsyncClient(
-                        headers=client_headers(),
-                        timeout=edgar_mode.http_timeout,
-                        limits=edgar_mode.limits,
-                        **kwargs,
+                        **_client_params(async_client = True, **kwargs)
                     ) as _client:
                 yield _client
 
     def _aclose_client():
-        tl = threading.local()
-
-        client = getattr(tl, "edgar_httpclient_aclient", None)
+        client = _local_client()
 
         if client is not None:
             try:
@@ -99,7 +116,7 @@ def _ahttp_client_closure():
             except Exception:
                 log.exception("Exception closing client")
 
-            tl.edgar_httpclient_aclient = None
+            _set_client(None)
             client = None
 
     return _get_client, _aclose_client


### PR DESCRIPTION
Implements a feature flag `edgartools.httpclient.PERSISTENT_CLIENT`. 

When disabled, the flag should have no functional impact on edgartools: a new HTTPX client would be created for each and every request. No change from prior behavior.

When enabled, the client would be reused across all requests. For synchronous requests, a single client is reused. For async requests, a client is attached and used for each asyncio loop. 

If enabled, an application would (if desired) need to explicitly close the client.

A parameter dictionary is added `httpclient.DEFAULT_PARAMS`, so that applications can modify the httpclient parameters used on client initialization. For example, could set  `httpclient.DEFAULT_PARAMS["http2"] = True` to enable HTTP2 mode in httpx.

Note: One concern is whether garbage collection of the async clients is desirable or whether to require explicit closure. As implemented, the async clients are maintained in a WeakKeyDictionary, so will be gc'd eagerly. 

Fixes #195 