### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 }
 ```
 
+### Option 3: sk (Universal Skills Manager)
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, Amp, and other compatible agents).
+
+```bash
+sk pkg add github dgunning/edgartools --path edgar/ai/skills
+sk sync
+```
+
 See [AI Integration Guide](docs/ai-integration.md) for complete documentation.
 
 </details>

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -379,6 +379,15 @@ Exported skills include:
 - YAML frontmatter for tool integration
 - Helper function documentation
 
+#### Install with `sk`
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, Amp, and other compatible agents).
+
+```bash
+sk pkg add github dgunning/edgartools --path edgar/ai/skills
+sk sync
+```
+
 ## Model Context Protocol (MCP) Server
 
 Run EdgarTools as an MCP server for Claude Desktop and other MCP clients.

--- a/edgar/ai/README.md
+++ b/edgar/ai/README.md
@@ -56,6 +56,15 @@ cp -r edgar/ai/skills/core ~/.claude/skills/edgartools/
 # Restart Claude Desktop - skill automatically discovered
 ```
 
+**Install with `sk`:**
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, Amp, and other compatible agents).
+
+```bash
+sk pkg add github dgunning/edgartools --path edgar/ai/skills
+sk sync
+```
+
 ### Usage Example
 
 Once installed, agents can read documentation and write code:


### PR DESCRIPTION
`sk` is a universal package manager (works across all coding agents), handles updates, etc.. (npm/cargo for agents).

would you be open to adding this?
