### PR TITLE
Added discrete_quarters paramter to cashflow_statement

### DIFF
--- a/edgar/xbrl/statements.py
+++ b/edgar/xbrl/statements.py
@@ -3073,7 +3073,7 @@ class StitchedStatement:
 
     def __init__(self, xbrls, statement_type: str, max_periods: int = 8, standard: bool = True,
                  use_optimal_periods: bool = True, include_dimensions: bool = False,
-                 view: ViewType = None):
+                 view: ViewType = None, discrete_quarters: bool = False):
         """
         Initialize with XBRLS object and statement parameters.
 
@@ -3086,12 +3086,15 @@ class StitchedStatement:
             include_dimensions: Whether to include dimensional segment data (default: False for stitching)
             view: StatementView controlling dimensional filtering. If provided, overrides include_dimensions.
                   'detailed' → include_dimensions=True, 'standard'/'summary' → include_dimensions=False.
+            discrete_quarters: If True and statement is CashFlowStatement, convert
+                              YTD cumulative periods into discrete quarter values (default: False)
         """
         self.xbrls = xbrls
         self.statement_type = statement_type
         self.max_periods = max_periods
         self.standard = standard
         self.use_optimal_periods = use_optimal_periods
+        self.discrete_quarters = discrete_quarters
         # If view is provided, derive include_dimensions from it
         if view is not None:
             normalized = normalize_view(view)
@@ -3128,7 +3131,8 @@ class StitchedStatement:
                 self.max_periods,
                 self.standard,
                 self.use_optimal_periods,
-                self.include_dimensions
+                self.include_dimensions,
+                self.discrete_quarters
             )
         return self._statement_data
 
@@ -3248,7 +3252,8 @@ class StitchedStatements:
 
     def cashflow_statement(self, max_periods: int = 8, standard: bool = True,
                            use_optimal_periods: bool = True, show_date_range: bool = False,
-                           include_dimensions: bool = False, view: ViewType = None) -> Optional[StitchedStatement]:
+                           include_dimensions: bool = False, view: ViewType = None,
+                           discrete_quarters: bool = False) -> Optional[StitchedStatement]:
         """
         Get a stitched cash flow statement across multiple time periods.
 
@@ -3259,12 +3264,15 @@ class StitchedStatements:
             show_date_range: Whether to show full date ranges for duration periods
             include_dimensions: Whether to include dimensional segment data (default: False)
             view: StatementView controlling dimensional filtering. Overrides include_dimensions if provided.
+            discrete_quarters: If True, convert YTD cumulative periods into discrete
+                              quarter values (e.g. Q2 = 6-month YTD minus Q1). Default: False.
 
         Returns:
             StitchedStatement for the cash flow statement
         """
         statement = StitchedStatement(self.xbrls, 'CashFlowStatement', max_periods, standard,
-                                     use_optimal_periods, include_dimensions, view=view)
+                                     use_optimal_periods, include_dimensions, view=view,
+                                     discrete_quarters=discrete_quarters)
         if show_date_range:
             statement.show_date_range = show_date_range
         return statement

--- a/edgar/xbrl/stitching/core.py
+++ b/edgar/xbrl/stitching/core.py
@@ -101,7 +101,8 @@ class StatementStitcher:
         statements: List[Dict[str, Any]],
         period_type: Union[PeriodType, str] = PeriodType.RECENT_PERIODS,
         max_periods: Optional[int] = None,
-        standard: bool = True
+        standard: bool = True,
+        discrete_quarters: bool = False
     ) -> Dict[str, Any]:
         """
         Stitch multiple statements into a unified view.
@@ -111,6 +112,8 @@ class StatementStitcher:
             period_type: Type of period view to generate
             max_periods: Maximum number of periods to include
             standard: Whether to use standardized concept labels
+            discrete_quarters: If True and statement is CashFlowStatement, convert
+                              YTD cumulative periods into discrete quarter values
 
         Returns:
             Dictionary with stitched statement data
@@ -170,6 +173,13 @@ class StatementStitcher:
         # Merge known concept renames (Issue #711): handles cases where a company
         # switched to a completely different concept name across filing years.
         self._merge_known_concept_renames()
+
+        # Unaccumulate YTD cash flow periods into discrete quarters.
+        # SEC requires only YTD cash flows in 10-Q filings (Q2 = 6-month cumulative,
+        # Q3 = 9-month cumulative). This step derives the discrete quarter values
+        # by subtracting adjacent YTD periods.
+        if discrete_quarters and statement_type == 'CashFlowStatement':
+            self._unaccumulate_cashflow_ytd()
 
         # Format the stitched data
         return self._format_output_with_ordering(statements)
@@ -688,6 +698,174 @@ class StatementStitcher:
                     continue
                 self._merge_into(primary, secondary)
 
+    # ------------------------------------------------------------------
+    # YTD → discrete quarter unaccumulation (CashFlowStatement only)
+    # ------------------------------------------------------------------
+
+    def _unaccumulate_cashflow_ytd(self):
+        """Convert cumulative YTD cash flow periods into discrete quarters.
+
+        SEC 10-Q filings report cash flow on a year-to-date basis:
+          Q1: 3-month (discrete, ~90 days)
+          Q2: 6-month cumulative from fiscal year start (~180 days)
+          Q3: 9-month cumulative from fiscal year start (~270 days)
+          FY: 12-month annual (~365 days)
+
+        This method identifies YTD duration periods that share the same fiscal
+        year start date and derives discrete quarter values:
+          Q2_discrete = YTD_6M - Q1
+          Q3_discrete = YTD_9M - YTD_6M
+          Q4_discrete = FY - YTD_9M
+
+        The YTD periods are replaced in-place with the discrete quarter values.
+        """
+        from edgar.core import log
+
+        # 1. Parse duration periods into structured records
+        parsed = self._parse_duration_periods()
+        if not parsed:
+            return
+
+        # 2. Group by fiscal year start date so we can find YTD sequences
+        by_start = defaultdict(list)
+        for p in parsed:
+            by_start[p['start_date']].append(p)
+
+        # 3. For each fiscal year start, sort by duration and derive discrete quarters
+        for start_date, group in by_start.items():
+            # Sort shortest to longest (Q1 → Q2 YTD → Q3 YTD → FY)
+            group.sort(key=lambda p: p['duration_days'])
+
+            # Need at least 2 periods to unaccumulate
+            if len(group) < 2:
+                continue
+
+            # Work from longest to shortest, subtracting the next-shorter period
+            for i in range(len(group) - 1, 0, -1):
+                longer = group[i]
+                shorter = group[i - 1]
+
+                longer_pid = longer['period_id']
+                shorter_pid = shorter['period_id']
+
+                # Classify the longer period to determine what discrete quarter it yields
+                discrete_label = self._classify_discrete_quarter(longer, shorter)
+                if not discrete_label:
+                    continue
+
+                log.debug(
+                    f"Unaccumulating {discrete_label}: "
+                    f"{longer_pid} ({longer['duration_days']}d) - "
+                    f"{shorter_pid} ({shorter['duration_days']}d)"
+                )
+
+                # Subtract shorter from longer for every concept
+                self._subtract_periods(longer_pid, shorter_pid, discrete_label)
+
+    def _parse_duration_periods(self) -> List[Dict[str, Any]]:
+        """Parse duration period IDs into structured records with start/end dates and duration."""
+        parsed = []
+        for period_id in self.periods:
+            if not period_id.startswith('duration_'):
+                continue
+            parts = period_id.split('_')
+            if len(parts) < 3:
+                continue
+            try:
+                start_date = parse_date(parts[1])
+                end_date = parse_date(parts[2])
+                duration_days = (end_date - start_date).days
+                parsed.append({
+                    'period_id': period_id,
+                    'start_date': parts[1],  # keep as string for grouping
+                    'end_date': parts[2],
+                    'start_dt': start_date,
+                    'end_dt': end_date,
+                    'duration_days': duration_days,
+                })
+            except (ValueError, TypeError):
+                continue
+        return parsed
+
+    @staticmethod
+    def _classify_discrete_quarter(
+        longer: Dict[str, Any], shorter: Dict[str, Any]
+    ) -> Optional[str]:
+        """Determine what discrete quarter results from subtracting shorter from longer.
+
+        Uses duration ranges to classify:
+          Q1 ~80-100d, Q2 YTD ~170-200d, Q3 YTD ~250-290d, FY ~350-380d
+
+        Returns a label like 'Q2', 'Q3', 'Q4' or None if the pair doesn't
+        represent a valid YTD subtraction.
+        """
+        ld = longer['duration_days']
+        sd = shorter['duration_days']
+
+        # Q2 discrete: ~180d YTD minus ~90d Q1
+        if 170 <= ld <= 200 and 80 <= sd <= 100:
+            return 'Q2'
+        # Q3 discrete: ~270d YTD minus ~180d YTD
+        if 250 <= ld <= 290 and 170 <= sd <= 200:
+            return 'Q3'
+        # Q4 discrete: ~365d FY minus ~270d YTD
+        if 350 <= ld <= 380 and 250 <= sd <= 290:
+            return 'Q4'
+        return None
+
+    def _subtract_periods(
+        self,
+        longer_pid: str,
+        shorter_pid: str,
+        discrete_label: str,
+    ):
+        """Subtract shorter YTD values from longer YTD values in-place.
+
+        For each concept that has values in both the longer and shorter periods,
+        computes: discrete_value = longer_value - shorter_value.
+
+        The longer period entry is updated in-place with the discrete value.
+        The display label in self.period_dates is updated to reflect the discrete quarter.
+        """
+        from edgar.core import log
+
+        for concept_key in list(self.data.keys()):
+            longer_entry = self.data[concept_key].get(longer_pid)
+            shorter_entry = self.data[concept_key].get(shorter_pid)
+
+            if longer_entry is None:
+                continue
+
+            if shorter_entry is None:
+                # No shorter period data for this concept — keep the longer value as-is.
+                continue
+
+            longer_val = longer_entry.get('value')
+            shorter_val = shorter_entry.get('value')
+
+            if longer_val is None or shorter_val is None:
+                continue
+
+            # Skip non-numeric values
+            if not isinstance(longer_val, (int, float)) or not isinstance(shorter_val, (int, float)):
+                continue
+
+            discrete_val = longer_val - shorter_val
+
+            # Update the longer period entry in-place with the discrete value
+            self.data[concept_key][longer_pid] = {
+                'value': discrete_val,
+                'decimals': longer_entry.get('decimals', 0),
+            }
+
+        # Update the display label to indicate this is now a discrete quarter
+        old_label = self.period_dates.get(longer_pid, '')
+        if 'YTD' in old_label:
+            new_label = old_label.replace('YTD ', '')
+        else:
+            new_label = f"{discrete_label} {old_label}" if old_label else discrete_label
+        self.period_dates[longer_pid] = new_label
+
     def _format_output_with_ordering(self, statements: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Format the stitched data for rendering with intelligent ordering using virtual presentation tree.
@@ -776,7 +954,8 @@ def stitch_statements(
     standard: bool = True,
     use_optimal_periods: bool = True,
     include_dimensions: bool = False,
-    industry: Optional[str] = None
+    industry: Optional[str] = None,
+    discrete_quarters: bool = False
 ) -> Dict[str, Any]:
     """
     Stitch together statements from multiple XBRL objects.
@@ -791,6 +970,8 @@ def stitch_statements(
         include_dimensions: Whether to include dimensional segment data (default: False for stitching)
         industry: Optional Fama-French 48 industry code (e.g., "Banks").
                   If None, auto-detected from the first XBRL object's standardization cache.
+        discrete_quarters: If True and statement_type is CashFlowStatement, convert
+                          YTD cumulative periods into discrete quarter values (default: False)
 
     Returns:
         Stitched statement data
@@ -888,4 +1069,5 @@ def stitch_statements(
                 statements.append(statement)
 
     # Stitch the statements
-    return stitcher.stitch_statements(statements, period_type, max_periods, standard)
+    return stitcher.stitch_statements(statements, period_type, max_periods, standard,
+                                       discrete_quarters=discrete_quarters)

--- a/edgar/xbrl/stitching/xbrls.py
+++ b/edgar/xbrl/stitching/xbrls.py
@@ -143,7 +143,8 @@ class XBRLS:
                      max_periods: int = 8,
                      standard: bool = True,
                      use_optimal_periods: bool = True,
-                     include_dimensions: bool = False) -> Dict[str, Any]:
+                     include_dimensions: bool = False,
+                     discrete_quarters: bool = False) -> Dict[str, Any]:
         """
         Get a stitched statement of the specified type.
 
@@ -153,12 +154,14 @@ class XBRLS:
             standard: Whether to use standardized concept labels
             use_optimal_periods: Whether to use entity info to determine optimal periods
             include_dimensions: Whether to include dimensional segment data (default: False for stitching)
+            discrete_quarters: If True and statement_type is CashFlowStatement, convert
+                              YTD cumulative periods into discrete quarter values (default: False)
 
         Returns:
             Dictionary with stitched statement data
         """
         # Check cache first
-        cache_key = f"{statement_type}_{max_periods}_{standard}_{use_optimal_periods}_{include_dimensions}"
+        cache_key = f"{statement_type}_{max_periods}_{standard}_{use_optimal_periods}_{include_dimensions}_{discrete_quarters}"
         if cache_key in self._statement_cache:
             return self._statement_cache[cache_key]
 
@@ -170,7 +173,8 @@ class XBRLS:
             max_periods=max_periods,
             standard=standard,
             use_optimal_periods=use_optimal_periods,
-            include_dimensions=include_dimensions
+            include_dimensions=include_dimensions,
+            discrete_quarters=discrete_quarters
         )
 
         # Cache the result

--- a/tests/test_cashflow_unaccumulation.py
+++ b/tests/test_cashflow_unaccumulation.py
@@ -1,0 +1,410 @@
+"""
+Tests for CashFlowStatement YTD → discrete quarter unaccumulation.
+
+The SEC requires 10-Q cash flow statements to report year-to-date (YTD) cumulative
+values. The unaccumulation feature derives discrete quarter values by subtracting
+adjacent YTD periods:
+    Q2_discrete = YTD_6M - Q1
+    Q3_discrete = YTD_9M - YTD_6M
+    Q4_discrete = FY - YTD_9M
+"""
+
+from collections import defaultdict
+
+import pytest
+
+from edgar.xbrl.stitching.core import StatementStitcher
+
+
+def _make_cashflow_stitcher(periods, concepts):
+    """Build a StatementStitcher pre-loaded with synthetic cashflow data.
+
+    Args:
+        periods: list of period_id strings (ordered newest-first as the stitcher expects)
+        concepts: list of dicts with keys:
+            key: concept key string
+            values: dict of {period_id: numeric_value}
+            label: display label (optional)
+    """
+    stitcher = StatementStitcher()
+    stitcher.periods = list(periods)
+    stitcher.period_dates = {pid: pid for pid in periods}
+    stitcher.data = defaultdict(dict)
+    stitcher.concept_metadata = {}
+
+    for c in concepts:
+        key = c['key']
+        for pid, val in c['values'].items():
+            stitcher.data[key][pid] = {'value': val, 'decimals': -3}
+        stitcher.concept_metadata[key] = {
+            'level': 0,
+            'is_abstract': False,
+            'is_total': c.get('is_total', False),
+            'original_concept': key,
+            'latest_label': c.get('label', key),
+            'standard_concept': None,
+        }
+    return stitcher
+
+
+class TestUnaccumulateCashflowYTD:
+    """Unit tests for _unaccumulate_cashflow_ytd on StatementStitcher."""
+
+    def test_q2_derived_from_ytd6_minus_q1(self):
+        """Q2 discrete = 6-month YTD minus Q1 (3-month)."""
+        # Q1: 90 days, YTD_6M: 181 days (same fiscal year start)
+        q1_pid = 'duration_2024-01-01_2024-03-31'       # 90 days
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'     # 181 days
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[ytd6_pid, q1_pid],
+            concepts=[
+                {'key': 'us-gaap_OperatingCashFlow', 'values': {
+                    q1_pid: 100,
+                    ytd6_pid: 350,   # cumulative 6-month
+                }},
+                {'key': 'us-gaap_CapitalExpenditure', 'values': {
+                    q1_pid: -50,
+                    ytd6_pid: -120,  # cumulative 6-month
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # YTD_6M period should now hold Q2 discrete values
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd6_pid]['value'] == 250   # 350 - 100
+        assert stitcher.data['us-gaap_CapitalExpenditure'][ytd6_pid]['value'] == -70  # -120 - (-50)
+        # Q1 values should be unchanged
+        assert stitcher.data['us-gaap_OperatingCashFlow'][q1_pid]['value'] == 100
+        assert stitcher.data['us-gaap_CapitalExpenditure'][q1_pid]['value'] == -50
+
+    def test_q3_derived_from_ytd9_minus_ytd6(self):
+        """Q3 discrete = 9-month YTD minus 6-month YTD."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'       # 90 days
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'     # 181 days
+        ytd9_pid = 'duration_2024-01-01_2024-09-30'     # 273 days
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[ytd9_pid, ytd6_pid, q1_pid],
+            concepts=[
+                {'key': 'us-gaap_OperatingCashFlow', 'values': {
+                    q1_pid: 100,
+                    ytd6_pid: 350,
+                    ytd9_pid: 600,   # cumulative 9-month
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # Q3 discrete: 600 - 350 = 250
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd9_pid]['value'] == 250
+        # Q2 discrete: 350 - 100 = 250
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd6_pid]['value'] == 250
+        # Q1 unchanged
+        assert stitcher.data['us-gaap_OperatingCashFlow'][q1_pid]['value'] == 100
+
+    def test_q4_derived_from_fy_minus_ytd9(self):
+        """Q4 discrete = FY (annual) minus 9-month YTD."""
+        ytd9_pid = 'duration_2024-01-01_2024-09-30'     # 273 days
+        fy_pid = 'duration_2024-01-01_2024-12-31'       # 365 days
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[fy_pid, ytd9_pid],
+            concepts=[
+                {'key': 'us-gaap_OperatingCashFlow', 'values': {
+                    ytd9_pid: 600,
+                    fy_pid: 900,     # full year
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # Q4 discrete: 900 - 600 = 300
+        assert stitcher.data['us-gaap_OperatingCashFlow'][fy_pid]['value'] == 300
+        # YTD9 unchanged (no shorter YTD to subtract from it in this set)
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd9_pid]['value'] == 600
+
+    def test_full_year_all_four_quarters(self):
+        """Full chain: Q1 + Q2 YTD + Q3 YTD + FY → four discrete quarters."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'       # 90 days
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'     # 181 days
+        ytd9_pid = 'duration_2024-01-01_2024-09-30'     # 273 days
+        fy_pid = 'duration_2024-01-01_2024-12-31'       # 365 days
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[fy_pid, ytd9_pid, ytd6_pid, q1_pid],
+            concepts=[
+                {'key': 'us-gaap_OperatingCashFlow', 'values': {
+                    q1_pid: 100,     # Q1 discrete
+                    ytd6_pid: 350,   # Q1 + Q2
+                    ytd9_pid: 600,   # Q1 + Q2 + Q3
+                    fy_pid: 1000,    # Q1 + Q2 + Q3 + Q4
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        assert stitcher.data['us-gaap_OperatingCashFlow'][q1_pid]['value'] == 100   # unchanged
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd6_pid]['value'] == 250  # 350-100
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd9_pid]['value'] == 250  # 600-350
+        assert stitcher.data['us-gaap_OperatingCashFlow'][fy_pid]['value'] == 400    # 1000-600
+
+    def test_concept_missing_in_shorter_period_kept_as_is(self):
+        """If a concept has no value in the shorter period, the longer value is kept unchanged."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[ytd6_pid, q1_pid],
+            concepts=[
+                # This concept only appears in YTD_6M, not Q1
+                {'key': 'us-gaap_SpecialItem', 'values': {
+                    ytd6_pid: 42,
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # Should be kept as-is since there's nothing to subtract
+        assert stitcher.data['us-gaap_SpecialItem'][ytd6_pid]['value'] == 42
+
+    def test_different_fiscal_year_starts_handled_independently(self):
+        """Periods from different fiscal years don't interfere with each other."""
+        # FY2023 Q1 and YTD_6M
+        fy23_q1 = 'duration_2023-01-01_2023-03-31'
+        fy23_ytd6 = 'duration_2023-01-01_2023-06-30'
+        # FY2024 Q1 and YTD_6M
+        fy24_q1 = 'duration_2024-01-01_2024-03-31'
+        fy24_ytd6 = 'duration_2024-01-01_2024-06-30'
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[fy24_ytd6, fy24_q1, fy23_ytd6, fy23_q1],
+            concepts=[
+                {'key': 'us-gaap_Revenue', 'values': {
+                    fy23_q1: 200,
+                    fy23_ytd6: 500,
+                    fy24_q1: 300,
+                    fy24_ytd6: 700,
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # FY2023: Q2 = 500 - 200 = 300
+        assert stitcher.data['us-gaap_Revenue'][fy23_ytd6]['value'] == 300
+        assert stitcher.data['us-gaap_Revenue'][fy23_q1]['value'] == 200
+        # FY2024: Q2 = 700 - 300 = 400
+        assert stitcher.data['us-gaap_Revenue'][fy24_ytd6]['value'] == 400
+        assert stitcher.data['us-gaap_Revenue'][fy24_q1]['value'] == 300
+
+    def test_period_label_ytd_stripped(self):
+        """Display labels should have 'YTD' removed after unaccumulation."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[ytd6_pid, q1_pid],
+            concepts=[
+                {'key': 'us-gaap_X', 'values': {q1_pid: 10, ytd6_pid: 30}},
+            ],
+        )
+        stitcher.period_dates[ytd6_pid] = 'Q2 YTD Jun 30, 2024'
+        stitcher.period_dates[q1_pid] = 'Q1 Mar 31, 2024'
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        assert stitcher.period_dates[ytd6_pid] == 'Q2 Jun 30, 2024'
+        # Q1 label untouched
+        assert stitcher.period_dates[q1_pid] == 'Q1 Mar 31, 2024'
+
+    def test_instant_periods_ignored(self):
+        """Instant periods (balance sheet style) should not be touched."""
+        instant_pid = 'instant_2024-06-30'
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[instant_pid, q1_pid],
+            concepts=[
+                {'key': 'us-gaap_Cash', 'values': {
+                    instant_pid: 5000,
+                    q1_pid: 100,
+                }},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        # Instant value untouched
+        assert stitcher.data['us-gaap_Cash'][instant_pid]['value'] == 5000
+
+    def test_single_period_no_op(self):
+        """With only one duration period, nothing should change."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+
+        stitcher = _make_cashflow_stitcher(
+            periods=[q1_pid],
+            concepts=[
+                {'key': 'us-gaap_X', 'values': {q1_pid: 100}},
+            ],
+        )
+
+        stitcher._unaccumulate_cashflow_ytd()
+
+        assert stitcher.data['us-gaap_X'][q1_pid]['value'] == 100
+
+
+class TestDiscreteQuartersFlag:
+    """Test that discrete_quarters=False (default) does NOT unaccumulate."""
+
+    def test_default_false_preserves_ytd_values(self):
+        """stitch_statements with default discrete_quarters=False should leave YTD values intact."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'
+
+        statements = [{
+            'statement_type': 'CashFlowStatement',
+            'periods': {
+                q1_pid: {'label': 'Q1 Mar 31, 2024'},
+                ytd6_pid: {'label': 'Q2 YTD Jun 30, 2024'},
+            },
+            'data': [{
+                'concept': 'us-gaap_OperatingCashFlow',
+                'label': 'Operating Cash Flow',
+                'level': 0,
+                'is_abstract': False,
+                'is_total': True,
+                'values': {q1_pid: 100, ytd6_pid: 350},
+                'decimals': {q1_pid: 0, ytd6_pid: 0},
+            }],
+        }]
+
+        stitcher = StatementStitcher()
+        result = stitcher.stitch_statements(
+            statements,
+            period_type=StatementStitcher.PeriodType.ALL_PERIODS,
+            max_periods=10,
+            standard=False,
+            discrete_quarters=False,  # default
+        )
+
+        # Find the operating cash flow row
+        row = next(r for r in result['statement_data']
+                   if r['concept'] == 'us-gaap_OperatingCashFlow')
+
+        # YTD value should be preserved (NOT subtracted)
+        assert row['values'][ytd6_pid] == 350
+        assert row['values'][q1_pid] == 100
+
+    def test_true_unaccumulates_ytd_values(self):
+        """stitch_statements with discrete_quarters=True should convert YTD to discrete."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'
+
+        statements = [{
+            'statement_type': 'CashFlowStatement',
+            'periods': {
+                q1_pid: {'label': 'Q1 Mar 31, 2024'},
+                ytd6_pid: {'label': 'Q2 YTD Jun 30, 2024'},
+            },
+            'data': [{
+                'concept': 'us-gaap_OperatingCashFlow',
+                'label': 'Operating Cash Flow',
+                'level': 0,
+                'is_abstract': False,
+                'is_total': True,
+                'values': {q1_pid: 100, ytd6_pid: 350},
+                'decimals': {q1_pid: 0, ytd6_pid: 0},
+            }],
+        }]
+
+        stitcher = StatementStitcher()
+        result = stitcher.stitch_statements(
+            statements,
+            period_type=StatementStitcher.PeriodType.ALL_PERIODS,
+            max_periods=10,
+            standard=False,
+            discrete_quarters=True,
+        )
+
+        row = next(r for r in result['statement_data']
+                   if r['concept'] == 'us-gaap_OperatingCashFlow')
+
+        # YTD should now be Q2 discrete: 350 - 100 = 250
+        assert row['values'][ytd6_pid] == 250
+        assert row['values'][q1_pid] == 100
+
+    def test_flag_ignored_for_non_cashflow(self):
+        """discrete_quarters=True on IncomeStatement should have no effect."""
+        q1_pid = 'duration_2024-01-01_2024-03-31'
+        ytd6_pid = 'duration_2024-01-01_2024-06-30'
+
+        statements = [{
+            'statement_type': 'IncomeStatement',
+            'periods': {
+                q1_pid: {'label': 'Q1 Mar 31, 2024'},
+                ytd6_pid: {'label': 'Q2 YTD Jun 30, 2024'},
+            },
+            'data': [{
+                'concept': 'us-gaap_Revenue',
+                'label': 'Revenue',
+                'level': 0,
+                'is_abstract': False,
+                'is_total': False,
+                'values': {q1_pid: 100, ytd6_pid: 350},
+                'decimals': {q1_pid: 0, ytd6_pid: 0},
+            }],
+        }]
+
+        stitcher = StatementStitcher()
+        result = stitcher.stitch_statements(
+            statements,
+            period_type=StatementStitcher.PeriodType.ALL_PERIODS,
+            max_periods=10,
+            standard=False,
+            discrete_quarters=True,  # should be ignored
+        )
+
+        row = next(r for r in result['statement_data']
+                   if r['concept'] == 'us-gaap_Revenue')
+
+        # Values should be unchanged — not a CashFlowStatement
+        assert row['values'][ytd6_pid] == 350
+        assert row['values'][q1_pid] == 100
+
+
+class TestClassifyDiscreteQuarter:
+    """Unit tests for the static _classify_discrete_quarter method."""
+
+    def test_q2_classification(self):
+        longer = {'duration_days': 181}
+        shorter = {'duration_days': 90}
+        assert StatementStitcher._classify_discrete_quarter(longer, shorter) == 'Q2'
+
+    def test_q3_classification(self):
+        longer = {'duration_days': 273}
+        shorter = {'duration_days': 181}
+        assert StatementStitcher._classify_discrete_quarter(longer, shorter) == 'Q3'
+
+    def test_q4_classification(self):
+        longer = {'duration_days': 365}
+        shorter = {'duration_days': 273}
+        assert StatementStitcher._classify_discrete_quarter(longer, shorter) == 'Q4'
+
+    def test_unrecognized_pair_returns_none(self):
+        # Two quarterly periods — doesn't match any pattern
+        longer = {'duration_days': 91}
+        shorter = {'duration_days': 90}
+        assert StatementStitcher._classify_discrete_quarter(longer, shorter) is None
+
+    def test_non_standard_fiscal_year_q2(self):
+        """Companies with non-calendar fiscal years (e.g. Apple ending Sep)."""
+        # Apple FY: Oct 1 - Sep 30. Q1 = Oct-Dec (92d), Q2 YTD = Oct-Mar (182d)
+        longer = {'duration_days': 182}
+        shorter = {'duration_days': 92}
+        assert StatementStitcher._classify_discrete_quarter(longer, shorter) == 'Q2'


### PR DESCRIPTION
Resolves #785 

Added parameter to have cashlow unaccumulate via parameter (defaults to False)

```python
from edgar import Company
 from edgar.xbrl import XBRLS

  company = Company("AAPL")
  filings = company.get_filings(form="10-Q").head(3)
  xbrls = XBRLS.from_filings(filings)
 cf_discrete = xbrls.statements.cashflow_statement(discrete_quarters=True)
```
