### PR TITLE
fix: support TOC named-anchor targets and centralize anchor matching

### DIFF
--- a/edgar/documents/document.py
+++ b/edgar/documents/document.py
@@ -19,6 +19,7 @@ from rich.text import Text
 from edgar.documents.nodes import Node, SectionNode
 from edgar.documents.table_nodes import TableNode
 from edgar.documents.types import SearchResult, XBRLFact
+from edgar.documents.utils.anchor_targets import find_anchor_targets, is_anchor_match
 from edgar.richtools import repr_rich
 
 logger = logging.getLogger(__name__)
@@ -255,8 +256,8 @@ class Section:
 
             boundary = extractor.section_boundaries[self.name]
 
-            # Find start anchor
-            start_elements = tree.xpath(f'//*[@id="{boundary.anchor_id}"]')
+            # Find start anchor by id or legacy name attribute
+            start_elements = find_anchor_targets(tree, boundary.anchor_id)
             if not start_elements:
                 return ""
 
@@ -268,15 +269,13 @@ class Section:
                 if not hasattr(el, 'get'):
                     continue
 
-                el_id = el.get('id', '')
-
                 # Check if we've reached the start anchor
-                if el_id == boundary.anchor_id:
+                if is_anchor_match(el, boundary.anchor_id):
                     in_range = True
                     continue
 
                 # Check if we've reached the end boundary
-                if boundary.end_element_id and el_id == boundary.end_element_id:
+                if boundary.end_element_id and is_anchor_match(el, boundary.end_element_id):
                     break
 
                 # Collect elements in range

--- a/edgar/documents/extractors/toc_section_extractor.py
+++ b/edgar/documents/extractors/toc_section_extractor.py
@@ -14,6 +14,7 @@ from lxml import html as lxml_html
 
 from edgar.documents.document import Document
 from edgar.documents.nodes import Node
+from edgar.documents.utils.anchor_targets import find_anchor_targets, is_anchor_match
 from edgar.documents.utils.toc_analyzer import TOCAnalyzer
 
 
@@ -75,7 +76,7 @@ class SECSectionExtractor:
 
         for section_name, anchor_id in toc_mapping.items():
             # Verify the anchor target exists
-            target_elements = tree.xpath(f'//*[@id="{anchor_id}"]')
+            target_elements = find_anchor_targets(tree, anchor_id)
             if target_elements:
                 element = target_elements[0]
 
@@ -236,7 +237,7 @@ class SECSectionExtractor:
         tree = lxml_html.fromstring(html_content)
 
         # Verify start anchor exists
-        start_elements = tree.xpath(f'//*[@id="{boundary.anchor_id}"]')
+        start_elements = find_anchor_targets(tree, boundary.anchor_id)
         if not start_elements:
             return ""
 
@@ -260,12 +261,12 @@ class SECSectionExtractor:
 
             if event == 'start':
                 # Check if we've reached the start anchor
-                if el_id == boundary.anchor_id:
+                if is_anchor_match(el, boundary.anchor_id):
                     in_range = True
                     continue
 
                 # Check if we've reached the end boundary
-                if boundary.end_element_id and el_id == boundary.end_element_id:
+                if boundary.end_element_id and is_anchor_match(el, boundary.end_element_id):
                     in_range = False
                     break
 

--- a/edgar/documents/utils/__init__.py
+++ b/edgar/documents/utils/__init__.py
@@ -3,6 +3,7 @@ Utility modules for HTML parsing.
 """
 
 from edgar.documents.utils.cache import CacheManager, CacheStats, LRUCache, TimeBasedCache, WeakCache, cached, get_cache_manager
+from edgar.documents.utils.anchor_targets import find_anchor_targets, is_anchor_match
 from edgar.documents.utils.currency_merger import CurrencyColumnMerger
 
 # Note: CacheableMixin not exported to avoid circular imports
@@ -22,6 +23,8 @@ __all__ = [
     'get_cache_manager',
     'cached',
     'CacheStats',
+    'find_anchor_targets',
+    'is_anchor_match',
     'StreamingParser',
     'TableMatrix',
     'ColumnAnalyzer',

--- a/edgar/documents/utils/anchor_targets.py
+++ b/edgar/documents/utils/anchor_targets.py
@@ -1,0 +1,17 @@
+"""Utilities for resolving and matching SEC anchor targets."""
+
+
+def find_anchor_targets(tree, anchor_id: str):
+    """Find elements matching an anchor target via either id or name."""
+    if not anchor_id:
+        return []
+
+    return tree.xpath('//*[@id=$anchor_id or @name=$anchor_id]', anchor_id=anchor_id)
+
+
+def is_anchor_match(element, anchor_id: str) -> bool:
+    """Return True if an element matches the given anchor by id or name."""
+    if not anchor_id:
+        return False
+
+    return element.get('id', '') == anchor_id or element.get('name', '') == anchor_id

--- a/edgar/documents/utils/toc_analyzer.py
+++ b/edgar/documents/utils/toc_analyzer.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, Tuple
 
 from lxml import html as lxml_html
 
+from edgar.documents.utils.anchor_targets import find_anchor_targets
+
 
 @dataclass
 class TOCSection:
@@ -95,7 +97,7 @@ class TOCAnalyzer:
                     # Check if this looks like a section reference (check text, anchor ID, and context)
                     if self._is_section_link(text, anchor_id, preceding_item):
                         # Verify target exists
-                        target_elements = tree.xpath(f'//*[@id="{anchor_id}"]')
+                        target_elements = find_anchor_targets(tree, anchor_id)
                         if target_elements:
                             # Try to extract item number from: anchor ID > preceding context > text
                             normalized_name = self._normalize_section_name(text, anchor_id, preceding_item)

--- a/tests/test_toc_name_anchors.py
+++ b/tests/test_toc_name_anchors.py
@@ -1,0 +1,58 @@
+"""Regression tests for TOC links that target <a name="..."> anchors."""
+
+from edgar.documents import HTMLParser, ParserConfig
+from edgar.documents.utils.toc_analyzer import TOCAnalyzer
+
+
+HTML_WITH_NAMED_ANCHORS = """
+<html>
+  <body>
+    <table>
+      <tr>
+        <td>Item 1.</td>
+        <td><a href="#ITEM_1_BUSINESS">Business</a></td>
+        <td>3</td>
+      </tr>
+      <tr>
+        <td>Item 1A.</td>
+        <td><a href="#ITEM_1A_RISK_FACTORS">Risk Factors</a></td>
+        <td>17</td>
+      </tr>
+      <tr>
+        <td>Item 2.</td>
+        <td><a href="#ITEM_2_PROPERTIES">Properties</a></td>
+        <td>29</td>
+      </tr>
+    </table>
+
+    <p><a name="ITEM_1_BUSINESS"></a>ITEM 1. BUSINESS</p>
+    <p>Business section text.</p>
+
+    <p><a name="ITEM_1A_RISK_FACTORS"></a>ITEM 1A. RISK FACTORS</p>
+    <p>Risk section text.</p>
+
+    <p><a name="ITEM_2_PROPERTIES"></a>ITEM 2. PROPERTIES</p>
+    <p>Properties section text.</p>
+  </body>
+</html>
+"""
+
+
+def test_toc_analyzer_resolves_name_anchors():
+    """TOC analyzer should map sections when targets are name anchors."""
+    analyzer = TOCAnalyzer()
+    mapping = analyzer.analyze_toc_structure(HTML_WITH_NAMED_ANCHORS)
+
+    assert mapping.get("Item 1") == "ITEM_1_BUSINESS"
+    assert mapping.get("Item 1A") == "ITEM_1A_RISK_FACTORS"
+    assert mapping.get("Item 2") == "ITEM_2_PROPERTIES"
+
+
+def test_parser_uses_toc_with_name_anchors():
+    """Parser should expose item sections from TOC when using name anchors."""
+    parser = HTMLParser(ParserConfig(form="10-K"))
+    doc = parser.parse(HTML_WITH_NAMED_ANCHORS)
+
+    assert "Item 1" in doc.sections
+    assert "Item 1A" in doc.sections
+    assert "Item 2" in doc.sections


### PR DESCRIPTION
Closes #726 

Fixes silent TOC detection failure for 10-K filings where TOC links point to `<a name="...">` anchors instead of `id` attributes. Extended target resolution to check both `id` and `name`.