### PR TITLE
feat: Support configuration of SEC domains via environment variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,23 @@ repos:
         language: node
         pass_filenames: true
         additional_dependencies: ["pyright"]
+      - id: check-hardcoded-sec-urls
+        name: Check for hardcoded SEC URLs
+        entry: bash -c
+        args:
+          - |
+            if grep -rn --include="*.py" -E "https?://(www\.|data\.)?sec\.gov" edgar/ --exclude-dir=__pycache__ | \
+               grep -v "edgar/config.py" | \
+               grep -v "# sec.gov OK" | \
+               grep -v "See https://www.sec.gov" | \
+               grep -v "xbrl.sec.gov" | \
+               grep -v "e.g." | \
+               grep -v "e.g.," | \
+               grep -v "example:"; then
+              echo "Error: Found hardcoded SEC URLs. Use SEC_BASE_URL, SEC_DATA_URL, or URL builders from edgar.urls instead."
+              echo "To allow a specific URL, add comment: # sec.gov OK"
+              exit 1
+            fi
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -47,8 +47,8 @@ from edgar.core import (
     log,
     parallel_thread_map,
     quarters_in_year,
-    sec_edgar,
 )
+from edgar.config import SEC_ARCHIVE_URL
 from edgar.dates import InvalidDateException
 from edgar.files.html import Document
 from edgar.files.html_documents import get_clean_html
@@ -88,10 +88,9 @@ __all__ = [
     'filing_date_to_year_quarters'
 ]
 
-full_index_url = "https://www.sec.gov/Archives/edgar/full-index/{}/QTR{}/{}.{}"
-daily_index_url = "https://www.sec.gov/Archives/edgar/daily-index/{}/QTR{}/{}.{}.idx"
+from edgar.urls import build_full_index_url, build_daily_index_url
 
-filing_homepage_url_re = re.compile(f"{sec_edgar}/data/[0-9]{1,}/[0-9]{10}-[0-9]{2}-[0-9]{4}-index.html")
+filing_homepage_url_re = re.compile(f"{SEC_ARCHIVE_URL}/data/[0-9]{{1,}}/[0-9]{{10}}-[0-9]{{2}}-[0-9]{{4}}-index.html")
 
 full_or_daily = ['daily', 'full']
 index_types = ['form', 'company', 'xbrl']
@@ -354,7 +353,7 @@ def fetch_filing_index(year_and_quarter: YearAndQuarter,
                        index: str
                        ):
     year, quarter = year_and_quarter
-    url = full_index_url.format(year, quarter, index, "gz")
+    url = build_full_index_url(year, quarter, index, "gz")
     try:
         index_table = fetch_filing_index_at_url(url, index)
         return (year, quarter), index_table
@@ -370,7 +369,7 @@ def fetch_daily_filing_index(date: str,
                              index: str = 'form'):
     year, month, day = date.split("-")
     quarter = (int(month) - 1) // 3 + 1
-    url = daily_index_url.format(year, quarter, index, date.replace("-", ""))
+    url = build_daily_index_url(int(year), quarter, date.replace("-", ""), "idx")
     index_table = fetch_filing_index_at_url(url, index, filing_date_format='%Y%m%d')
     return index_table
 
@@ -1685,7 +1684,7 @@ class Filing:
 
     @property
     def homepage_url(self) -> str:
-        return f"{sec_edgar}/data/{self.cik}/{self.accession_no}-index.html"
+        return f"{SEC_ARCHIVE_URL}/data/{self.cik}/{self.accession_no}-index.html"
 
     @property
     def text_url(self) -> str:
@@ -1697,7 +1696,7 @@ class Filing:
 
     @property
     def base_dir(self) -> str:
-        return f"{sec_edgar}/data/{self.cik}/{self.accession_no.replace('-', '')}"
+        return f"{SEC_ARCHIVE_URL}/data/{self.cik}/{self.accession_no.replace('-', '')}"
 
     @property
     def url(self) -> str:

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -27,7 +27,8 @@ from rich.panel import Panel
 from rich.table import Column, Table
 from rich.text import Text
 
-from edgar.core import binary_extensions, has_html_content, sec_dot_gov, text_extensions
+from edgar.core import binary_extensions, has_html_content, text_extensions
+from edgar.config import SEC_BASE_URL
 from edgar.files.html_documents import get_clean_html
 from edgar.files.markdown import to_markdown
 from edgar.httpclient import async_http_client
@@ -42,7 +43,7 @@ __all__ = ['Attachment', 'Attachments', 'FilingHomepage', 'FilerInfo', 'Attachme
 def sec_document_url(attachment_url: str) -> str:
     # Remove "ix?doc=/" or "ix.xhtml?doc=/" from the filing url
     attachment_url = re.sub(r"ix(\.xhtml)?\?doc=/", "", attachment_url)
-    return f"{sec_dot_gov}{attachment_url}"
+    return f"{SEC_BASE_URL}{attachment_url}"
 
 def sequence_sort_key(x):
     seq = x.sequence_number

--- a/edgar/config.py
+++ b/edgar/config.py
@@ -1,0 +1,25 @@
+"""
+Configuration module for SEC EDGAR URLs.
+
+This module allows users to configure custom SEC mirror URLs via environment variables:
+- EDGAR_BASE_URL: Base URL for SEC website (default: https://www.sec.gov)
+- EDGAR_DATA_URL: Base URL for SEC data API (default: https://data.sec.gov)
+- EDGAR_XBRL_URL: Base URL for XBRL taxonomy (default: http://xbrl.sec.gov)
+
+Example:
+    import os
+    os.environ['EDGAR_BASE_URL'] = 'https://mysite.com'
+
+    from edgar import Company
+    company = Company('AAPL')  # Will use mysite.com instead of sec.gov
+"""
+import os
+
+__all__ = ['SEC_BASE_URL', 'SEC_DATA_URL', 'SEC_XBRL_URL', 'SEC_ARCHIVE_URL']
+
+# Load configuration from environment variables at module import time
+# These are constants and won't change during runtime
+SEC_BASE_URL = os.environ.get('EDGAR_BASE_URL', 'https://www.sec.gov').rstrip('/')
+SEC_DATA_URL = os.environ.get('EDGAR_DATA_URL', 'https://data.sec.gov').rstrip('/')
+SEC_XBRL_URL = os.environ.get('EDGAR_XBRL_URL', 'http://xbrl.sec.gov').rstrip('/')
+SEC_ARCHIVE_URL = f"{SEC_BASE_URL}/Archives/edgar"

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -49,9 +49,7 @@ __all__ = [
     'NORMAL',
     'CRAWL',
     'CAUTION',
-    'sec_edgar',
     'IntString',
-    'sec_dot_gov',
     'get_identity',
     'python_version',
     'set_identity',
@@ -162,10 +160,6 @@ else:
     edgar_mode = NORMAL
 
 edgar_identity = 'EDGAR_IDENTITY'
-
-# SEC urls
-sec_dot_gov = "https://www.sec.gov"
-sec_edgar = "https://www.sec.gov/Archives/edgar"
 
 # Local storage directory.
 edgar_data_dir = os.path.join(os.path.expanduser("~"), ".edgar")

--- a/edgar/current_filings.py
+++ b/edgar/current_filings.py
@@ -33,7 +33,7 @@ title_regex = re.compile(r"(.*?) - (.*) \((\d+)\) \((.*)\)")
 """
 Get the current filings from the SEC. Use this to get the filings filed after the 5:30 deadline
 """
-GET_CURRENT_URL = "https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&output=atom&owner=only&count=100"
+from edgar.config import SEC_BASE_URL
 
 
 def _empty_filing_index():
@@ -105,7 +105,7 @@ def get_current_url(atom: bool = True,
                     start: int = 0,
                     form: str = '',
                     owner: str = 'include'):
-    url = "https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent"
+    url = f"{SEC_BASE_URL}/cgi-bin/browse-edgar?action=getcurrent"
 
     count = count if count in [10, 20, 40, 80, 100] else 40
     owner = owner if owner in ['include', 'exclude', 'only'] else 'include'

--- a/edgar/entity/data.py
+++ b/edgar/entity/data.py
@@ -368,9 +368,10 @@ class EntityData:
         download_json = lazy_import('edgar.httprequests.download_json')
 
         # Load additional filings from the SEC
+        from edgar.config import SEC_DATA_URL
         filing_tables = [self.filings.data]
         for file in self._files:
-            submissions = download_json("https://data.sec.gov/submissions/" + file['name'])
+            submissions = download_json(f"{SEC_DATA_URL}/submissions/" + file['name'])
             filing_table = extract_company_filings_table(submissions)
             filing_tables.append(filing_table)
 

--- a/edgar/entity/entity_facts.py
+++ b/edgar/entity/entity_facts.py
@@ -47,7 +47,8 @@ def download_company_facts_from_sec(cik: int) -> Dict[str, Any]:
     """
     Download company facts from the SEC
     """
-    company_facts_url = f"https://data.sec.gov/api/xbrl/companyfacts/CIK{cik:010}.json"
+    from edgar.urls import build_company_facts_url
+    company_facts_url = build_company_facts_url(cik)
     try:
         return download_json(company_facts_url)
     except httpx.HTTPStatusError as err:

--- a/edgar/entity/submissions.py
+++ b/edgar/entity/submissions.py
@@ -79,7 +79,8 @@ def download_entity_submissions_from_sec(cik: int) -> Optional[Dict[str, Any]]:
         Optional[Dict[str, Any]]: The entity submissions JSON data, or None if not found
     """
     try:
-        submission_json = download_json(f"https://data.sec.gov/submissions/CIK{cik:010}.json")
+        from edgar.urls import build_submissions_url
+        submission_json = download_json(build_submissions_url(cik))
     except httpx.HTTPStatusError as e:
         # Handle the case where the cik is invalid and not found on Edgar
         if e.response.status_code == 404:

--- a/edgar/forms.py
+++ b/edgar/forms.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from rich.console import Group, Text
 from rich.markdown import Markdown
 
-from edgar.core import sec_dot_gov
+from edgar.config import SEC_BASE_URL
 from edgar.httprequests import download_file
 from edgar.richtools import df_to_rich_table, repr_rich
 
@@ -33,7 +33,7 @@ def list_forms():
             cells = tr.find_all('td')
             rows.append({"Form": cells[0].text.replace("Number:", "").strip(),
                          "Description": cells[1].text.replace("Description:", "").strip(),
-                         "Url": f"{sec_dot_gov}{cells[1].find('a').attrs['href']}" if cells[1].find('a') else "",
+                         "Url": f"{SEC_BASE_URL}{cells[1].find('a').attrs['href']}" if cells[1].find('a') else "",
                          "LastUpdated": cells[2].text.replace("Last Updated:", "").strip(),
                          "SECNumber": cells[3].text.replace("SEC Number:", "").strip(),
                          "Topics": cells[4].text.replace("Topic(s):", "").strip()

--- a/edgar/headers.py
+++ b/edgar/headers.py
@@ -12,7 +12,7 @@ from rich.table import Column, Table
 from rich.text import Text
 
 from edgar._party import Address, get_addresses_as_columns
-from edgar.core import sec_dot_gov
+from edgar.config import SEC_BASE_URL
 from edgar.formatting import display_size
 from edgar.httprequests import download_file
 from edgar.reference import describe_form
@@ -40,7 +40,7 @@ class FilingDirectory:
 
     @property
     def index_headers(self):
-        return download_file(f"{sec_dot_gov}/{self.name}/{self.accession_number}-index-headers.html")
+        return download_file(f"{SEC_BASE_URL}/{self.name}/{self.accession_number}-index-headers.html")
 
     @classmethod
     def load(cls, basedir: str):

--- a/edgar/reference/tickers.py
+++ b/edgar/reference/tickers.py
@@ -18,14 +18,15 @@ __all__ = ['cusip_ticker_mapping', 'get_ticker_from_cusip', 'get_company_tickers
            'get_cik_tickers', 'get_company_ticker_name_exchange', 'get_companies_by_exchange', 'popular_us_stocks',
            'get_mutual_fund_tickers', 'find_mutual_fund_cik', 'list_all_tickers', 'find_ticker', 'find_ticker_safe', 'get_cik_ticker_lookup',
            'get_company_cik_lookup', 'get_cik_tickers_from_ticker_txt', 'get_cik_tickers', 'get_company_tickers',
-           'ticker_txt_url', 'company_tickers_json_url', 'mutual_fund_tickers_url', 'company_tickers_exchange_url',
            'Exchange'
            ]
 
-ticker_txt_url = "https://www.sec.gov/include/ticker.txt"
-company_tickers_json_url = "https://www.sec.gov/files/company_tickers.json"
-mutual_fund_tickers_url = "https://www.sec.gov/files/company_tickers_mf.json"
-company_tickers_exchange_url = "https://www.sec.gov/files/company_tickers_exchange.json"
+from edgar.urls import (
+    build_ticker_url,
+    build_company_tickers_url,
+    build_mutual_fund_tickers_url,
+    build_company_tickers_exchange_url
+)
 
 
 @lru_cache(maxsize=1)
@@ -86,10 +87,10 @@ def get_company_tickers(
         if os.getenv("EDGAR_USE_LOCAL_DATA"):
             tickers_json = load_tickers_from_local()
             if not tickers_json:
-                tickers_json = download_json(company_tickers_json_url)
+                tickers_json = download_json(build_company_tickers_url())
         else:
             # Download JSON data
-            tickers_json = download_json(company_tickers_json_url)
+            tickers_json = download_json(build_company_tickers_url())
 
         # Pre-allocate lists for better memory efficiency
         ciks = []
@@ -153,9 +154,9 @@ def get_cik_tickers_from_ticker_txt():
         if os.getenv("EDGAR_USE_LOCAL_DATA"):
             ticker_txt = load_cik_tickers_from_local()
             if not ticker_txt:
-                ticker_txt = download_file(ticker_txt_url, as_text=True)
+                ticker_txt = download_file(build_ticker_url(), as_text=True)
         else:
-            ticker_txt = download_file(ticker_txt_url, as_text=True)
+            ticker_txt = download_file(build_ticker_url(), as_text=True)
         source = StringIO(ticker_txt)
         data = pd.read_csv(source,
                            sep='\t',
@@ -289,7 +290,7 @@ def get_company_ticker_name_exchange():
     """
     Return a DataFrame with columns [cik	name	ticker	exchange]
     """
-    data = download_json("https://www.sec.gov/files/company_tickers_exchange.json")
+    data = download_json(build_company_tickers_exchange_url())
     return pd.DataFrame(data['data'], columns=data['fields'])
 
 
@@ -313,7 +314,7 @@ def get_mutual_fund_tickers():
     This returns a dataframe with columns
         cik    seriesId     classId ticker
     """
-    data = download_json("https://www.sec.gov/files/company_tickers_mf.json")
+    data = download_json(build_mutual_fund_tickers_url())
     return pd.DataFrame(data['data'], columns=['cik', 'seriesId', 'classId', 'ticker'])
 
 

--- a/edgar/urls.py
+++ b/edgar/urls.py
@@ -1,0 +1,78 @@
+"""
+URL builder utilities for SEC EDGAR.
+
+This module provides centralized URL construction functions that use the
+configured SEC mirror URLs from edgar.config.
+"""
+from edgar.config import SEC_BASE_URL, SEC_DATA_URL, SEC_ARCHIVE_URL
+
+__all__ = [
+    'build_archive_url',
+    'build_api_url',
+    'build_submissions_url',
+    'build_company_facts_url',
+    'build_full_index_url',
+    'build_daily_index_url',
+    'build_feed_url',
+    'build_ticker_url',
+    'build_company_tickers_url',
+    'build_mutual_fund_tickers_url',
+    'build_company_tickers_exchange_url',
+]
+
+
+def build_archive_url(path: str) -> str:
+    """Build a URL for the SEC Archives/edgar directory."""
+    path = path.lstrip('/')
+    return f"{SEC_ARCHIVE_URL}/{path}"
+
+
+def build_api_url(path: str) -> str:
+    """Build a URL for the SEC data API."""
+    path = path.lstrip('/')
+    return f"{SEC_DATA_URL}/api/{path}"
+
+
+def build_submissions_url(cik: int) -> str:
+    """Build a URL for company submissions data."""
+    return f"{SEC_DATA_URL}/submissions/CIK{cik:010d}.json"
+
+
+def build_company_facts_url(cik: int) -> str:
+    """Build a URL for company facts data."""
+    return f"{SEC_DATA_URL}/api/xbrl/companyfacts/CIK{cik:010d}.json"
+
+
+def build_full_index_url(year: int, quarter: int, index_type: str, file_type: str) -> str:
+    """Build a URL for full index files."""
+    return f"{SEC_ARCHIVE_URL}/full-index/{year}/QTR{quarter}/{index_type}.{file_type}"
+
+
+def build_daily_index_url(year: int, quarter: int, date_str: str, file_type: str) -> str:
+    """Build a URL for daily index files."""
+    return f"{SEC_ARCHIVE_URL}/daily-index/{year}/QTR{quarter}/{date_str}.{file_type}"
+
+
+def build_feed_url(year: int, quarter: int) -> str:
+    """Build a URL for SEC EDGAR feed directory."""
+    return f"{SEC_ARCHIVE_URL}/Feed/{year}/QTR{quarter}/"
+
+
+def build_ticker_url() -> str:
+    """Build URL for ticker.txt reference file."""
+    return f"{SEC_BASE_URL}/include/ticker.txt"
+
+
+def build_company_tickers_url() -> str:
+    """Build URL for company_tickers.json reference file."""
+    return f"{SEC_BASE_URL}/files/company_tickers.json"
+
+
+def build_mutual_fund_tickers_url() -> str:
+    """Build URL for mutual fund tickers reference file."""
+    return f"{SEC_BASE_URL}/files/company_tickers_mf.json"
+
+
+def build_company_tickers_exchange_url() -> str:
+    """Build URL for company tickers by exchange reference file."""
+    return f"{SEC_BASE_URL}/files/company_tickers_exchange.json"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,156 @@
+"""Tests for edgar.config module - SEC URL configuration"""
+import os
+import pytest
+import importlib
+
+
+@pytest.fixture
+def clean_env():
+    """Clean environment variables before and after tests"""
+    env_vars = ['EDGAR_BASE_URL', 'EDGAR_DATA_URL', 'EDGAR_XBRL_URL']
+    # Store original values
+    original = {k: os.environ.get(k) for k in env_vars}
+
+    # Clean before test
+    for var in env_vars:
+        os.environ.pop(var, None)
+
+    yield
+
+    # Restore after test
+    for var in env_vars:
+        os.environ.pop(var, None)
+        if original[var] is not None:
+            os.environ[var] = original[var]
+
+
+@pytest.mark.fast
+class TestConfig:
+    """Test configuration module"""
+
+    def test_default_urls(self, clean_env):
+        """Test default SEC URLs are returned when no env vars set"""
+        # Need to reload module to pick up environment changes
+        import edgar.config
+        importlib.reload(edgar.config)
+
+        assert edgar.config.SEC_BASE_URL == "https://www.sec.gov"
+        assert edgar.config.SEC_DATA_URL == "https://data.sec.gov"
+        assert edgar.config.SEC_XBRL_URL == "http://xbrl.sec.gov"
+        assert edgar.config.SEC_ARCHIVE_URL == "https://www.sec.gov/Archives/edgar"
+
+    def test_custom_base_url(self, clean_env):
+        """Test custom base URL from environment variable"""
+        os.environ['EDGAR_BASE_URL'] = "https://mysite.com"
+
+        import edgar.config
+        importlib.reload(edgar.config)
+
+        assert edgar.config.SEC_BASE_URL == "https://mysite.com"
+        assert edgar.config.SEC_ARCHIVE_URL == "https://mysite.com/Archives/edgar"
+
+    def test_custom_data_url(self, clean_env):
+        """Test custom data URL from environment variable"""
+        os.environ['EDGAR_DATA_URL'] = "https://data.mysite.com"
+
+        import edgar.config
+        importlib.reload(edgar.config)
+
+        assert edgar.config.SEC_DATA_URL == "https://data.mysite.com"
+
+    def test_url_strips_trailing_slash(self, clean_env):
+        """Test that trailing slashes are stripped from URLs"""
+        os.environ['EDGAR_BASE_URL'] = "https://mysite.com/"
+
+        import edgar.config
+        importlib.reload(edgar.config)
+
+        assert edgar.config.SEC_BASE_URL == "https://mysite.com"
+
+
+@pytest.mark.fast
+class TestURLBuilders:
+    """Test URL builder utilities"""
+
+    def test_build_archive_url_default(self, clean_env):
+        """Test archive URL building with defaults"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_archive_url
+        url = build_archive_url("data/12345/file.txt")
+        assert url == "https://www.sec.gov/Archives/edgar/data/12345/file.txt"
+
+    def test_build_archive_url_custom(self, clean_env):
+        """Test archive URL building with custom base"""
+        os.environ['EDGAR_BASE_URL'] = "https://mysite.com"
+
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_archive_url
+        url = build_archive_url("data/12345/file.txt")
+        assert url == "https://mysite.com/Archives/edgar/data/12345/file.txt"
+
+    def test_build_api_url(self, clean_env):
+        """Test API URL building"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_api_url
+        url = build_api_url("xbrl/companyfacts/CIK0000320193.json")
+        assert url == "https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json"
+
+    def test_build_submissions_url(self, clean_env):
+        """Test submissions URL building"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_submissions_url
+        url = build_submissions_url(320193)
+        assert url == "https://data.sec.gov/submissions/CIK0000320193.json"
+
+    def test_build_company_facts_url(self, clean_env):
+        """Test company facts URL building"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_company_facts_url
+        url = build_company_facts_url(320193)
+        assert url == "https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json"
+
+    def test_build_full_index_url(self, clean_env):
+        """Test full index URL building"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_full_index_url
+        url = build_full_index_url(2024, 1, "form", "idx")
+        assert url == "https://www.sec.gov/Archives/edgar/full-index/2024/QTR1/form.idx"
+
+    def test_url_path_normalization(self, clean_env):
+        """Test that paths are normalized (no double slashes)"""
+        import edgar.config
+        import edgar.urls
+        importlib.reload(edgar.config)
+        importlib.reload(edgar.urls)
+
+        from edgar.urls import build_archive_url
+
+        # Path with leading slash should work
+        url1 = build_archive_url("/data/12345/file.txt")
+        url2 = build_archive_url("data/12345/file.txt")
+        assert url1 == url2
+        assert "//" not in url1.replace("https://", "")


### PR DESCRIPTION
We're using edgartools in conjunction with a private EDGAR mirror to get around some rate-limiting related restrictions and also do other complex data analysis. This PR adds preliinary support for configuring an override to a custom domain.

We will submit future PRs to support also configuring rate-limiting based on environment variable as well if this approach seems reasonable to the maintainers.