### PR TITLE
Add a cover page accessor to xblr2

### DIFF
--- a/edgar/xbrl2/statements.py
+++ b/edgar/xbrl2/statements.py
@@ -669,6 +669,20 @@ class Statements:
             
         return "\n".join(lines)
 
+    def cover_page(self) -> Statement:
+        """
+        Get a cover page.
+
+        Returns:
+            A cover page statement
+        """
+        if hasattr(self.xbrl, 'find_statement'):
+            matching_statements, found_role, _ = self.xbrl.find_statement("CoverPage", False)
+            if found_role:
+                return Statement(self.xbrl, found_role, canonical_type="CoverPage")
+
+        return self["CoverPage"]
+
     def balance_sheet(self, parenthetical: bool = False) -> Statement:
         """
         Get a balance sheet.


### PR DESCRIPTION
This change adds a cover page accessor method in xbrl2/statements.py. This works in a similar way as the existing statement accessors:
```
cover_page = x.statements.cover_page().to_dataframe()
balance_sheet = x.statements.balance_sheet().to_dataframe()
income_statement = x.statements.income_statement().to_dataframe()
```

This is useful for finding `dei_EntityCommonStockSharesOutstanding | Entity Common Stock, Shares Outstanding`