### PR TITLE
fix: Include skill-related markdown files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ include = [
   "edgar/**/*.py",
   "edgar/**/templates/*.html",
   "edgar/**/docs/*.md",
+  "edgar/ai/skills/core/*.md",
   "edgar/reference/data/*",
   "edgar/entity/data/*",
   "edgar/xbrl/standardization/*",


### PR DESCRIPTION
Currently, when running the snippet shown in the [4.25 release notes](https://github.com/dgunning/edgartools/releases/tag/v4.25.0):

```python
from edgar.ai import install_skill, package_skill

# Install to ~/.claude/skills/ with one function call
install_skill()
```

We get:
```none
ValueError: No markdown files found in .../.venv/lib/python3.13/site-packages/edgar/ai/skills/core
```
This PR attempts to fix that by including the files in the wheel.