### PR TITLE
Add markdown conversion support for HTML attachments and add support for optional page breaks

### DIFF
--- a/ai_docs/attachments_api.md
+++ b/ai_docs/attachments_api.md
@@ -70,8 +70,33 @@ Each `Attachment` provides rich metadata and content extraction methods:
 - `attachment.description`: description from SEC filing
 - `attachment.document_type`: type (e.g., 'EX-99.1', 'HTML', etc.)
 - `attachment.text()`: plain text content
+- `attachment.markdown()`: markdown content (HTML attachments only)
 - `attachment.download(path)`: download file
 - `attachment.is_html()`, `attachment.is_xml()`, `attachment.is_text()`, etc.
+
+### Markdown Conversion
+Convert HTML attachments to markdown format:
+```python
+# Convert a single HTML attachment
+attachment = attachments[1]  # Get primary document
+if attachment.is_html():
+    markdown_content = attachment.markdown()
+    print(markdown_content)
+
+# Batch convert all HTML attachments
+markdown_dict = attachments.markdown()
+for doc_name, markdown_content in markdown_dict.items():
+    print(f"Document: {doc_name}")
+    print(f"Content length: {len(markdown_content)} characters")
+    
+# Save markdown to files
+for doc_name, markdown_content in markdown_dict.items():
+    base_name = doc_name.rsplit('.', 1)[0]
+    with open(f"{base_name}.md", "w") as f:
+        f.write(markdown_content)
+```
+
+The `markdown()` method returns `None` for non-HTML attachments, making it safe to call on any attachment.
 
 ## Common Patterns
 - Get all exhibits:

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -42,6 +42,56 @@ print(text)
 
 This will print the text content of the attachment.
 
+### Converting HTML attachments to markdown
+
+You can convert HTML attachments to markdown format using the `markdown()` method.
+
+```python
+# Convert a single HTML attachment to markdown
+attachment = filing.attachments[1]  # Get the primary document
+if attachment.is_html():
+    markdown_content = attachment.markdown()
+    print(markdown_content)
+```
+
+The `markdown()` method returns `None` for non-HTML attachments, so you can safely call it on any attachment.
+
+### Batch markdown conversion
+
+You can convert all HTML attachments in a filing to markdown at once:
+
+```python
+# Convert all HTML attachments to markdown
+markdown_dict = filing.attachments.markdown()
+
+# This returns a dictionary mapping document names to markdown content
+for doc_name, markdown_content in markdown_dict.items():
+    print(f"Document: {doc_name}")
+    print(f"Markdown length: {len(markdown_content)} characters")
+    print("---")
+```
+
+### Saving markdown content
+
+You can save the markdown content to files:
+
+```python
+# Save individual attachment markdown
+attachment = filing.attachments[1]
+markdown_content = attachment.markdown()
+if markdown_content:
+    with open(f"{attachment.document}.md", "w") as f:
+        f.write(markdown_content)
+
+# Save all HTML attachments as markdown files
+markdown_dict = filing.attachments.markdown()
+for doc_name, markdown_content in markdown_dict.items():
+    # Remove extension and add .md
+    base_name = doc_name.rsplit('.', 1)[0]
+    with open(f"{base_name}.md", "w") as f:
+        f.write(markdown_content)
+```
+
 
 ### Downloading an attachment
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -56,19 +56,40 @@ if attachment.is_html():
 
 The `markdown()` method returns `None` for non-HTML attachments, so you can safely call it on any attachment.
 
+#### Page Break Delimiter Support
+
+The `markdown()` method supports optional page break delimiters to help you understand document structure:
+
+```python
+# Convert with page break delimiters
+attachment = filing.attachments[1]
+markdown_with_breaks = attachment.markdown(include_page_breaks=True)
+
+# Page breaks appear as: {1}------------------------------------------------
+# Where the number indicates the page number
+```
+
+When `include_page_breaks=True`, the markdown will include delimiters at page boundaries in the format:
+- `{0}------------------------------------------------` at the start of the document
+- `{1}------------------------------------------------` before the second page content
+- `{2}------------------------------------------------` before the third page content
+- And so on...
+
 ### Batch markdown conversion
 
 You can convert all HTML attachments in a filing to markdown at once:
 
 ```python
-# Convert all HTML attachments to markdown
+# Convert all HTML attachments (without page breaks)
 markdown_dict = filing.attachments.markdown()
 
-# This returns a dictionary mapping document names to markdown content
-for doc_name, markdown_content in markdown_dict.items():
-    print(f"Document: {doc_name}")
-    print(f"Markdown length: {len(markdown_content)} characters")
-    print("---")
+# Convert all HTML attachments with page breaks
+markdown_dict = filing.attachments.markdown(include_page_breaks=True)
+
+# Result is a dictionary: {"filename.htm": "markdown content", ...}
+for filename, content in markdown_dict.items():
+    print(f"--- {filename} ---")
+    print(content[:500])  # Show first 500 characters
 ```
 
 ### Saving markdown content

--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -1447,13 +1447,18 @@ class Filing:
         assert downloaded is not None
         return str(downloaded)
 
-    def markdown(self) -> str:
-        """return the markdown version of this filing html"""
+    def markdown(self, include_page_breaks: bool = False) -> str:
+        """
+        Return the markdown version of this filing html
+        
+        Args:
+            include_page_breaks: If True, include page break delimiters in the markdown
+        """
         html = self.html()
         if html:
             clean_html = get_clean_html(html)
             if clean_html:
-                return to_markdown(clean_html)
+                return to_markdown(clean_html, include_page_breaks=include_page_breaks)
         text_content = self.text()
         return text_to_markdown(text_content)
 

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -302,10 +302,15 @@ class Attachment:
                 return content
         return None
 
-    def markdown(self) -> Optional[str]:
+    def markdown(self, include_page_breaks: bool = False) -> Optional[str]:
         """
         Convert the attachment to markdown format if it's HTML content.
-        Returns None if the attachment is not HTML or cannot be converted.
+        
+        Args:
+            include_page_breaks: If True, include page break delimiters in the markdown
+            
+        Returns:
+            None if the attachment is not HTML or cannot be converted.
         """
         if not self.is_html():
             return None
@@ -318,13 +323,12 @@ class Attachment:
         if not has_html_content(content):
             return None
             
-        # Use the same approach as Filing.markdown()
+        # Use the same approach as Filing.markdown() but with page break support
         clean_html = get_clean_html(content)
         if clean_html:
-            return to_markdown(clean_html)
+            return to_markdown(clean_html, include_page_breaks=include_page_breaks)
             
-        # Fallback to text conversion
-        return text_to_markdown(content)
+        return None
 
     def __rich__(self):
         icon = get_file_icon(self.document_type, self.sequence_number, self.document)
@@ -589,17 +593,22 @@ class Attachments:
 
             return thread, httpd, url
 
-    def markdown(self) -> Dict[str, str]:
+    def markdown(self, include_page_breaks: bool = False) -> Dict[str, str]:
         """
         Convert all HTML attachments to markdown format.
-        Returns a dictionary mapping attachment document names to their markdown content.
-        Only includes attachments that can be successfully converted to markdown.
+        
+        Args:
+            include_page_breaks: If True, include page break delimiters in the markdown
+            
+        Returns:
+            A dictionary mapping attachment document names to their markdown content.
+            Only includes attachments that can be successfully converted to markdown.
         """
         markdown_attachments = {}
         
         for attachment in self._attachments:
             if attachment.is_html():
-                md_content = attachment.markdown()
+                md_content = attachment.markdown(include_page_breaks=include_page_breaks)
                 if md_content:
                     markdown_attachments[attachment.document] = md_content
                     

--- a/edgar/files/markdown.py
+++ b/edgar/files/markdown.py
@@ -27,6 +27,8 @@ class MarkdownRenderer:
                 rendered = self._render_table(processed_table) if processed_table else ""
             elif node.type == 'heading':
                 rendered = self._render_heading(node)
+            elif node.type == 'page_break':
+                rendered = self._render_page_break(node)
 
             if rendered:
                 rendered_parts.append(rendered.rstrip())  # Remove trailing whitespace
@@ -172,11 +174,14 @@ class MarkdownRenderer:
 
         return '\n'.join(formatted_lines)
 
+    def _render_page_break(self, node: BaseNode) -> str:
+        """Render page break as delimiter"""
+        return f"{{{node.page_number}}}------------------------------------------------"
 
 
-def to_markdown(html_content: str) -> Optional[str]:
-    """Convert HTML content to markdown"""
-    document = Document.parse(html_content)
+def to_markdown(html_content: str, include_page_breaks: bool = False) -> Optional[str]:
+    """Convert HTML content to markdown with optional page breaks"""
+    document = Document.parse(html_content, include_page_breaks=include_page_breaks)
     if document:
         return document.to_markdown()
     return None

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -454,3 +454,6 @@ def test_page_break_detection_patterns():
 
 
 
+
+
+

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -339,4 +339,118 @@ def test_attachment_markdown_with_non_html_filing():
         assert isinstance(markdown_content, str)
 
 
+def test_attachment_markdown_with_page_breaks():
+    """Test that HTML attachments can be converted to markdown with page breaks"""
+    filing = Filing(form='10-K', filing_date='2023-06-02', company='Cyber App Solutions Corp.', cik=1851048,
+                    accession_no='0001477932-23-004175')
+    attachments = filing.attachments
+    
+    # Get the HTML attachment (sequence 1)
+    html_attachment = attachments.get_by_sequence(1)
+    assert html_attachment.document == "cyber_10k.htm"
+    assert html_attachment.is_html()
+    
+    # Test with page breaks enabled
+    markdown_with_breaks = html_attachment.markdown(include_page_breaks=True)
+    assert markdown_with_breaks is not None
+    assert isinstance(markdown_with_breaks, str)
+    
+    # Test without page breaks
+    markdown_without_breaks = html_attachment.markdown(include_page_breaks=False)
+    assert markdown_without_breaks is not None
+    assert isinstance(markdown_without_breaks, str)
+    
+    # Check that page break markers are present when enabled
+    if '{' in markdown_with_breaks and '}' in markdown_with_breaks:
+        assert '------------------------------------------------' in markdown_with_breaks
+        print("✓ Page break delimiters found in markdown output")
+    else:
+        print("ℹ No page break markers found in this document")
+    
+    # The version with page breaks should be different from the one without
+    # (unless there are no page breaks in the document)
+    if '{' in markdown_with_breaks:
+        assert markdown_with_breaks != markdown_without_breaks
+        print("✓ Page break versions are different")
+    else:
+        print("ℹ No page breaks detected in this document")
+
+
+def test_attachments_batch_markdown_with_page_breaks():
+    """Test batch conversion of attachments with page breaks"""
+    filing = Filing(form='10-K', filing_date='2023-06-02', company='Cyber App Solutions Corp.', cik=1851048,
+                    accession_no='0001477932-23-004175')
+    attachments = filing.attachments
+    
+    # Test batch conversion with page breaks
+    markdown_dict_with_breaks = attachments.markdown(include_page_breaks=True)
+    assert isinstance(markdown_dict_with_breaks, dict)
+    
+    # Test batch conversion without page breaks
+    markdown_dict_without_breaks = attachments.markdown(include_page_breaks=False)
+    assert isinstance(markdown_dict_without_breaks, dict)
+    
+    # Both should have the same keys (document names)
+    assert set(markdown_dict_with_breaks.keys()) == set(markdown_dict_without_breaks.keys())
+    
+    # Check that at least one attachment was converted
+    assert len(markdown_dict_with_breaks) > 0
+    print(f"✓ Converted {len(markdown_dict_with_breaks)} attachments to markdown")
+
+
+def test_filing_markdown_with_page_breaks():
+    """Test that main filing can be converted to markdown with page breaks"""
+    filing = Filing(form='10-K', filing_date='2023-06-02', company='Cyber App Solutions Corp.', cik=1851048,
+                    accession_no='0001477932-23-004175')
+    
+    # Test main filing with page breaks
+    markdown_with_breaks = filing.markdown(include_page_breaks=True)
+    assert markdown_with_breaks is not None
+    assert isinstance(markdown_with_breaks, str)
+    
+    # Test main filing without page breaks
+    markdown_without_breaks = filing.markdown(include_page_breaks=False)
+    assert markdown_without_breaks is not None
+    assert isinstance(markdown_without_breaks, str)
+    
+    print("✓ Main filing markdown conversion with page breaks working")
+
+
+def test_page_break_detection_patterns():
+    """Test that various page break patterns are detected correctly"""
+    test_html = """
+    <html>
+    <body>
+        <div>Content before first page break</div>
+        <p style="page-break-before:always"></p>
+        <div>Content after first page break</div>
+        <hr style="page-break-after:always"/>
+        <div>Content after second page break</div>
+        <div style="page-break-before:always"></div>
+        <div>Content after third page break</div>
+    </body>
+    </html>
+    """
+    
+    from edgar.files.html import Document
+    
+    # Test with page breaks enabled
+    document = Document.parse(test_html, include_page_breaks=True)
+    assert document is not None
+    
+    # Count page break nodes
+    page_break_nodes = [node for node in document.nodes if node.type == 'page_break']
+    assert len(page_break_nodes) >= 1  # At least one page break should be detected
+    
+    # Check that page numbers are sequential starting from 0
+    page_numbers = [node.page_number for node in page_break_nodes]
+    expected_numbers = list(range(0, len(page_break_nodes)))
+    assert page_numbers == expected_numbers
+    
+    # Ensure the first page break is page 0 (document start)
+    assert page_numbers[0] == 0
+    
+    print(f"✓ Detected {len(page_break_nodes)} page breaks with correct numbering: {page_numbers}")
+
+
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -276,4 +276,67 @@ def test_get_report_attachments():
     assert 'CONSOLIDATED BALANCE SHEETS' in text
 
 
+def test_attachment_markdown_conversion():
+    """Test that HTML attachments can be converted to markdown"""
+    filing = Filing(form='10-K', filing_date='2023-06-02', company='Cyber App Solutions Corp.', cik=1851048,
+                    accession_no='0001477932-23-004175')
+    attachments = filing.attachments
+    
+    # Get the HTML attachment (sequence 1)
+    html_attachment = attachments.get_by_sequence(1)
+    assert html_attachment.document == "cyber_10k.htm"
+    assert html_attachment.is_html()
+    
+    # Test markdown conversion
+    markdown_content = html_attachment.markdown()
+    assert markdown_content is not None
+    assert isinstance(markdown_content, str)
+    assert len(markdown_content) > 0
+    
+    # Test that non-HTML attachments return None
+    if len(attachments) > 1:
+        for attachment in attachments:
+            if not attachment.is_html():
+                assert attachment.markdown() is None
+
+
+def test_attachments_markdown_batch_conversion():
+    """Test batch markdown conversion for all HTML attachments"""
+    filing = Filing(form='10-K', filing_date='2023-06-02', company='Cyber App Solutions Corp.', cik=1851048,
+                    accession_no='0001477932-23-004175')
+    attachments = filing.attachments
+    
+    # Get markdown for all HTML attachments
+    markdown_dict = attachments.markdown()
+    assert isinstance(markdown_dict, dict)
+    
+    # Should have at least the main HTML document
+    assert len(markdown_dict) > 0
+    
+    # Check that the main HTML document is included
+    assert "cyber_10k.htm" in markdown_dict
+    
+    # Verify all entries are strings
+    for doc_name, markdown_content in markdown_dict.items():
+        assert isinstance(doc_name, str)
+        assert isinstance(markdown_content, str)
+        assert len(markdown_content) > 0
+
+
+def test_attachment_markdown_with_non_html_filing():
+    """Test markdown conversion with a filing that has non-HTML primary document"""
+    filing = Filing(form='4', filing_date='2024-05-24', company='t Hart Cees', cik=1983327,
+                    accession_no='0000950170-24-064537')
+    attachments = filing.attachments
+    
+    # Test markdown conversion - should handle gracefully
+    markdown_dict = attachments.markdown()
+    assert isinstance(markdown_dict, dict)
+    
+    # May be empty if no HTML attachments
+    for doc_name, markdown_content in markdown_dict.items():
+        assert isinstance(doc_name, str)
+        assert isinstance(markdown_content, str)
+
+
 

--- a/tests/test_html_tables.py
+++ b/tests/test_html_tables.py
@@ -1,6 +1,6 @@
 import pytest
 from bs4 import BeautifulSoup
-from edgar.files.html import TableNode, TableRow, TableCell, StyleInfo
+from edgar.files.html import TableNode, TableRow, TableCell, StyleInfo, Document
 from edgar.files.tables import ProcessedTable
 
 def create_table_node(rows: list[list[tuple[str, int]]]) -> TableNode:
@@ -160,3 +160,156 @@ def test_edge_cases():
         [("C", 1), ("D", 1)]
     ])
     assert table.row_count == 3
+
+
+def test_table_with_tbody_structure():
+    """Test parsing of HTML tables with tbody elements containing tr rows
+    
+    This test covers the specific case that was failing before the fix where
+    tables with <tbody><tr>...</tr></tbody> structure were not being processed
+    because the parser was only looking for direct child <tr> elements.
+    """
+    html_content = """
+    <html>
+    <body>
+        <div>Content before table</div>
+        <table cellspacing="0" cellpadding="0" border="0" style="font-family: Arial; font-size: 10pt; width: 100%; border-collapse: collapse;">
+            <tbody>
+                <tr>
+                    <td style="width: 35%; vertical-align: bottom;">
+                        <div style="text-align: center;">Title of each class</div>
+                    </td>
+                    <td style="width: 30%; vertical-align: bottom;">
+                        <div style="text-align: center;">Trading symbol(s)</div>
+                    </td>
+                    <td style="width: 34.94%; vertical-align: bottom;">
+                        <div style="text-align: center;">Name of each exchange on which registered</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="width: 35%; vertical-align: bottom;">
+                        <div style="text-align: center;">Common Stock, $0.00001 par value per share</div>
+                    </td>
+                    <td style="width: 30%; vertical-align: bottom;">
+                        <div style="text-align: center;">AAPL</div>
+                    </td>
+                    <td style="width: 34.94%; vertical-align: bottom;">
+                        <div style="text-align: center;">The Nasdaq Stock Market LLC</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="width: 35%; vertical-align: bottom;">
+                        <div style="text-align: center;">0.000% Notes due 2025</div>
+                    </td>
+                    <td style="width: 30%; vertical-align: bottom;">
+                        <div style="text-align: center;">—</div>
+                    </td>
+                    <td style="width: 34.94%; vertical-align: bottom;">
+                        <div style="text-align: center;">The Nasdaq Stock Market LLC</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <div>Content after table</div>
+    </body>
+    </html>
+    """
+    
+    # Parse the document
+    document = Document.parse(html_content)
+    assert document is not None
+    
+    # Check that we have the expected nodes
+    table_nodes = [node for node in document.nodes if node.type == 'table']
+    text_nodes = [node for node in document.nodes if node.type == 'text_block']
+    
+    # Should have exactly 1 table node
+    assert len(table_nodes) == 1, f"Expected 1 table node, got {len(table_nodes)}"
+    
+    # Verify the table structure
+    table = table_nodes[0]
+    assert table.row_count == 3, f"Expected 3 rows, got {table.row_count}"
+    assert table.approximate_column_count == 3, f"Expected 3 columns, got {table.approximate_column_count}"
+    
+    # Verify table content by checking the first row
+    first_row = table.content[0]
+    assert len(first_row.cells) == 3
+    
+    # Check cell contents (the divs should be processed to extract text)
+    cell_texts = [cell.content.strip() for cell in first_row.cells]
+    assert "Title of each class" in cell_texts[0]
+    assert "Trading symbol" in cell_texts[1]
+    assert "exchange" in cell_texts[2]
+    
+    # Verify second row contains AAPL data
+    second_row = table.content[1]
+    cell_texts = [cell.content.strip() for cell in second_row.cells]
+    assert "Common Stock" in cell_texts[0]
+    assert "AAPL" in cell_texts[1]
+    assert "Nasdaq" in cell_texts[2]
+    
+    # Should also have text nodes for content before/after table
+    assert len(text_nodes) >= 2, f"Expected at least 2 text nodes, got {len(text_nodes)}"
+    
+    # Verify markdown conversion includes the table
+    markdown = document.to_markdown()
+    assert "Title of each class" in markdown
+    assert "AAPL" in markdown
+    assert "Common Stock" in markdown
+    assert "|" in markdown  # Should contain table formatting
+
+
+def test_table_with_nested_structure_multiple_tbody():
+    """Test parsing of more complex table structures with multiple tbody elements"""
+    html_content = """
+    <html>
+    <body>
+        <table border="0" cellpadding="0" cellspacing="0">
+            <thead>
+                <tr>
+                    <th>Header 1</th>
+                    <th>Header 2</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Data 1A</td>
+                    <td>Data 1B</td>
+                </tr>
+                <tr>
+                    <td>Data 2A</td>
+                    <td>Data 2B</td>
+                </tr>
+            </tbody>
+            <tbody>
+                <tr>
+                    <td>Data 3A</td>
+                    <td>Data 3B</td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+    </html>
+    """
+    
+    document = Document.parse(html_content)
+    assert document is not None
+    
+    table_nodes = [node for node in document.nodes if node.type == 'table']
+    assert len(table_nodes) == 1
+    
+    table = table_nodes[0]
+    # Should have all rows: 1 thead + 2 tbody sections with 3 data rows total = 4 total rows
+    assert table.row_count == 4
+    assert table.approximate_column_count == 2
+    
+    # Check content
+    all_texts = []
+    for row in table.content:
+        for cell in row.cells:
+            all_texts.append(cell.content.strip())
+    
+    # Should contain all the expected data
+    expected_texts = ["Header 1", "Header 2", "Data 1A", "Data 1B", "Data 2A", "Data 2B", "Data 3A", "Data 3B"]
+    for expected in expected_texts:
+        assert expected in all_texts, f"Expected text '{expected}' not found in table content"

--- a/tests/test_markdown_page_breaks.py
+++ b/tests/test_markdown_page_breaks.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+
+from edgar.files.html import Document
+
+
+class TestMarkdownPageBreaks:
+    """Dedicated tests for markdown page break functionality"""
+
+    def test_explicit_page_breaks_with_content(self):
+        """Test that explicit page breaks work and preserve content"""
+        html_content = """
+        <html>
+        <body>
+            <div>Content before first page break</div>
+            <p style="page-break-before:always">Content after first page break</p>
+            <div>More content</div>
+            <hr style="page-break-after:always"/>
+            <div>Content after hr page break</div>
+        </body>
+        </html>
+        """
+        
+        document = Document.parse(html_content, include_page_breaks=True)
+        assert document is not None
+        
+        # Check that we have page breaks and content
+        page_break_nodes = [node for node in document.nodes if node.type == 'page_break']
+        text_nodes = [node for node in document.nodes if node.type == 'text_block']
+        
+        assert len(page_break_nodes) >= 1  # At least document start
+        assert len(text_nodes) >= 3  # Should have text content
+        
+        # Test markdown conversion
+        markdown = document.to_markdown()
+        assert markdown is not None
+        
+        # Should have both page breaks and content
+        assert '{' in markdown and '}' in markdown  # Page break markers
+        assert 'Content before first page break' in markdown
+        assert 'Content after first page break' in markdown
+        assert 'More content' in markdown
+        assert 'Content after hr page break' in markdown
+
+    def test_page_div_breaks_with_content(self):
+        """Test that page-like divs are detected as page breaks while preserving content"""
+        html_content = """
+        <html>
+        <body>
+            <div>Content before page breaks</div>
+            <div style="height: 842.4pt; width: 597.6pt; position: relative; overflow: hidden; padding: 0;">
+                <div>Page 1 header</div>
+                <p>Page 1 paragraph content</p>
+                <div>Page 1 footer</div>
+            </div>
+            <div style="height: 842.4pt; width: 597.6pt; position: relative; overflow: hidden; padding: 0;">
+                <div>Page 2 header</div>
+                <p>Page 2 paragraph content</p>
+                <div>Page 2 footer</div>
+            </div>
+            <div>Content after page breaks</div>
+        </body>
+        </html>
+        """
+        
+        document = Document.parse(html_content, include_page_breaks=True)
+        assert document is not None
+        
+        # Check that we have page breaks and content
+        page_break_nodes = [node for node in document.nodes if node.type == 'page_break']
+        text_nodes = [node for node in document.nodes if node.type == 'text_block']
+        
+        # Should detect: document_start (page 0) + 2 page divs = 3 page breaks
+        assert len(page_break_nodes) == 3
+        # Should have multiple text nodes with content (content gets efficiently combined)
+        assert len(text_nodes) >= 3
+        
+        # Test markdown conversion
+        markdown = document.to_markdown()
+        assert markdown is not None
+        
+        # Should have both page breaks and content
+        page_break_count = markdown.count('{')
+        assert page_break_count >= 3  # At least 3 page breaks
+        
+        # Verify content is preserved
+        assert 'Content before page breaks' in markdown
+        assert 'Page 1 header' in markdown
+        assert 'Page 1 paragraph content' in markdown
+        assert 'Page 1 footer' in markdown
+        assert 'Page 2 header' in markdown
+        assert 'Page 2 paragraph content' in markdown
+        assert 'Page 2 footer' in markdown
+        assert 'Content after page breaks' in markdown
+        
+
+
+    def test_unilever_like_structure(self):
+        """Test a structure similar to the Unilever 20-F file"""
+        html_content = """
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div style="--justify: justify; --position: absolute; background-color: #FFFFFF; border: 1px solid #CCCC; content-visibility: auto; float: none; font-family: Arial, Sans Serif; font-size: 0; height: 842.4pt; margin: 10px auto 10px auto; overflow: hidden; padding: 0; position: relative; width: 597.6pt; word-wrap: break-word;">
+                <div style="left: 0pt; position: var(--position); top: 799.88pt;">
+                    <div style="width: 512pt;"></div>
+                </div>
+                <div style="left: 0pt; position: var(--position); top: 0pt;">
+                    <div style="width: 512pt;"></div>
+                </div>
+                <div>
+                    <div style="line-height: 8pt; position: var(--position); top: 113.39pt; width: 597.6pt;">
+                        <span style="font-family: 'Arial', sans-serif; font-size: 8pt; font-style: normal; font-weight: normal; left: 69.27pt; position: var(--position); white-space: pre;">
+                            Indicate by check mark which basis of accounting the registrant has used to prepare the financial statements included in this filing:
+                        </span>
+                    </div>
+                    <div style="position: var(--position); top: 131.31pt; width: 597.6pt;">
+                        <div style="font-size: 0pt; left: 42.67pt; position: var(--position); top: 0pt; width: 512.25pt;">
+                            <div>
+                                <table style="border-collapse: collapse; display: inline-table; width: 100%;">
+                                    <tbody>
+                                        <tr style="height: 0;">
+                                            <td colspan="1" rowspan="1" style="padding: 0; width: 135pt;"></td>
+                                            <td colspan="1" rowspan="1" style="padding: 0; width: 3.75pt;"></td>
+                                            <td colspan="1" rowspan="1" style="padding: 0; width: 234.75pt;"></td>
+                                        </tr>
+                                        <tr style="height: 21.75pt;">
+                                            <td colspan="1" rowspan="1" style="font-size: 0; text-align: left; vertical-align: top;">
+                                                <div style="left: 0pt; position: var(--position); top: 0pt; width: 135pt;">
+                                                    <div>
+                                                        <div style="line-height: 9pt; position: var(--position); top: 2.63pt; width: 135pt;">
+                                                            <span style="font-family: 'Arial', sans-serif; font-size: 7pt; font-style: normal; font-weight: normal; left: 2.63pt; position: var(--position); text-decoration: none; white-space: pre;">
+                                                                U.S. GAAP 
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div style="--justify: justify; --position: absolute; background-color: #FFFFFF; border: 1px solid #CCCC; content-visibility: auto; float: none; font-family: Arial, Sans Serif; font-size: 0; height: 842.4pt; margin: 10px auto 10px auto; overflow: hidden; padding: 0; position: relative; width: 597.6pt; word-wrap: break-word;">
+                <div style="left: 0pt; position: var(--position); top: 799.88pt;">
+                    <div style="width: 512pt;"></div>
+                </div>
+                <div>
+                    <div style="line-height: 8pt; position: var(--position); top: 50pt; width: 597.6pt;">
+                        <span style="font-family: 'Arial', sans-serif; font-size: 12pt; font-weight: bold; left: 200pt; position: var(--position);">
+                            UNILEVER PLC
+                        </span>
+                    </div>
+                    <div style="line-height: 8pt; position: var(--position); top: 100pt; width: 597.6pt;">
+                        <span style="font-family: 'Arial', sans-serif; font-size: 10pt; left: 50pt; position: var(--position);">
+                            Annual Report on Form 20-F for the fiscal year ended December 31, 2023
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </body>
+        </html>
+        """
+        
+        document = Document.parse(html_content, include_page_breaks=True)
+        assert document is not None
+        
+        # Check that we have page breaks and content
+        page_break_nodes = [node for node in document.nodes if node.type == 'page_break']
+        text_nodes = [node for node in document.nodes if node.type == 'text_block']
+        table_nodes = [node for node in document.nodes if node.type == 'table']
+        
+
+        
+        # Should detect: 2 page divs (no document_start needed since first element is a page div) = 2 page breaks
+        assert len(page_break_nodes) == 2
+        # Should have content nodes - at least some text and/or tables
+        assert len(text_nodes) + len(table_nodes) >= 2
+        
+        # Test markdown conversion
+        markdown = document.to_markdown()
+        assert markdown is not None
+        
+        # Should have both page breaks and content
+        page_break_count = markdown.count('{')
+        assert page_break_count >= 2
+        
+        # Verify some content is preserved
+        content_found = any(phrase in markdown for phrase in [
+            'accounting', 'registrant', 'financial statements', 'UNILEVER', 'Annual Report', 'Form 20-F'
+        ])
+        assert content_found, f"Expected content not found in markdown: {markdown[:500]}..."
+        
+
+
+    def test_page_break_detection_with_page_divs(self):
+        """Test that div elements with page-like dimensions are detected as page breaks"""
+        test_html = """
+        <html>
+        <body>
+            <div>Content before page breaks</div>
+            <div style="height: 842.4pt; width: 597.6pt; position: relative; overflow: hidden; padding: 0;">
+                <div>Page 1 content</div>
+            </div>
+            <div style="height: 842.4pt; width: 597.6pt; position: relative; overflow: hidden; padding: 0;">
+                <div>Page 2 content</div>
+            </div>
+            <div style="height: 792pt; width: 612pt; position: absolute; overflow: hidden; padding: 0;">
+                <div>Page 3 content (Letter size)</div>
+            </div>
+            <div style="height: 100px; width: 200px; position: relative;">
+                <div>Not a page (wrong dimensions)</div>
+            </div>
+            <div>Content after page breaks</div>
+        </body>
+        </html>
+        """
+        
+        # Test with page breaks enabled
+        document = Document.parse(test_html, include_page_breaks=True)
+        assert document is not None
+        
+        # Count page break nodes
+        page_break_nodes = [node for node in document.nodes if node.type == 'page_break']
+        
+        # Should detect: 
+        # - page 0 (document start - content before first page div)
+        # - page 1 (first page-like div - A4: 842.4pt x 597.6pt)
+        # - page 2 (second page-like div - A4: 842.4pt x 597.6pt)  
+        # - page 3 (third page-like div - Letter: 792pt x 612pt)
+        # Total = 4 page breaks
+        assert len(page_break_nodes) == 4
+        
+        # Check that page numbers are sequential starting from 0
+        page_numbers = [node.page_number for node in page_break_nodes]
+        expected_numbers = [0, 1, 2, 3]
+        assert page_numbers == expected_numbers
+        
+        # Check that the page breaks have the correct source elements
+        sources = [node.metadata.get('source_element', 'unknown') for node in page_break_nodes]
+        assert sources[0] == 'document_start'  # Document start page break
+        assert sources[1] == 'div'  # First page div
+        assert sources[2] == 'div'  # Second page div  
+        assert sources[3] == 'div'  # Third page div
+        
+        # Verify content is preserved
+        markdown = document.to_markdown()
+        assert 'Content before page breaks' in markdown
+        assert 'Page 1 content' in markdown
+        assert 'Page 2 content' in markdown
+        assert 'Page 3 content (Letter size)' in markdown
+        assert 'Not a page (wrong dimensions)' in markdown  # This should not be treated as page break
+        assert 'Content after page breaks' in markdown
+        
+
+
+    def test_mixed_page_breaks(self):
+        """Test mixing explicit page breaks with page divs"""
+        html_content = """
+        <html>
+        <body>
+            <div>Initial content</div>
+            <p style="page-break-before:always">After explicit break</p>
+            <div style="height: 842.4pt; width: 597.6pt; position: relative; overflow: hidden;">
+                <div>Page div content</div>
+            </div>
+            <hr style="page-break-after:always"/>
+            <div>Final content</div>
+        </body>
+        </html>
+        """
+        
+        document = Document.parse(html_content, include_page_breaks=True)
+        assert document is not None
+        
+        markdown = document.to_markdown()
+        assert markdown is not None
+        
+        # Should have multiple page breaks and all content
+        page_break_count = markdown.count('{')
+        assert page_break_count >= 4  # document_start + explicit + page div + hr
+        
+        assert 'Initial content' in markdown
+        assert 'After explicit break' in markdown
+        assert 'Page div content' in markdown
+        assert 'Final content' in markdown
+        
+
+
+ 


### PR DESCRIPTION
This PR adds markdown conversion support for HTML attachments, optional page breaks in markdown output and fixes parsing issues with nested HTML structure. Practical use case for this is when needing documents in machine-readable format, and being able to correctly match by page.

## New Features

- **Markdown conversion**: Added `markdown()` method to `Attachment` and `Attachments` classes
- **Page break support**: Added optional `include_page_breaks` parameter with delimiter format `{page_number}------------------------------------------------` in markdown output

## Bug Fixes

- **Improved HTML parsing**: Now properly handles nested `<tbody>`, `<thead>`, and `<tfoot>` elements. With previous code, some content in the markdown output was completely skipped, as only direct children were considered
