### PR TITLE
Fix table truncation: increase text() width from 80 to 500 chars

### DIFF
--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -1533,7 +1533,7 @@ class Filing:
         html_content = self.html()
         if html_content and is_probably_html(html_content):
             document = Document.parse(html_content)
-            return rich_to_text(document)
+            return rich_to_text(document, width=500)  # Wide enough for tables without truncation
         else:
             text_extract_attachments = self.attachments.query("document_type == 'TEXT-EXTRACT'")
             if len(text_extract_attachments) > 0 and text_extract_attachments.get_by_index(0) is not None:


### PR DESCRIPTION
This pull request makes a targeted improvement to the text extraction process from HTML filings. The main change is to ensure that table data is not truncated when converting rich HTML content to plain text.

- In `edgar/_filings.py`, the `rich_to_text` function is now called with a `width=500` parameter in the `text` method, ensuring that tables and wide content are fully captured during text extraction.

This was causing text to truncate tables: 
```
  1341→                                                                                
  1342→                                                                                
  1343→             Dece…                                                              
  1344→               31,                                                              
  1345→              2024                                                              
  1346→ ────────────────────────────────────────────────────────────────────────────── 
  1347→                         Gross       Gross                    Cash              
  1348→             Adju…       Unre…       Unre…        Fair         and       Shor…  
  1349→              Cost       Gains       Loss…       Value        Cash       Inve…  
  1350→                                                             Equi…              
  1351→  Cash    $  14,3…    $      —    $      —    $  14,3…    $  14,3…    $      —  
  1352→  Cer…                                                                          
  1353→  of                                                                            
  1354→  dep…       12,7…           —           —       12,7…           —       12,7…  
  1355→  and                                                                           
  1356→  time                                                                          
  1357→  dep…                                                                          
  1358→  Com…       3,908          11           —       3,919           —       3,919  
  1359→  pap…                                                                          
  1360→  U.S.                                                                          
  1361→  gov…       3,618           3          -1       3,620           —       3,620  
  1362→  sec…                                                                          
  1363→  Cor…                                                                          
  1364→  debt         117           1           —         118           —         118  
  1365→  sec…                                                                          
  1366→  Mon…                                                                          
  1367→  mar…       1,753           —           —       1,753       1,753           — 
  ```
  
after fix it is
  ```
    1002→                                         December 31, 2024                                                                                                                                           
  1003→ ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
  1004→                                             Adjusted Cost       Gross Unrealized Gains       Gross Unrealized Losses       Fair Value       Cash and Cash Equivalents       Short-Term Investments  
  1005→  Cash                                $             14,386    $                       —    $                        —    $      14,386    $                     14,386    $                       —  
  1006→  Certificates of deposit and time                  12,767                            —                             —           12,767                               —                       12,767  
  1007→  deposits                                                                                                                                                                                           
  1008→  Commercial paper                                   3,908                           11                             —            3,919                               —                        3,919  
  1009→  U.S. government securities                         3,618                            3                            -1            3,620                               —                        3,620  
  1010→  Corporate debt securities                            117                            1                             —              118                               —                          118  
  1011→  Money market funds                                 1,753                            —                             —            1,753                           1,753                            —  
  1012→  Total cash, cash equivalents and    $             36,549    $                      15    $                       -1    $      36,563    $                     16,139    $                  20,424  
  1013→  short-term investments                                                                      
  ```