### PR TITLE
fix(httprequests): evaluate data directory at runtime instead of import time

### DIFF
--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -815,7 +815,7 @@ logger = logging.getLogger(__name__)
 )
 async def download_bulk_data(
         url: str,
-        data_directory: Path = get_edgar_data_directory(),
+        data_directory: Optional[Path] = None,
         client: Optional[AsyncClient] = None,
 ) -> Path:
     """
@@ -837,6 +837,10 @@ async def download_bulk_data(
     """
     if not url:
         raise ValueError("Data URL cannot be empty")
+
+    # Get the data directory if not provided
+    if data_directory is None:
+        data_directory = get_edgar_data_directory()
 
     filename = os.path.basename(url)
     if not filename:


### PR DESCRIPTION
Previously, `download_bulk_data()` evaluated `get_edgar_data_directory()` at import time,
causing the data directory to remain fixed even after `set_local_storage_path()` updated
the environment variable.

This change ensures that `data_directory` is resolved dynamically at call time,
so updates made by `use_local_storage()` or `set_local_storage_path()` are respected
by all subsequent bulk data downloads.

While this does not fully resolve #381, it addresses a key part of the issue where
downloads were silently stored in the default path (`~/.edgar`) instead of the
user-specified local directory.

Related to #381
