### PR TITLE
Silence uu warnings

### DIFF
--- a/edgar/sgml/sgml_parser.py
+++ b/edgar/sgml/sgml_parser.py
@@ -49,7 +49,7 @@ class SGMLDocument:
                 output_stream = BytesIO()
 
                 # Decode the UU content
-                uu.decode(input_stream, output_stream)
+                uu.decode(input_stream, output_stream, quiet=True)
 
                 # Get the decoded bytes
                 return output_stream.getvalue()


### PR DESCRIPTION
Call `uu.decode()` with `quiet=True` to silence the unnecessary `Warning: Trailing Garbage` messages. Fixes #317 