### PR TITLE
fix: prevent duplicate revenue rows from additional income statement

### DIFF
--- a/edgar/entity/enhanced_statement.py
+++ b/edgar/entity/enhanced_statement.py
@@ -2074,13 +2074,42 @@ class EnhancedStatementBuilder:
         # This preserves valid top-level concepts like weighted-average shares
         # that may be rooted outside IncomeStatementAbstract in learned trees.
         if items:
-            existing_root_concepts = {item.concept for item in items}
+            def _collect_concepts(item: MultiPeriodItem, seen: set):
+                if item.concept:
+                    seen.add(item.concept)
+                for child in item.children:
+                    _collect_concepts(child, seen)
+
+            # Track all concepts already represented in the promoted tree,
+            # not just top-level roots. This prevents duplicate branches like
+            # RevenuesAbstract -> Revenues from being re-added as extra roots.
+            existing_concepts = set()
+            for existing_item in items:
+                _collect_concepts(existing_item, existing_concepts)
+
+            def _prune_duplicate_subtree(item: MultiPeriodItem) -> Optional[MultiPeriodItem]:
+                pruned_children = []
+                for child in item.children:
+                    pruned_child = _prune_duplicate_subtree(child)
+                    if pruned_child:
+                        pruned_children.append(pruned_child)
+                item.children = pruned_children
+
+                if item.concept in existing_concepts or item.concept in promoted_added:
+                    # Keep abstract containers only when they still expose
+                    # unique descendants after duplicate pruning.
+                    if item.is_abstract and item.children:
+                        return item
+                    return None
+
+                return item
+
             for root_concept in virtual_tree.get('roots', []):
                 if root_concept == abstract_root:
                     continue
                 if root_concept in promoted_added:
                     continue
-                if root_concept in existing_root_concepts:
+                if root_concept in existing_concepts:
                     continue
 
                 root_item = self._build_canonical_item(
@@ -2092,8 +2121,11 @@ class EnhancedStatementBuilder:
                     statement_type=statement_type
                 )
                 if root_item:
+                    root_item = _prune_duplicate_subtree(root_item)
+
+                if root_item:
                     items.append(root_item)
-                    existing_root_concepts.add(root_concept)
+                    _collect_concepts(root_item, existing_concepts)
 
         # If no abstract root, just build normally
         if not items:

--- a/tests/issues/regression/test_issue_income_statement_revenue_duplicate_root.py
+++ b/tests/issues/regression/test_issue_income_statement_revenue_duplicate_root.py
@@ -1,0 +1,79 @@
+"""
+Regression test: prevent duplicated revenue rows from additional income statement roots.
+
+When revenue is promoted to the top-level income statement, some learned virtual trees also
+contain RevenuesAbstract as an additional root. That extra root must not re-introduce
+Revenues as a second row.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from edgar.entity.enhanced_statement import EnhancedStatementBuilder
+
+
+def _collect_concepts(item, concepts):
+    """Recursively collect concept names from a statement subtree."""
+    concepts.append(item.concept)
+    for child in item.children:
+        _collect_concepts(child, concepts)
+
+
+@pytest.mark.fast
+def test_promoted_revenue_not_duplicated_with_additional_revenue_root():
+    """Revenue should appear once even if RevenuesAbstract is also a root."""
+    builder = EnhancedStatementBuilder()
+
+    virtual_tree = {
+        "nodes": {
+            "IncomeStatementAbstract": {
+                "concept": "IncomeStatementAbstract",
+                "label": "Income Statement [Abstract]",
+                "children": [],
+                "is_abstract": True,
+                "is_total": False,
+                "occurrence_rate": 1.0,
+            },
+            "RevenuesAbstract": {
+                "concept": "RevenuesAbstract",
+                "label": "Revenues:",
+                "children": ["Revenues"],
+                "is_abstract": True,
+                "is_total": False,
+                "occurrence_rate": 0.35,
+            },
+            "Revenues": {
+                "concept": "Revenues",
+                "label": "Revenues",
+                "children": [],
+                "is_abstract": False,
+                "is_total": False,
+                "occurrence_rate": 0.35,
+            },
+        },
+        "roots": ["IncomeStatementAbstract", "RevenuesAbstract"],
+    }
+
+    periods = ["FY 2025", "FY 2024"]
+    period_maps = {
+        "FY 2025": {
+            "Revenues": SimpleNamespace(numeric_value=100.0, label="Revenues"),
+        },
+        "FY 2024": {
+            "Revenues": SimpleNamespace(numeric_value=95.0, label="Revenues"),
+        },
+    }
+
+    items = builder._build_with_promoted_concepts(
+        virtual_tree=virtual_tree,
+        period_maps=period_maps,
+        periods=periods,
+        statement_type="IncomeStatement",
+    )
+
+    concepts = []
+    for item in items:
+        _collect_concepts(item, concepts)
+
+    assert concepts.count("Revenues") == 1


### PR DESCRIPTION
fixes #789 

When revenue is promoted to the top-level income statement, some learned virtual trees also contain RevenuesAbstract as an additional root. The previous guard only checked top-level root concepts for duplicates, missing nested concepts that were already promoted (e.g., Revenues under IncomeStatementAbstract).

Changes:

- Replace shallow existing_root_concepts check with deep recursive _collect_concepts that tracks all concepts already in the built tree

- Add _prune_duplicate_subtree to recursively remove children that duplicate promoted or existing concepts, preserving abstract containers only when they still expose unique descendants

- Update tracking after appending new roots to prevent cascading duplicates

- Add regression test that reproduces the exact scenario (RevenuesAbstract as additional root with Revenues child)