### PR TITLE
reduce log verbosity for httpxthrottlecache and pyrate_limiter

### DIFF
--- a/edgar/core.py
+++ b/edgar/core.py
@@ -665,6 +665,11 @@ def initialize_rich_logging():
 
     # Turn down 3rd party logging
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpxthrottlecache").setLevel(logging.WARNING)
+    logging.getLogger("pyrate_limiter").setLevel(
+        logging.CRITICAL
+    )  # TODO: Temporary, until next pyrate_limiter update that reduces the spurious "async" message
+
 
 # Turn on rich logging if the environment variable is set
 if os.getenv('EDGAR_USE_RICH_LOGGING', '0') == '1':


### PR DESCRIPTION
Per https://github.com/dgunning/edgartools/discussions/388#discussioncomment-14105195, increases the log levels to WARNING for the httpxthrottlecache and CRITICAL for pyrate_limiter. 

The Critical for pyrate_limiter is temporary, due to the spurious/unnecessary warning message. This will be removed in subsequent release. Any pyrate_limiter error will propagate through httpxthrottlecache anyway. 

Please check and see if this addresses the issue you were seeing with the log levels.
