### PR TITLE
Use `exists_ok` over `exists()` for edgar_data_dir

### DIFF
--- a/edgar/core.py
+++ b/edgar/core.py
@@ -239,8 +239,7 @@ def get_edgar_data_directory() -> Path:
     """Get the edgar data directory"""
     default_local_data_dir = Path(os.path.join(os.path.expanduser("~"), ".edgar"))
     edgar_data_dir = Path(os.getenv('EDGAR_LOCAL_DATA_DIR', default_local_data_dir))
-    if not edgar_data_dir.exists():
-        os.makedirs(edgar_data_dir)
+    os.makedirs(edgar_data_dir, exist_ok=True)
     return edgar_data_dir
 
 


### PR DESCRIPTION
We are hitting an `FileExistsError` exception despite the `exists()` check. Opt to use the [`exists_ok`](https://docs.python.org/3/library/os.html#os.makedirs) parameter for `makedirs` to prevent the exception.

I suppose we could keep the `exists()` check as well, but I removed because it felt redundant. Happy to change.

Example case:
![Screenshot 2025-01-23 at 2 45 30 PM](https://github.com/user-attachments/assets/53a15480-2663-4e59-b1a3-1172f3ebd19b)
