### PR TITLE
feat: Request caching using Hishel / HTTPX

### DIFF
--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -16,13 +16,16 @@ DEFAULT_PARAMS = {
     "default_encoding": "utf-8",
 }
 
+client_factory_class = httpx.Client
+asyncclient_factory_class = httpx.AsyncClient
+
 def _client_factory(**kwargs)-> httpx.Client:
     params = DEFAULT_PARAMS.copy()
     params["headers"] = client_headers()
     
     params.update(**kwargs)
     
-    return httpx.Client(**params)
+    return client_factory_class(**params)
 
 def _http_client_manager():
     """When PERSISTENT_CLIENT, creates and reuses a single client. Otherwise, creates a new client per invocation."""
@@ -76,7 +79,7 @@ async def async_http_client(client: Optional[httpx.AsyncClient] = None, **kwargs
     params["headers"] = client_headers()
     
     params.update(**kwargs)
-    async with httpx.AsyncClient(**params) as client:
+    async with asyncclient_factory_class(**params) as client:
         yield client
 
 def close_clients():

--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -128,3 +128,5 @@ def install_cached_client(cache_directory: Path | None, controller_args: dict | 
     httprequests.throttle_disabled = True  # Use the RateLimiterTransport
     httpclient.client_factory_class = partial(cached_factory, cache_directory=cache_directory, controller_args=controller_args)
     httpclient.asyncclient_factory_class = partial(asynccached_factory, cache_directory=cache_directory, controller_args=controller_args)
+
+    httpclient.close_clients()

--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -28,16 +28,14 @@ import logging
 logging.getLogger("hishel.controller").setLevel(logging.INFO)
 ```
 """
-from edgar import httpclient, core, httprequests, httpclient_limitertransport
+from edgar import httpclient, core, httprequests
 import logging
 import hishel
 import httpcore
 from pathlib import Path
 from functools import partial
 from contextlib import asynccontextmanager
-
 from limiter import Limiter 
-import httpx
 
 logger = logging.getLogger(__name__)
 

--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -1,0 +1,97 @@
+"""
+Implements a Hishel cache controller.
+
+cache_directory defaults to `Path(core.edgar_data_dir) / "requestcache"`
+
+Example 1: Using a heuristic cache
+https://hishel.com/advanced/controllers/#allowing-heuristics
+See get_freshness_lifetime and get_heuristic_freshness in https://github.com/karpetrosyan/hishel/blob/master/hishel/_controller.py
+
+```
+from edgar import httpclient_cache as hcc
+hcc.install_cached_client(cache_directory = None, controller_args = {"allow_heuristics": True, "allow_stale": True, "always_revalidate": False})
+For more info on Heuristics: https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-heuristic-fresh
+```
+
+Example 2: Implementing force_cache - caching everything
+https://hishel.com/advanced/controllers/#force-caching
+Note - Caching everything is not safe: you must manually clear the cache directory
+
+```
+from edgar import httpclient_cache as hcc
+hcc.install_cached_client(cache_directory = None, controller_args = {"force_cache": True})
+```
+
+To enable logging:
+```
+import logging
+logging.getLogger("hishel.controller").setLevel(logging.INFO)
+```
+"""
+from edgar import httpclient, core
+import logging
+import hishel
+import httpcore
+from pathlib import Path
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+def custom_key_generator(request: httpcore.Request, body: bytes | None) -> str:
+    """ Generates a stable, readable key for a given request.
+
+    Args:
+        request (httpcore.Request): _description_
+        body (bytes): _description_
+
+    Returns:
+        str: Persistent key for the request
+    """
+
+    
+    host = request.url.host.decode()
+    url = request.url.target.decode()
+
+    url_p = url.replace("/", "__")
+    return f"{host}_{url_p}"
+
+
+def _get_storage(base_path):
+    storage = hishel.FileStorage(base_path = base_path)
+    return storage
+
+def _get_cache_controller(**kwargs):
+    controller = hishel.Controller(
+        cacheable_methods=["GET", "POST"],
+        cacheable_status_codes=[200],
+        key_generator=custom_key_generator,
+        **kwargs
+        # allow_stale=True, # Use the stale response if there is a connection issue and the new response cannot be obtained.
+        # always_revalidate=False,
+        # allow_heuristics=True 
+    )
+
+    return controller
+
+def cached_factory(cache_directory: Path | None = None, controller_args: dict | None = None, **kwargs):
+    params = httpclient.DEFAULT_PARAMS.copy()
+    params["headers"] = httpclient.client_headers()
+    params.update(**kwargs)
+    if controller_args is None:
+        controller_args = {}
+
+    client = hishel.CacheClient(
+        # transport=transport,
+        controller=_get_cache_controller(**controller_args),
+        storage=_get_storage(base_path=cache_directory),
+        **params
+    )
+
+    return client
+
+
+def install_cached_client(cache_directory: Path | None, controller_args: dict | None = None):
+    if cache_directory is None:
+        cache_directory = Path(core.edgar_data_dir) / "requestcache"
+
+    httpclient._client_factory = partial(cached_factory, cache_directory=cache_directory, controller_args=controller_args)


### PR DESCRIPTION
As a follow-up to https://github.com/dgunning/edgartools/discussions/179#discussioncomment-12033238, sharing this draft PR for discussion.

#### Caching
- Introduces `edgar.httpclient_cache` module
- Cache is activated via `edgar.httpclient_cache.install_cached_client(cache_directory, controller_args)`
- To force caching of everything, pass `controller_args = {"force_cache": True}`
- To use an [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-heuristic-fresh) heuristic cache (caches at min(10% of file age, 1 week), pass `controller_args = {"allow_heuristics": True, "allow_stale": True, "always_revalidate": False}`

Note: Alternative caching policies could be implemented, but defining a cache controller with custom rules... such as certain URLs for X time. That said, I think the heuristic rules are a good start - data that's less than a day old would only be cached for an hour. 

#### Rate Limiting
Rate limiting must be done at the request level, not at the application layer, so that only cache misses are throttled. 

- Added an override to edgar.httprequest to disable the @throttle_requests. This is activated when `install_cached_client` is called.
- Decorate the HTTPX transport with a rate limiter, using the same limiter across all clients (Async or Sync)

#### New dependencies
Optional - only needed if you use the httpclient_cache module. 
- https://pypi.org/project/limiter/
- https://pypi.org/project/hishel/

#### Testing notes
Since this is disabled by default, the test cases currently won't exercise this feature.