### PR TITLE
fix(documents): drop redundant per-event size accumulator in StreamingParser

### DIFF
--- a/edgar/documents/utils/streaming.py
+++ b/edgar/documents/utils/streaming.py
@@ -59,7 +59,6 @@ class StreamingParser:
         self.in_table = False
         self._table_depth = 0
         self.table_buffer = []
-        self.bytes_processed = 0
 
     def parse(self, html: str) -> "Document":
         """
@@ -80,10 +79,21 @@ class StreamingParser:
         # Store original HTML BEFORE parsing (needed for TOC-based section detection)
         original_html = html
 
+        # Size-check the input once, against the actual byte length.
+        # The previous per-event accumulator re-serialized each element
+        # on its `end` event via etree.tostring(elem), which double-
+        # counted nested subtrees and grew with table size (O(n²)).
+        # HTMLParser._parse already performs this check for the
+        # streaming entry point; this guard preserves the invariant
+        # for callers that invoke StreamingParser directly.
+        encoded = html.encode('utf-8')
+        if len(encoded) > self.config.max_document_size:
+            raise DocumentTooLargeError(len(encoded), self.config.max_document_size)
+
         try:
             # Create streaming parser
             parser = etree.iterparse(
-                io.BytesIO(html.encode('utf-8')),
+                io.BytesIO(encoded),
                 events=('start', 'end'),
                 html=True,
                 recover=True,
@@ -93,13 +103,6 @@ class StreamingParser:
             # Process events
             for event, elem in parser:
                 self._process_event(event, elem)
-
-                # Check size limit (only on end events outside tables to
-                # avoid repeatedly serializing growing table subtrees)
-                if event == 'end' and self._table_depth == 0:
-                    self.bytes_processed += len(etree.tostring(elem, encoding='unicode', method='html'))
-                if self.bytes_processed > self.config.max_document_size:
-                    raise DocumentTooLargeError(self.bytes_processed, self.config.max_document_size)
 
                 # Flush buffer if needed
                 if len(self.node_buffer) >= self.MAX_NODE_BUFFER:

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -393,6 +393,51 @@ class TestPerformance:
         # The streaming parser currently has issues with iterparse
         # clearing elements before text can be extracted
 
+    def test_streaming_parser_size_check_uses_input_bytes(self):
+        """``StreamingParser.parse`` must size-check against input bytes.
+
+        Regression pin. Before commit 6b702bd9 the streaming loop
+        accumulated ``len(etree.tostring(elem))`` on every iteration,
+        which re-serialized nested subtrees and could falsely reject
+        documents whose actual size was within the configured limit.
+        That commit deferred the accounting around table subtrees but
+        kept the per-event accumulator otherwise — leaving the size
+        check coupled to lxml internals (sibling-pruning order, tail
+        attribution) instead of the input.
+
+        This test calls ``StreamingParser`` directly to bypass the
+        upstream ``HTMLParser._parse`` size guard and pins the
+        invariant: parsing succeeds when actual input size is within
+        ``max_document_size`` and raises ``DocumentTooLargeError``
+        only when it isn't, regardless of how the document is nested.
+        """
+        from edgar.documents.utils.streaming import StreamingParser
+
+        # Deeply-nested inline soup mirrors SEC inline-XBRL filings.
+        inner = "<p><b><i><u><em><strong>x</strong></em></u></i></b></p>"
+        rows = "".join(inner for _ in range(2000))
+        html = f"<html><body>{rows}</body></html>"
+        actual_size = len(html.encode("utf-8"))
+
+        # Cap just above actual size — accounting that reports more
+        # than actual bytes would falsely raise here.
+        config = ParserConfig(
+            streaming_threshold=actual_size // 2,
+            max_document_size=actual_size + 1024,
+        )
+        parser = StreamingParser(config, strategies={})
+        doc = parser.parse(html)
+        assert doc is not None
+
+        # Cap below actual size must still raise.
+        too_small = ParserConfig(
+            streaming_threshold=actual_size // 2,
+            max_document_size=actual_size // 2,
+        )
+        parser_small = StreamingParser(too_small, strategies={})
+        with pytest.raises(DocumentTooLargeError):
+            parser_small.parse(html)
+
 
 class TestXBRLExtraction:
     """Test XBRL extraction functionality."""


### PR DESCRIPTION
## Problem

`StreamingParser.parse` accumulates the document size by re-serializing each element on its `iterparse` `end` event:

```python
self.bytes_processed += len(etree.tostring(elem, encoding='unicode', method='html'))
```

Because lxml's `tostring` walks the element's full subtree and `iterparse` fires `end` for every closing tag, nested elements are counted multiple times. Commit 6b702bd9 ("Fix streaming parser destroying table children before processing") explicitly identified this as O(n²) and worked around it for tables (`_table_depth == 0` guard). The accumulator outside tables was kept.

The accumulator is also redundant. `HTMLParser._parse` already validates `len(html.encode('utf-8'))` against `max_document_size` *before* dispatching to streaming mode (`edgar/documents/parser.py:120`). The only callers that reach the streaming-side check are direct `StreamingParser` users — for whom a single check at the top of `parse()` is simpler and correct.

## Change

- Drop `self.bytes_processed` and the per-event accumulator block in the iteration loop.
- Compute `encoded = html.encode('utf-8')` once at the top of `parse()`, raise `DocumentTooLargeError` if it exceeds `max_document_size`, and reuse `encoded` for `etree.iterparse` (avoids encoding twice).
- Add a regression test (`test_streaming_parser_size_check_uses_input_bytes`) that calls `StreamingParser` directly to bypass the routing-layer pre-check, and pins both directions: under-limit input parses, over-limit input raises `DocumentTooLargeError`.

## Behavior

No observable behavior change for any reachable code path:

- `parse_html()` callers — unchanged. The routing-layer size check fires first, exactly as before.
- Direct `StreamingParser` callers — same `DocumentTooLargeError` semantics, now keyed off actual input bytes instead of an lxml-coupled approximation that varied with sibling-pruning order and tail attribution.

The patch is purely defensive cleanup: the in-loop accounting was already partially neutralized by the table-skip workaround, and the residual coupling to lxml internals made it brittle to future refactors of the cleanup logic. Removing it eliminates a class of regressions before they happen.

## Tests

- `tests/test_html_parser.py::TestPerformance` — 3 passed (including the new test).
- `tests/test_html_parser.py` + `tests/test_html_parser_regressions.py` full unit run — 36 passed, 3 skipped (env-dependent).
- `tests/test_html_parser_integration.py` — same set of pre-existing failures as on `main` (live-SEC tests requiring `EDGAR_IDENTITY`); not affected by the patch.
