### PR TITLE
Fix deprecation warnings in Python >3.12

### DIFF
--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -718,7 +718,10 @@ async def download_bulk_data(
                                 raise ValueError(f"Attempted path traversal in tar file: {member.name}")
 
                             # Extract file and update progress
-                            tar.extract(member, str(download_path))
+                            try:
+                                tar.extract(member, str(download_path), filter="tar")
+                            except TypeError:
+                                tar.extract(member, str(download_path))
                             pbar.update(member.size)
             else:
                 raise ValueError(f"Unsupported file format: {filename}")


### PR DESCRIPTION
Python 3.12 and newer will give this warning if not using a filter: `DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.`

Also see https://docs.python.org/3/library/tarfile.html#extraction-filters