### PR TITLE
Add 3.13 to Classifiers for PYPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Minor housekeeping - 3.13 should be listed on classifiers, so it'll show correctly in PYPI

<img width="342" height="245" alt="image" src="https://github.com/user-attachments/assets/58c39d6e-0549-4a5e-a865-a0eafb1496dc" />
