### PR TITLE
fix(httpclient): respect EDGAR_LOCAL_DATA_DIR for HTTP cache directory

### DIFF
--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -22,7 +22,7 @@ from httpxthrottlecache import HttpxThrottleCache
 
 from edgar.core import get_identity, strtobool
 
-from .core import edgar_data_dir
+from .core import edgar_data_dir, get_edgar_data_directory
 
 MAX_SUBMISSIONS_AGE_SECONDS = 30  # Check for submissions every 30 seconds (reduced from 10 min for Issue #471)
 MAX_INDEX_AGE_SECONDS = 30 * 60  # Check for updates to index (ie: daily-index) every 30 minutes
@@ -66,7 +66,7 @@ def _get_cache_rules() -> dict:
 CACHE_RULES = _get_cache_rules()
 
 def get_cache_directory() -> str:
-    cachedir = Path(edgar_data_dir) / "_tcache"
+    cachedir = get_edgar_data_directory() / "_tcache"
     cachedir.mkdir(parents=True, exist_ok=True)
 
     return str(cachedir)


### PR DESCRIPTION
## Problem

The `get_cache_directory()` function in `httpclient.py` uses the hardcoded `edgar_data_dir` global variable instead of `get_edgar_data_directory()`, which means the `EDGAR_LOCAL_DATA_DIR` environment variable is not respected for the HTTP cache location.

Related: #381

## Solution

Change `get_cache_directory()` to use `get_edgar_data_directory()`.

## Changes (`edgar/httpclient.py`)

```diff
- from .core import edgar_data_dir
+ from .core import edgar_data_dir, get_edgar_data_directory

  def get_cache_directory() -> str:
-     cachedir = Path(edgar_data_dir) / "_tcache"
+     cachedir = get_edgar_data_directory() / "_tcache"
      cachedir.mkdir(parents=True, exist_ok=True)
      return str(cachedir)
```