### PR TITLE
Bypass Cache for Bulk Files

### DIFF
--- a/edgar/httpclient_cache.py
+++ b/edgar/httpclient_cache.py
@@ -70,7 +70,6 @@ def get_cache_controller(**kwargs):
         def construct_response_from_cache(
             self, request: httpcore.Request, response: httpcore.Response, original_request: httpcore.Request
         ) -> Union[httpcore.Request, httpcore.Response, None]:
-            raise ValueError("Shouldn't reach here")
             if response.status != 200:
                 return None
 

--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -481,7 +481,7 @@ async def stream_file(
     temp_file = Path(temp_dir) / f"download_{uuid.uuid1()}"
 
     try:
-        async with async_http_client(client, timeout=TIMEOUT) as async_client:
+        async with async_http_client(client, timeout=TIMEOUT, bypass_cache=True) as async_client:
             async with async_client.stream("GET", url) as response:
                 inspect_response(response)
                 total_size = int(response.headers.get("Content-Length", 0))


### PR DESCRIPTION
Fixes: #378 

This is a workaround for now - download_bulk_files can pass a "bypass_cache" signal, for #388 . 

Please check the progress bar behavior, this was a quick fix to make sure bulk files bypass the cache - to fix the streaming updates.

Beyond this PR, I'll review the streaming behavior in #386. 