### PR TITLE
Update Viewing-Financial-Statements.ipynb to Work with Latest API

### DIFF
--- a/notebooks/Viewing-Financial-Statements.ipynb
+++ b/notebooks/Viewing-Financial-Statements.ipynb
@@ -127,7 +127,7 @@
    },
    "cell_type": "code",
    "source": [
-    "financials = c.financials\n",
+    "financials = c.get_financials()\n",
     "financials"
    ],
    "id": "3c827af01d94cf7b",
@@ -266,7 +266,7 @@
     }
    },
    "cell_type": "code",
-   "source": "financials.balance_sheet",
+   "source": "financials.balance_sheet()",
    "id": "d42ba84013a8bed0",
    "outputs": [
     {
@@ -354,7 +354,7 @@
     }
    },
    "cell_type": "code",
-   "source": "financials.income",
+   "source": "financials.income_statement()",
    "id": "3cd2edbb6b2cd909",
    "outputs": [
     {
@@ -428,7 +428,7 @@
     }
    },
    "cell_type": "code",
-   "source": "financials.cashflow",
+   "source": "financials.cashflow_statement()",
    "id": "febcc6053aa873aa",
    "outputs": [
     {
@@ -536,7 +536,7 @@
    },
    "cell_type": "code",
    "source": [
-    "xb = financials.xbrl_data\n",
+    "xb = financials.xb\n",
     "xb"
    ],
    "id": "8eca6ef94b026756",


### PR DESCRIPTION
While exploring the library and familiarizing myself with its API, I noticed that `notebooks/Viewing-Financial-Statements.ipynb` was outdated and no longer functioning as expected.

I’ve updated the notebook to align with the current API, ensuring it runs smoothly. Submitting this PR to share the fixes—hope it’s helpful!