### PR TITLE
fix: alias Schedule13D.event_date and Schedule13G.date_of_event (#804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schedule 13D/13G event-date attribute name mismatch** — `Schedule13D` exposed the triggering-event date as `date_of_event` while `Schedule13G` exposed it as `event_date`, breaking duck-typing across a mixed list of 13D/13G filings and forcing callers to use `getattr` / `hasattr`. Both classes now accept either name; the underlying attribute is unchanged, so existing code keeps working. ([#804](https://github.com/dgunning/edgartools/issues/804))
+
 ## [5.31.0] - 2026-05-08
 
 ### Added

--- a/edgar/beneficial_ownership/schedule13.py
+++ b/edgar/beneficial_ownership/schedule13.py
@@ -367,6 +367,11 @@ class Schedule13D:
         return self._filing.filing_date
 
     @property
+    def event_date(self) -> str:
+        """Alias for ``date_of_event`` for API consistency with ``Schedule13G``."""
+        return self.date_of_event
+
+    @property
     def total_shares(self) -> int:
         """
         Total beneficial ownership across all reporting persons.
@@ -798,6 +803,11 @@ class Schedule13G:
     def filing_date(self) -> date:
         """Get the filing date"""
         return self._filing.filing_date
+
+    @property
+    def date_of_event(self) -> str:
+        """Alias for ``event_date`` for API consistency with ``Schedule13D``."""
+        return self.event_date
 
     @property
     def total_shares(self) -> int:

--- a/tests/issues/regression/test_issue_804_schedule13_event_date_alias.py
+++ b/tests/issues/regression/test_issue_804_schedule13_event_date_alias.py
@@ -1,0 +1,63 @@
+"""Regression test for GitHub issue #804.
+
+Schedule13D exposed the triggering-event date as ``date_of_event`` while
+Schedule13G exposed it as ``event_date``, breaking duck-typing across a
+mixed list of 13D/13G filings. Both classes now accept either name as a
+read-only alias for the underlying attribute.
+"""
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from edgar.beneficial_ownership import Schedule13D, Schedule13G
+
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "beneficial_ownership"
+SCHEDULE_13D_XML_PATH = TEST_DATA_DIR / "schedule13d.xml"
+SCHEDULE_13G_XML_PATH = TEST_DATA_DIR / "schedule13g.xml"
+
+
+def _load_schedule_13d() -> Schedule13D:
+    filing = Mock()
+    filing.form = "SCHEDULE 13D"
+    filing.filing_date = date(2024, 12, 31)
+    filing.xml = Mock(return_value=SCHEDULE_13D_XML_PATH.read_text())
+    return Schedule13D.from_filing(filing)
+
+
+def _load_schedule_13g() -> Schedule13G:
+    filing = Mock()
+    filing.form = "SCHEDULE 13G"
+    filing.filing_date = date(2025, 11, 26)
+    filing.xml = Mock(return_value=SCHEDULE_13G_XML_PATH.read_text())
+    return Schedule13G.from_filing(filing)
+
+
+@pytest.mark.fast
+def test_schedule13d_exposes_event_date_alias():
+    """Schedule13D.event_date must mirror the parsed date_of_event."""
+    schedule = _load_schedule_13d()
+    assert schedule.date_of_event == "12/31/2024"
+    assert schedule.event_date == schedule.date_of_event
+
+
+@pytest.mark.fast
+def test_schedule13g_exposes_date_of_event_alias():
+    """Schedule13G.date_of_event must mirror the parsed event_date."""
+    schedule = _load_schedule_13g()
+    assert schedule.event_date == "11/19/2025"
+    assert schedule.date_of_event == schedule.event_date
+
+
+@pytest.mark.fast
+def test_event_date_works_across_mixed_schedule13_list():
+    """A mixed iterable of 13D/13G must answer to a single attribute name."""
+    schedules = [_load_schedule_13d(), _load_schedule_13g()]
+    expected = ["12/31/2024", "11/19/2025"]
+
+    # Both names work uniformly across the heterogeneous list.
+    assert [s.event_date for s in schedules] == expected
+    assert [s.date_of_event for s in schedules] == expected


### PR DESCRIPTION
Fixes #804.

`Schedule13D` exposed the triggering-event date as `date_of_event` and `Schedule13G` exposed it as `event_date`, so iterating a mixed list of the two crashed on whichever attribute you hadn't picked. Both classes now accept either name. The real attributes are unchanged; the other name is a read-only property that returns the same value, so existing code on either side keeps working.

The reporter suggested aliasing only `Schedule13D.event_date → date_of_event`. I went both ways because the names map to genuinely different XML elements (`<dateOfEvent>` on 13D, `<eventDateRequiresFilingThisStatement>` on 13G), and a one-way alias would still force existing 13G users to migrate. Cost is one attribute lookup per access.

### Changes

- `edgar/beneficial_ownership/schedule13.py` — `event_date` property on `Schedule13D`, `date_of_event` property on `Schedule13G`. 10 lines.
- `tests/issues/regression/test_issue_804_schedule13_event_date_alias.py` — three fast tests, including the mixed-list iteration from the issue body.
- `CHANGELOG.md` — entry under `[Unreleased]`.

### Test plan

- [x] `pytest tests/issues/regression/test_issue_804_schedule13_event_date_alias.py tests/test_beneficial_ownership.py` — 29 passed (3 new, 26 existing)
- [x] `ruff check edgar/beneficial_ownership/schedule13.py` — clean for added code. One pre-existing F841 on line 730 (`item10_not_applicable`) is unchanged on `main` and out of scope.
- [x] Manual check: `Schedule13D(...).event_date == .date_of_event` and `Schedule13G(...).date_of_event == .event_date` both return the parsed value.
