### PR TITLE
Switch HTTPX Rate Limiter to PyRate

### DIFF
--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -74,7 +74,7 @@ def _get_cache_controller(**kwargs):
 
     return controller
 
-def cached_factory(limiter: Callable, cache_directory: Path | None = None, controller_args: dict | None = None, **kwargs):
+def cached_factory(limiter: Callable, cache_directory: Path | None = None, controller_args: dict | None = None, storage: hishel.BaseStorage | None = None, **kwargs):
     params = httpclient.DEFAULT_PARAMS.copy()
     params["headers"] = httpclient.client_headers()
     params.update(**kwargs)
@@ -82,9 +82,13 @@ def cached_factory(limiter: Callable, cache_directory: Path | None = None, contr
         controller_args = {}
 
     controller = _get_cache_controller(**controller_args)
+
+    if storage is None:
+        storage = hishel.FileStorage(base_path = cache_directory)
+        
     client = hishel.CacheClient(
         controller=controller,
-        storage=hishel.FileStorage(base_path = cache_directory),
+        storage=storage,
         **params
     )
 
@@ -98,17 +102,20 @@ def cached_factory(limiter: Callable, cache_directory: Path | None = None, contr
     return client
 
 @asynccontextmanager
-async def asynccached_factory(limiter: Callable, cache_directory: Path | None = None, controller_args: dict | None = None, **kwargs):
+async def asynccached_factory(limiter: Callable, cache_directory: Path | None = None, controller_args: dict | None = None, async_storage: hishel.AsyncBaseStorage | None = None, **kwargs):
     params = httpclient.DEFAULT_PARAMS.copy()
     params["headers"] = httpclient.client_headers()
     params.update(**kwargs)
     if controller_args is None:
         controller_args = {}
+    
+    if async_storage is None:
+        async_storage = hishel.AsyncFileStorage(base_path = cache_directory)
 
     controller = _get_cache_controller(**controller_args)
     client = hishel.AsyncCacheClient(
         controller=controller,
-        storage=hishel.AsyncFileStorage(base_path = cache_directory),
+        storage=async_storage,
         **params
     )
         


### PR DESCRIPTION
 This PR changes the default cache in httpclient_cache from [limiter](https://pypi.org/project/limiter/) to https://pypi.org/project/pyrate-limiter/, and makes it easier to change limiters by passing a callable... eliminating the global used for the previous limiter. 

This came up in https://github.com/dgunning/edgartools/issues/320, where user wanted to set a custom throttler... and perhaps share this throttler *across* processes. PyRate_Limiter allows different [backends](https://pyratelimiter.readthedocs.io/en/latest/#backends), some of which allow cross-process throttling.

Custom throttlers would now be possible by passing the Limiter to install_cached_client.
#### Example using default pyrate_limiter

```py

from edgar import httpclient_cache, set_identity, Company
from pathlib import Path
import logging

logging.basicConfig(
    format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
    level=logging.INFO,
    datefmt='%Y-%m-%d %H:%M:%S')

logging.getLogger("hishel.controller").setLevel(logging.DEBUG)

httpclient_cache.install_cached_client(cache_directory = Path(r"my_cachedir"), controller_args = {"allow_heuristics": True, "allow_stale": True, "always_revalidate": False})

# set_identity("you@email.com")

filings = Company('MS').get_filings(form="10-Q").latest(10)
```

> 2025-06-18 09:55:45 pyrate_limiter INFO     Initializing default bucket(InMemoryBucket) with rates: [limit=10/1000]


#### Custom Rate Limiter (1 Request per Second)

```py
%load_ext autoreload
%autoreload 2

# pip install hishel httpx limiter

from edgar import httpclient_cache, set_identity, Company
from pathlib import Path
import logging

logging.basicConfig(
    format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
    level=logging.INFO,
    datefmt='%Y-%m-%d %H:%M:%S')

logging.getLogger("hishel.controller").setLevel(logging.DEBUG)

limiter = httpclient_cache._init_pyrate_limiter(1)

httpclient_cache.install_cached_client(limiter = limiter, cache_directory = Path(r"."), controller_args = {"allow_heuristics": True, "allow_stale": True, "always_revalidate": False})

# set_identity("you@email.com")

filings = Company('MS').get_filings(form="10-Q").latest(10)
```
> 2025-07-09 18:02:01 pyrate_limiter INFO     Initializing default bucket(InMemoryBucket) with rates: [limit=1/1000]
