### PR TITLE
feat; Persistent HTTP Clients

### DIFF
--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -26,6 +26,7 @@ from rich.text import Text
 from edgar.richtools import repr_rich, print_xml, print_rich
 from edgar.core import sec_dot_gov, display_size, binary_extensions, text_extensions, has_html_content
 from edgar.httprequests import get_with_retry, download_file, download_file_async
+from edgar.httpclient import async_http_client
 
 xbrl_document_types = ['XBRL INSTANCE DOCUMENT', 'XBRL INSTANCE FILE', 'EXTRACTED XBRL INSTANCE DOCUMENT']
 
@@ -275,8 +276,10 @@ class Attachments:
     @staticmethod
     async def _download_all_attachments(attachments: List[Attachment]):
         import asyncio
-        return await asyncio.gather(
-            *[download_file_async(attachment.url, as_text=attachment.is_text()) for attachment in attachments])
+
+        async with async_http_client() as client:
+            return await asyncio.gather(
+                *[download_file_async(client, attachment.url, as_text=attachment.is_text()) for attachment in attachments])
 
     def download(self, path: Union[str, Path], archive: bool = False):
         """

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -25,6 +25,8 @@ from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
 from rich.prompt import Prompt
 
+from edgar.httpclient import close_clients
+
 log = logging.getLogger(__name__)
 
 # Pandas version
@@ -171,6 +173,8 @@ def set_identity(user_identity: str):
     """
     os.environ[edgar_identity] = user_identity
     log.info(f"Identity of the Edgar REST client set to [{user_identity}]")
+
+    close_clients() # close any httpx clients, to reset the identity. 
 
 
 identity_prompt = """

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -25,8 +25,6 @@ from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
 from rich.prompt import Prompt
 
-from edgar.httpclient import close_clients
-
 log = logging.getLogger(__name__)
 
 # Pandas version
@@ -174,6 +172,7 @@ def set_identity(user_identity: str):
     os.environ[edgar_identity] = user_identity
     log.info(f"Identity of the Edgar REST client set to [{user_identity}]")
 
+    from edgar.httpclient import close_clients
     close_clients() # close any httpx clients, to reset the identity. 
 
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -63,13 +63,14 @@ http_client, _close_client = _http_client_manager()
 
 @asynccontextmanager
 async def async_http_client(client: Optional[httpx.AsyncClient] = None, **kwargs) -> AsyncGenerator[httpx.AsyncClient]:
-    """Async callers do not reuse clients, and are expected to create / tear down the client via the contextmanager.
+    """
+    Async callers should create a single client for a group of tasks, rather than creating a single client per task.
     
-    The nullable client parameter is used for methods that may or may not be passed an AsyncClient. If an AsyncClient is passed, this is a noop... it returns the client and doesn't close it.
+    Client: Optional parameter to allow code paths that accept optional clients: if a client is passed, this is a no-op and the client isn't closed.
     """
 
     if client is not None:
-        yield nullcontext(client) # type: ignore # caller responsible for closing
+        yield nullcontext(client)  # Caller is responsible for closing
 
     params = DEFAULT_PARAMS.copy()
     params["headers"] = client_headers()

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -62,7 +62,7 @@ def _http_client_manager():
 http_client, _close_client = _http_client_manager()
 
 @asynccontextmanager
-async def async_http_client(client: Optional[httpx.AsyncClient] = None, **kwargs) -> AsyncGenerator[httpx.AsyncClient]:
+async def async_http_client(client: Optional[httpx.AsyncClient] = None, **kwargs) -> AsyncGenerator[httpx.AsyncClient, None]:
     """
     Async callers should create a single client for a group of tasks, rather than creating a single client per task.
     

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,9 +1,8 @@
 import logging
 import threading
-import asyncio
-from contextlib import asynccontextmanager, contextmanager
-from weakref import WeakKeyDictionary
+from contextlib import asynccontextmanager, contextmanager, nullcontext
 import httpx
+from typing import AsyncGenerator, Optional
 
 from edgar.core import client_headers, edgar_mode
 
@@ -24,14 +23,6 @@ def _client_factory(**kwargs)-> httpx.Client:
     params.update(**kwargs)
     
     return httpx.Client(**params)
-
-def _async_client_factory(**kwargs) -> httpx.AsyncClient:
-    params = DEFAULT_PARAMS.copy()
-    params["headers"] = client_headers()
-    
-    params.update(**kwargs)
-
-    return httpx.AsyncClient(**params)
 
 def _http_client_manager():
     """When PERSISTENT_CLIENT, creates and reuses a single client. Otherwise, creates a new client per invocation."""
@@ -68,54 +59,25 @@ def _http_client_manager():
 
     return _get_client, _close_client
 
-def _async_client_manager():
-    """When PERSISTENT_CLIENT, creates and reuses a single client per asyncio loop. Otherwise, creates a new client per invocation."""
-    
-    asynciolock = asyncio.Lock()
-    threadlock = threading.Lock()
-
-    clients = WeakKeyDictionary()  # store in a weakkeydictionary, to allow GC when out of scope
-
-    @asynccontextmanager
-    async def _get_client(**kwargs):
-        loop = asyncio.get_running_loop()            
-
-        client = clients.get(loop, None)
-        if client is not None:
-            yield client
-        elif PERSISTENT_CLIENT:
-            with threadlock: 
-                async with asynciolock:
-                    if client is None:
-                        log.info("Creating new Async HTTPX Client")
-                        client = _async_client_factory(**kwargs)
-                    clients[loop] = (client)
-
-                yield client
-        else:
-            # Create a new client per request
-            async with _async_client_factory(**kwargs) as _client:
-                yield _client
-
-    def _clear_all_async_clients():
-        """Clears clients, allows GC. Try to async run them, but this will fail in a nested asyncio loop."""
-
-        for client in clients.values():
-            try:
-                asyncio.run(client.aclose())
-            except Exception as e:
-                log.debug("Couldn't close %s", e)
-
-        clients.clear()
-        
-    return _get_client, _clear_all_async_clients
-
-
 http_client, _close_client = _http_client_manager()
-ahttp_client, _aclose_client = _async_client_manager()
+
+@asynccontextmanager
+async def async_http_client(client: Optional[httpx.AsyncClient] = None, **kwargs) -> AsyncGenerator[httpx.AsyncClient]:
+    """Async callers do not reuse clients, and are expected to create / tear down the client via the contextmanager.
+    
+    The nullable client parameter is used for methods that may or may not be passed an AsyncClient. If an AsyncClient is passed, this is a noop... it returns the client and doesn't close it.
+    """
+
+    if client is not None:
+        yield nullcontext(client) # type: ignore # caller responsible for closing
+
+    params = DEFAULT_PARAMS.copy()
+    params["headers"] = client_headers()
+    
+    params.update(**kwargs)
+    async with httpx.AsyncClient(**params) as client:
+        yield client
 
 def close_clients():
     """Closes and invalidates existing client sessions."""
     _close_client()
-    _aclose_client()
-

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -10,15 +10,15 @@ from edgar.core import client_headers, edgar_mode
 
 log = logging.getLogger(__name__)
 
-REUSE_CLIENTS = False
+REUSE_CLIENT = False
 
 def _http_client_closure():
-    """When REUSE_CLIENTS, creates and reuses a single client."""
+    """When REUSE_CLIENT, creates and reuses a single client."""
     client = None
 
     @contextmanager
     def _get_client( **kwargs):
-        if REUSE_CLIENTS:
+        if REUSE_CLIENT:
 
             nonlocal client
             if client is None:
@@ -60,7 +60,7 @@ def _ahttp_client_closure():
     @asynccontextmanager
     async def _get_client(**kwargs):
 
-        if REUSE_CLIENTS:
+        if REUSE_CLIENT:
             async with lock:
                 tl = threading.local()
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,32 +1,30 @@
-import httpx
 import logging
-from asyncio import Lock
-from contextlib import contextmanager, asynccontextmanager
-from functools import partial
-from edgar.core import edgar_mode, client_headers
-from contextvars import ContextVar
 import threading
+from asyncio import Lock
+from contextlib import asynccontextmanager, contextmanager
+
+import httpx
+
+from edgar.core import client_headers, edgar_mode
+
 
 log = logging.getLogger(__name__)
 
 REUSE_CLIENTS = False
 
 def _http_client_closure():
-    """
-    When REUSE_CLIENTS, creates and reuses a single client.
-    """
-
+    """When REUSE_CLIENTS, creates and reuses a single client."""
     client = None
 
     @contextmanager
-    def _get_client(**kwargs):
+    def _get_client( **kwargs):
         if REUSE_CLIENTS:
 
             nonlocal client
             if client is None:
 
                 log.info("Creating new HTTP Client")
-                
+
                 client = httpx.Client(headers=client_headers(),
                                     timeout=edgar_mode.http_timeout,
                                     limits=edgar_mode.limits,
@@ -41,7 +39,7 @@ def _http_client_closure():
                                     default_encoding="utf-8",
                                     **kwargs) as _client:
                 yield _client
-    
+
     def _close_client():
         nonlocal client
 
@@ -50,25 +48,20 @@ def _http_client_closure():
                 client.close()
             except Exception:
                 log.exception("Exception closing client")
-            
+
             client = None
 
     return _get_client, _close_client
 
 def _ahttp_client_closure():
-    """
-    Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops.
-    """
-    
+    """Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops."""
     lock = Lock()
 
     @asynccontextmanager
     async def _get_client(**kwargs):
 
         if REUSE_CLIENTS:
-             
             async with lock:
-                # Creates 
                 tl = threading.local()
 
                 client = getattr(tl, "edgar_httpclient_aclient", None)
@@ -76,22 +69,22 @@ def _ahttp_client_closure():
                 if client is None:
                     log.info("Creating new Async HTTP Client")
                     client = httpx.AsyncClient(
-                        headers=client_headers(), 
+                        headers=client_headers(),
                         timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits, 
-                        **kwargs
+                        limits=edgar_mode.limits,
+                        **kwargs,
                     )
-                setattr(tl, "edgar_httpclient_aclient", client)
+                tl.edgar_httpclient_aclient = client
 
             yield client
 
         else:
             # Create a new client per request
             async with httpx.AsyncClient(
-                        headers=client_headers(), 
-                        timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits, 
-                        **kwargs
+                        headers=client_headers(),
+                        timeout=edgar_mode.http_timeout,
+                        limits=edgar_mode.limits,
+                        **kwargs,
                     ) as _client:
                 yield _client
 
@@ -105,8 +98,9 @@ def _ahttp_client_closure():
                 client.close()
             except Exception:
                 log.exception("Exception closing client")
-            
-            client = setattr(tl, "edgar_httpclient_aclient", None)
+
+            tl.edgar_httpclient_aclient = None
+            client = None
 
     return _get_client, _aclose_client
 
@@ -115,9 +109,6 @@ http_client, _close_client = _http_client_closure()
 ahttp_client, _aclose_client = _ahttp_client_closure()
 
 def close_clients():
-    """
-    Closes and invalidates existing client sessions
-    """
-
+    """Closes and invalidates existing client sessions."""
     _close_client()
     _aclose_client()

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from asyncio import Lock
+import asyncio
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
@@ -10,34 +10,51 @@ from edgar.core import client_headers, edgar_mode
 
 log = logging.getLogger(__name__)
 
-REUSE_CLIENT = False
+REUSE_CLIENT = True
+
+DEFAULT_PARAMS = {
+    "timeout": edgar_mode.http_timeout,
+    "limits": edgar_mode.limits,
+    "default_encoding": "utf-8",
+}
+
+def _client_params(async_client: bool = False, **kwargs) -> dict:
+    """Merges defaults and additional kw args for httpx Client initialization.
+
+    Args:
+        async_client (bool, optional): Indicates whether this is used for a httpx.AsyncClient, as some options 
+        may be specific to particular modes, such as httpx Transports. Defaults to False.
+
+    Returns:
+        dict: _description_
+    """
+
+    params = DEFAULT_PARAMS.copy()
+    params["headers"] =  client_headers()
+    params.update(kwargs)
+
+    return params
 
 def _http_client_closure():
     """When REUSE_CLIENT, creates and reuses a single client."""
     client = None
+    lock = threading.Lock()
 
     @contextmanager
     def _get_client( **kwargs):
         if REUSE_CLIENT:
-
             nonlocal client
+
             if client is None:
+                with lock:
+                    if client is None: 
+                        log.info("Creating new HTTP Client")
 
-                log.info("Creating new HTTP Client")
-
-                client = httpx.Client(headers=client_headers(),
-                                    timeout=edgar_mode.http_timeout,
-                                    limits=edgar_mode.limits,
-                                    default_encoding="utf-8",
-                                    **kwargs)
+                        client = httpx.Client(**_client_params(async_client = False, **kwargs))
             yield client
         else:
             # Create a new client per request
-            with httpx.Client(headers=client_headers(),
-                                    timeout=edgar_mode.http_timeout,
-                                    limits=edgar_mode.limits,
-                                    default_encoding="utf-8",
-                                    **kwargs) as _client:
+            with httpx.Client(**_client_params(async_client = False, **kwargs)) as _client:
                 yield _client
 
     def _close_client():
@@ -55,43 +72,43 @@ def _http_client_closure():
 
 def _ahttp_client_closure():
     """Creates a AsyncClient per thread. Necessary to avoid sharing across eventloops."""
-    lock = Lock()
+    
+    asynciolock = asyncio.Lock()
+    threadlock = threading.Lock()
+
+    tl = threading.local()  # Shared thread-local storage per thread
+
+    def _local_client():
+        return getattr(tl, "edgar_httpclient_asyncclient", None)
+
+    def _set_client(client):
+        tl.edgar_httpclient_asyncclient = client
 
     @asynccontextmanager
     async def _get_client(**kwargs):
 
-        if REUSE_CLIENT:
-            async with lock:
-                tl = threading.local()
-
-                client = getattr(tl, "edgar_httpclient_aclient", None)
-
-                if client is None:
-                    log.info("Creating new Async HTTP Client")
-                    client = httpx.AsyncClient(
-                        headers=client_headers(),
-                        timeout=edgar_mode.http_timeout, 
-                        limits=edgar_mode.limits,
-                        **kwargs,
-                    )
-                tl.edgar_httpclient_aclient = client
-
+        client = _local_client()
+        if client is not None:
             yield client
+        elif REUSE_CLIENT:
+            with threadlock: 
+                async with asynciolock:
+                    if client is None:
+                        log.info("Creating new Async HTTP Client")
+                        client = httpx.AsyncClient(**_client_params(async_client = True, **kwargs)
+                        )
+                    _set_client(client)
 
+                yield client
         else:
             # Create a new client per request
             async with httpx.AsyncClient(
-                        headers=client_headers(),
-                        timeout=edgar_mode.http_timeout,
-                        limits=edgar_mode.limits,
-                        **kwargs,
+                        **_client_params(async_client = True, **kwargs)
                     ) as _client:
                 yield _client
 
     def _aclose_client():
-        tl = threading.local()
-
-        client = getattr(tl, "edgar_httpclient_aclient", None)
+        client = _local_client()
 
         if client is not None:
             try:
@@ -99,7 +116,7 @@ def _ahttp_client_closure():
             except Exception:
                 log.exception("Exception closing client")
 
-            tl.edgar_httpclient_aclient = None
+            _set_client(None)
             client = None
 
     return _get_client, _aclose_client

--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -211,13 +211,13 @@ def get_with_retry(url, identity=None, identity_callable=None, **kwargs):
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
     """
-    with http_client() as client:        
+    with http_client() as client:
         response = client.get(url, **kwargs)
         if response.status_code == 429:
             raise TooManyRequestsError(url)
         elif is_redirect(response):
-            return get_with_retry(response.headers["Location"], identity=identity, identity_callable=identity_callable,
-                                  **kwargs)
+            return get_with_retry(url=response.headers["Location"], identity=identity, identity_callable=identity_callable,
+                                 **kwargs)
         return response
 
 

--- a/edgar/storage.py
+++ b/edgar/storage.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 import pandas as pd
 from bs4 import BeautifulSoup
-from httpx import HTTPStatusError
+from httpx import HTTPStatusError, AsyncClient
 from tqdm.auto import tqdm
 
 from edgar.core import log, get_edgar_data_directory, filing_date_to_year_quarters, extract_dates
@@ -38,34 +38,35 @@ def is_using_local_storage() -> bool:
     return os.getenv('EDGAR_USE_LOCAL_DATA', "0") == "1"
 
 
-async def download_facts_async() -> Path:
+async def download_facts_async(client: Optional[AsyncClient]) -> Path:
     """
     Download company facts
     """
     log.info(f"Downloading Company facts to {get_edgar_data_directory()}/companyfacts")
-    return await download_bulk_data("https://www.sec.gov/Archives/edgar/daily-index/xbrl/companyfacts.zip")
 
+    return await download_bulk_data(client, "https://www.sec.gov/Archives/edgar/daily-index/xbrl/companyfacts.zip")
 
 def download_facts() -> Path:
     """
     Download company facts
     """
-    return asyncio.run(download_facts_async())
+    
+    return asyncio.run(download_facts_async(client = None))
 
-
-async def download_submissions_async() -> Path:
+async def download_submissions_async(client: Optional[AsyncClient]) -> Path:
     """
     Download company submissions
     """
     log.info(f"Downloading Company submissions to {get_edgar_data_directory()}/submissions")
-    return await download_bulk_data("https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip")
+
+    return await download_bulk_data(client, "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip")
 
 
 def download_submissions() -> Path:
     """
     Download company facts
     """
-    return asyncio.run(download_submissions_async())
+    return asyncio.run(download_submissions_async(client = None))
 
 def download_ticker_data(reference_data_directory: Path):
     """
@@ -160,7 +161,7 @@ def download_filings(filing_date: Optional[str] = None,
                     if bulk_file_directory.exists():
                         log.info('Skipping %s. Already exists', bulk_file_directory)
                         continue
-                path = asyncio.run(download_bulk_data(bulk_filing_file, data_directory=data_directory))
+                path = asyncio.run(download_bulk_data(client=None, data_url=bulk_filing_file, data_directory=data_directory))
                 log.info('Downloaded feed file to %s', path)
 
 

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -77,18 +77,17 @@ async def test_get_with_retry_async(status_code):
 @pytest.mark.parametrize("status_code", [301, 302])
 async def test_get_with_retry_async_for_redirect(status_code):
     mock_response = httpx.Response(status_code=status_code)
-    async with async_http_client() as client:
-        # Set the Location header for status codes 301 and 302
-        if status_code in [301, 302]:
-            mock_response.headers["Location"] = "http://example.com/redirected"
+    # Set the Location header for status codes 301 and 302
+    if status_code in [301, 302]:
+        mock_response.headers["Location"] = "http://example.com/redirected"
 
-        with patch("httpx.Client.get", return_value=mock_response):
-            with patch("edgar.httprequests.get_with_retry") as mock_retry:
-                get_with_retry(client=client, url="http://example.com")
-                mock_retry.assert_called_once_with(client=client, url="http://example.com/redirected",
-                                                identity=os.environ['EDGAR_IDENTITY'],
-                                                headers={'User-Agent': 'Dev Gunning developer-gunning@gmail.com'},
-                                                identity_callable=None)
+    with patch("httpx.Client.get", return_value=mock_response):
+        with patch("edgar.httprequests.get_with_retry") as mock_retry:
+            get_with_retry(url="http://example.com")
+            mock_retry.assert_called_once_with(url="http://example.com/redirected",
+                                            identity=os.environ['EDGAR_IDENTITY'],
+                                            headers={'User-Agent': 'Dev Gunning developer-gunning@gmail.com'},
+                                            identity_callable=None)
 
 def test_post_with_retry():
     mock_response = httpx.Response(status_code=200)

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -5,6 +5,8 @@ from unittest.mock import patch, MagicMock
 import httpx
 import pytest
 
+from edgar.httpclient import async_http_client
+
 from edgar.httprequests import (
     get_with_retry,
     get_with_retry_async,
@@ -55,50 +57,53 @@ def test_get_with_retry_for_redirect(status_code, monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", [200, 429])
 async def test_get_with_retry_async(status_code):
-    mock_response = httpx.Response(status_code=status_code)
-    with patch("httpx.AsyncClient.get", return_value=mock_response):
-        if status_code == 429:
-            with pytest.raises(TooManyRequestsError):
-                await get_with_retry_async("http://example.com")
-        elif status_code in [301, 302]:
-            with patch("edgar.httprequests.get_with_retry_async") as mock_retry:
-                await get_with_retry_async("http://example.com")
-                mock_retry.assert_called_once()
-        else:
-            response = await get_with_retry_async("http://example.com")
-            assert response == mock_response
+
+    async with async_http_client() as client:
+        mock_response = httpx.Response(status_code=status_code)
+        with patch("httpx.AsyncClient.get", return_value=mock_response):
+            if status_code == 429:
+                with pytest.raises(TooManyRequestsError):
+                    await get_with_retry_async(client=client, url="http://example.com")
+            elif status_code in [301, 302]:
+                with patch("edgar.httprequests.get_with_retry_async") as mock_retry:
+                    await get_with_retry_async(client=client, url="http://example.com")
+                    mock_retry.assert_called_once()
+            else:
+                response = await get_with_retry_async(client=client, url="http://example.com")
+                assert response == mock_response
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", [301, 302])
 async def test_get_with_retry_async_for_redirect(status_code):
     mock_response = httpx.Response(status_code=status_code)
+    async with async_http_client() as client:
+        # Set the Location header for status codes 301 and 302
+        if status_code in [301, 302]:
+            mock_response.headers["Location"] = "http://example.com/redirected"
 
-    # Set the Location header for status codes 301 and 302
-    if status_code in [301, 302]:
-        mock_response.headers["Location"] = "http://example.com/redirected"
-
-    with patch("httpx.Client.get", return_value=mock_response):
-        with patch("edgar.httprequests.get_with_retry") as mock_retry:
-            get_with_retry("http://example.com")
-            mock_retry.assert_called_once_with("http://example.com/redirected",
-                                               identity=os.environ['EDGAR_IDENTITY'],
-                                               headers={'User-Agent': 'Dev Gunning developer-gunning@gmail.com'},
-                                               identity_callable=None)
+        with patch("httpx.Client.get", return_value=mock_response):
+            with patch("edgar.httprequests.get_with_retry") as mock_retry:
+                get_with_retry(client=client, url="http://example.com")
+                mock_retry.assert_called_once_with(client=client, url="http://example.com/redirected",
+                                                identity=os.environ['EDGAR_IDENTITY'],
+                                                headers={'User-Agent': 'Dev Gunning developer-gunning@gmail.com'},
+                                                identity_callable=None)
 
 def test_post_with_retry():
     mock_response = httpx.Response(status_code=200)
     with patch("httpx.Client.post", return_value=mock_response):
-        response = post_with_retry("http://example.com", data={"key": "value"})
+        response = post_with_retry(url="http://example.com", data={"key": "value"})
         assert response == mock_response
 
 
 @pytest.mark.asyncio
 async def test_post_with_retry_async():
-    mock_response = httpx.Response(status_code=200)
-    with patch("httpx.AsyncClient.post", return_value=mock_response):
-        response = await post_with_retry_async("http://example.com", json={"key": "value"})
-        assert response == mock_response
+    async with async_http_client() as client:
+        mock_response = httpx.Response(status_code=200)
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            response = await post_with_retry_async(client=client, url="http://example.com", json={"key": "value"})
+            assert response == mock_response
 
 
 def test_identity_not_set_exception(monkeypatch):
@@ -134,13 +139,15 @@ def test_identity_from_environment_variable(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_daily_index_url_async():
-    urls = ['https://www.sec.gov/Archives/edgar/daily-index/2024/QTR2/form.20240502.idx',
-            'https://www.sec.gov/Archives/edgar/daily-index/2024/QTR2/form.20240502.idx']
-    # Use asyncio to run get_with_retry_async
-    tasks = [get_with_retry_async(url) for url in urls]
-    results = await asyncio.gather(*tasks)
-    for r in results:
-        assert r.status_code == 200
+    async with async_http_client() as client:
+
+        urls = ['https://www.sec.gov/Archives/edgar/daily-index/2024/QTR2/form.20240502.idx',
+                'https://www.sec.gov/Archives/edgar/daily-index/2024/QTR2/form.20240502.idx']
+        # Use asyncio to run get_with_retry_async
+        tasks = [get_with_retry_async(client=client, url=url) for url in urls]
+        results = await asyncio.gather(*tasks)
+        for r in results:
+            assert r.status_code == 200
 
 
 def test_download_index_file():

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -47,8 +47,8 @@ def test_get_with_retry_for_redirect(status_code, monkeypatch):
 
     with patch("httpx.Client.get", return_value=mock_response):
         with patch("edgar.httprequests.get_with_retry") as mock_retry:
-            get_with_retry("http://example.com")
-            mock_retry.assert_called_once_with("http://example.com/redirected",
+            get_with_retry(url="http://example.com")
+            mock_retry.assert_called_once_with(url="http://example.com/redirected",
                                                identity=os.environ['EDGAR_IDENTITY'],
                                                headers={'User-Agent': 'Dev Gunning developer-gunning@gmail.com'},
                                                identity_callable=None)


### PR DESCRIPTION
When disabled, the flag should have no functional impact on edgartools: a new HTTPX client would be created for each and every request. No change from prior behavior.

When enabled, the client would be reused across all requests. For synchronous requests, a single client is reused. For async requests, a client is attached and used for each asyncio loop.

If enabled, an application would (if desired) need to explicitly close the client.

A parameter dictionary is added httpclient.DEFAULT_PARAMS, so that applications can modify the httpclient parameters used on client initialization. For example, could set httpclient.DEFAULT_PARAMS["http2"] = True to enable HTTP2 mode in httpx.

Note: One concern is whether garbage collection of the async clients is desirable or whether to require explicit closure. As implemented, the async clients are maintained in a WeakKeyDictionary, so will be gc'd eagerly.

Note 2: This differs from #196 in the Async code path. In #196, I avoided touching the code outside httpclient / httprequests. This ended up with an unnatural solution: where AsyncClients may or may not be closed. In this, the async code paths are modified to take an optional client... and the top level asyncio.gather's are modified to create a single AsyncClient for the entire set. This is cleaner and more explicit. 