### PR TITLE
Cache Performance - Large Files

### DIFF
--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -39,12 +39,11 @@ from edgar.core import get_identity, edgar_mode, strtobool
 from edgar.httpclient_cache import get_cache_controller
 from edgar.httpclient_ratelimiter import RateLimitingTransport, AsyncRateLimitingTransport, create_rate_limiter
 from pathlib import Path
-from pyrate_limiter import Limiter, BucketAsyncWrapper
 from .core import edgar_data_dir
 
 log = logging.getLogger(__name__)
 
-HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8", http2=True}
+HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8", "http2": True}
 
 CACHE_ENABLED = True
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -51,7 +51,7 @@ CACHE_ENABLED = True
 
 def get_cache_directory():
     if CACHE_ENABLED:
-        cachedir = Path(edgar_data_dir) / "_cache"
+        cachedir = Path(edgar_data_dir) / "_pcache"
         cachedir.mkdir(exist_ok=True)
 
         return str(cachedir)
@@ -167,7 +167,7 @@ def get_transport() -> httpx.BaseTransport:
     cache_dir = get_cache_directory()
     if cache_dir:
         log.info(f"Cache is ENABLED, writing to {cache_dir}")
-        storage = hishel.FileStorage(base_path=Path(cache_dir))
+        storage = hishel.FileStorage(base_path=Path(cache_dir), serializer=hishel.PickleSerializer())
         controller = get_cache_controller()
         rate_limit_transport = RateLimitingTransport(_RATE_LIMITER)
         return hishel.CacheTransport(transport=rate_limit_transport, storage=storage, controller=controller)

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -44,7 +44,7 @@ from .core import edgar_data_dir
 
 log = logging.getLogger(__name__)
 
-HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8"}
+HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8", http2=True}
 
 CACHE_ENABLED = True
 

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -43,7 +43,14 @@ from .core import edgar_data_dir
 
 log = logging.getLogger(__name__)
 
-HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8", "http2": True}
+try: 
+    # enable http2 if h2 is installed
+    import h2  # type: ignore  # noqa 
+    http2 = True
+except ImportError: 
+    http2 = False
+
+HTTPX_PARAMS = {"timeout": edgar_mode.http_timeout, "limits": edgar_mode.limits, "default_encoding": "utf-8", "http2": http2}
 
 CACHE_ENABLED = True
 

--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -84,6 +84,7 @@ def get_cache_controller(**kwargs):
                     # log.debug("Submissions age is %d, max_age is %d", age_seconds, max_age)
                     if age_seconds > max_age:
                         log.debug("Request needs to be validated before using %s (age=%d, max_age=%d)", target, age_seconds, max_age)
+                        self._make_request_conditional(request=request, response=response)
                         return request
                     else:
                         log.debug("Cache hit for %s (age=%d, max_age=%d)", target, age_seconds, max_age)


### PR DESCRIPTION
While reviewing #378, I noticed that bulk files were much slower with the cache enabled due to serialization:

This PR contains three performance optimizations:
- Use a faster [serializer ](https://hishel.com/advanced/serializers/) than the default JSON serializer
- Fixes revalidation - after the cache time is up, we should revalidate the data not re-download again. This needed the `_make_request_conditional` option. 
- Enable [HTTP2 ](https://www.python-httpx.org/http2/) if H2 is installed: I haven't yet seen a significant difference in my testing so far, but http2 may help complex apps with many concurrent operations.

I did some performance testing, and this cuts the cache hits for large files from 14 seconds to 1-2 seconds. 

More broadly, a set of performance tests will be helpful. Not sure yet how though. 