### PR TITLE
Fix CUSIP extraction for nested <issuerCusipNumber> in Schedule 13 (#802)

### DIFF
--- a/edgar/beneficial_ownership/schedule13.py
+++ b/edgar/beneficial_ownership/schedule13.py
@@ -188,7 +188,13 @@ class Schedule13D:
                     zipcode=child_text(address_el, 'zipCode')
                 )
 
-            cusip = child_text(issuer_el, 'issuerCUSIP') or ''
+            # Check for the legacy flat tag first
+            cusip = child_text(issuer_el, 'issuerCUSIP')
+            # If missing, check for the new nested SEC schema
+            if not cusip:
+                cusip = child_text(issuer_el, 'issuerCusipNumber')
+            cusip = cusip or ''
+
             result['issuer_info'] = IssuerInfo(
                 cik=child_text(issuer_el, 'issuerCIK') or '',
                 name=child_text(issuer_el, 'issuerName') or '',
@@ -601,7 +607,13 @@ class Schedule13G:
                     zipcode=child_text(address_el, 'zipCode')
                 )
 
-            cusip = child_text(issuer_el, 'issuerCusip') or ''
+            # Check for the legacy flat tag first
+            cusip = child_text(issuer_el, 'issuerCusip')
+            # If missing, check for the new nested SEC schema
+            if not cusip:
+                cusip = child_text(issuer_el, 'issuerCusipNumber')
+            cusip = cusip or ''
+
             result['issuer_info'] = IssuerInfo(
                 cik=child_text(issuer_el, 'issuerCik') or '',
                 name=child_text(issuer_el, 'issuerName') or '',


### PR DESCRIPTION
Description
Resolves the issue where CUSIPs were missing from newer Schedule 13 filings due to SEC XML schema changes. Fixes #802

Changes Made
Updated Schedule13D.parse_xml and Schedule13G.parse_xml. The parsers will now check for their respective legacy tags first (issuerCUSIP / issuerCusip). If missing, they will recursively search for the new <issuerCusipNumber> tag.