### PR TITLE
Fix bug where press release url's are not properly printed

### DIFF
--- a/edgar/sgml/sgml_common.py
+++ b/edgar/sgml/sgml_common.py
@@ -188,7 +188,6 @@ def parse_submission_text(content: str) -> Tuple[FilingHeader, DefaultDict[str, 
     return header, documents
 
 
-
 class FilingSGML:
     """
     Main class that parses and provides access to both the header and documents
@@ -230,7 +229,6 @@ class FilingSGML:
     def effective_date(self):
         return self.header.filing_metadata.get('EFFECTIVE DATE')
 
-
     def html(self):
         html_document = self.attachments.primary_html_document
         if html_document and not html_document.is_binary() and not html_document.empty:
@@ -271,7 +269,7 @@ class FilingSGML:
                 attachment = Attachment(
                     sequence_number=sequence,
                     ixbrl=False,
-                    path=f"/<SGML FILE>/{document.filename}",
+                    path=f"/Archives/edgar/data/{self.header.cik}/{self.header.accession_number.replace('-', '')}/{document.filename}",
                     document=document.filename,
                     document_type=get_document_type(filename=document.filename, declared_document_type=document.type),
                     description=document.description,
@@ -367,7 +365,7 @@ class FilingSGML:
 
         # Create FilingSGML instance
         return cls(header=header, documents=documents)
-    
+
     @classmethod
     def from_text(cls, full_text_submission: str) -> "FilingSGML":
         """

--- a/edgar/sgml/sgml_header.py
+++ b/edgar/sgml/sgml_header.py
@@ -386,6 +386,12 @@ class FilingHeader:
                 [subject_company.filing_information.file_number for subject_company in self.subject_companies])
         return list(set(numbers))
 
+    @property
+    def cik(self) -> Optional[str]:
+        if self.filers and self.filers[0].company_information:
+            return self.filers[0].company_information.cik
+        return None
+
     @classmethod
     def parse_submission_format_header(cls, parsed_data: Dict[str, Any]):
         """Parse SUBMISSION format into same data structure"""


### PR DESCRIPTION
This used to work fine, but updates in late January broke this feature. The last commit where this worked fine was 345aa048a30ebbe76bdf4507da8250fce7f2d84c , "Add uu_decode to convert SGML attachments to bytes".

Uses f string to properly set the url


This is the script I was using to test if the url's were properly being printed: 


```py
import edgar
from edgar import Company, set_identity, company_reports

set_identity("my_email@gmail.com")

company = Company('A')
start_date_str = '2024-01-01'

all_filings = company.get_filings(form=['8-K'], date=f"{start_date_str}:")
all_filings = list(all_filings)

for filing in all_filings[:4]:
    all_prs: list[edgar.company_reports.PressRelease] = filing.obj().press_releases

    if not all_prs:
        continue

    print(all_prs)

    for pr in all_prs:
        print(pr.url())
        print(pr.attachment.path)
        print('\n')
        # print(pr)
```

If you run it with the current version you'll see the url's aren't printed properly. If you run it with this PR or with versions older than Jan 25th you'll see they are printed properly. 