### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/edgar/offerings/formd.py
+++ b/edgar/offerings/formd.py
@@ -120,8 +120,8 @@ class SalesCompensationRecipient:
         # Name and Crd can be "None"
         name = re.sub("None", "", child_text(recipient_tag, "recipientName") or "")
         crd = re.sub("None", "", child_text(recipient_tag, "recipientCRDNumber") or "")
-        associated_bd_name = re.sub("None", "", child_text(recipient_tag, "associatedBDName") or "", re.IGNORECASE)
-        associated_bd_crd = re.sub("None", "", child_text(recipient_tag, "associatedBDCRDNumber") or "", re.IGNORECASE)
+        associated_bd_name = re.sub("None", "", child_text(recipient_tag, "associatedBDName") or "", flags=re.IGNORECASE)
+        associated_bd_crd = re.sub("None", "", child_text(recipient_tag, "associatedBDCRDNumber") or "", flags=re.IGNORECASE)
 
         address_tag = recipient_tag.find("recipientAddress")
         address = Address(


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+ which you can see in the [CI logs](https://github.com/dgunning/edgartools/actions/runs/14506249587/job/40696118501#step:5:140):
```python
/home/runner/work/edgartools/edgartools/edgar/offerings/formd.py:124: DeprecationWarning: 'count' is passed as positional argument
```