### PR TITLE
feat: add support for FDUS investment parser

### DIFF
--- a/edgar/bdc/investments.py
+++ b/edgar/bdc/investments.py
@@ -254,7 +254,7 @@ def _parse_investment_identifier(dimension_label: str) -> tuple[str, str, str]:
     fdus_match = re.match(
         r'^(?P<prefix>'
         r'Non-control/Non-affiliate(?: Investments| Investmnts)?|'
-        r'Affiliate(?: Investments)?|'
+        r'Affiliate(?: Investments| InvesAffiliate Investments)?|'
         r'Control(?: Investments)?'
         r')\s+'
         r'(?P<body>.+?)\s+'

--- a/tests/test_bdc.py
+++ b/tests/test_bdc.py
@@ -628,6 +628,24 @@ class TestInvestmentIdentifierParsing:
         assert company == 'Detechtion Holdings, LLC'
         assert inv_type == 'First Lien Debt'
 
+    def test_parse_fdus_truncated_investments_prefix_typo(self):
+        """Test parsing a leaked/truncated relationship prefix in the company name."""
+        identifier, company, inv_type = _parse_investment_identifier(
+            'us-gaap:InvestmentIdentifierAxis: Non-control/Non-affiliate Investmnts Suited Connector LLC '
+            'Information Technology Services Common Equity (97,808 units) Investment date 12/1/2021'
+        )
+        assert company == 'Suited Connector LLC'
+        assert inv_type == 'Common Equity'
+
+    def test_parse_fdus_leaked_affiliate_prefix_fragment(self):
+        """Test parsing a leaked prefix fragment before the company name."""
+        identifier, company, inv_type = _parse_investment_identifier(
+            'us-gaap:InvestmentIdentifierAxis: Affiliate InvesAffiliate Investments Medsurant Holdings LLC '
+            'Healthcare Services Preferred Equity (84,997 units) Investment date 4/12/2011'
+        )
+        assert company == 'Medsurant Holdings LLC'
+        assert inv_type == 'Preferred Equity'
+
 class TestPortfolioInvestmentsIntegration:
     """Integration tests for portfolio investments."""
 


### PR DESCRIPTION
Fix FDUS investment identifier parsing for BDC portfolio extraction

Adds support for FDUS labels and a small amount of malformed-prefix tolerance
Includes focused parser tests in `tests/test_bdc.py`