### PR TITLE
fix: display source section index in SearchResults panels (#765)

### DIFF
--- a/edgar/search/textsearch.py
+++ b/edgar/search/textsearch.py
@@ -183,13 +183,15 @@ class SearchResults:
         title = f"Searching for '{self.query}'"
         subtitle = f"{len(self)} result(s)" if not self.empty else "No results"
         sorted_sections = sorted(self.sections, key=lambda s: s.score, reverse=True)
-        for i, doc_section in enumerate(sorted_sections):
+        for doc_section in sorted_sections:
             if doc_section.doc.startswith("|  |") and self._show_tables:
                 table = convert_table(doc_section.doc)
                 section = table
             else:
                 section = Markdown(doc_section.doc + "\n\n---")
-            renderables.append(Panel(section, box=box.ROUNDED, title=f"{i}"))
+            # Title is the section index in the source corpus, not the display rank.
+            # Otherwise BM25 (sorts by score) and regex (no score) disagree on what "0" means.
+            renderables.append(Panel(section, box=box.ROUNDED, title=f"{doc_section.loc}"))
         return Panel(
             Group(*renderables), title=title, subtitle=subtitle, box=box.SIMPLE
         )

--- a/tests/issues/regression/test_issue_765_search_loc_displayed.py
+++ b/tests/issues/regression/test_issue_765_search_loc_displayed.py
@@ -1,0 +1,54 @@
+"""Regression test for #765 — SearchResults rendered panel titles must be
+the source section index (DocSection.loc), not the score-sorted display rank.
+
+Previously BM25 path sorted by score so `panel title "0"` meant
+"highest-scoring section" while regex path (no score) showed "0" for the
+first match in document order — same query, different meaning per method.
+"""
+
+import pytest
+
+from edgar.search.textsearch import DocSection, SearchResults
+
+
+def _titles(result: SearchResults) -> list[str]:
+    """Extract panel titles in the order __rich__ renders them."""
+    rendered = result.__rich__()
+    group = rendered.renderable  # outer Panel wraps a Group of Panels
+    return [str(child.title) for child in group.renderables]
+
+
+@pytest.mark.fast
+def test_panel_titles_use_source_loc_not_display_rank():
+    sections = [
+        DocSection(loc=3, doc="alpha", score=0.5),
+        DocSection(loc=11, doc="beta", score=2.0),
+        DocSection(loc=17, doc="gamma", score=1.0),
+    ]
+    result = SearchResults(query="x", sections=sections)
+    titles = _titles(result)
+    # Sorted by score descending: beta (2.0), gamma (1.0), alpha (0.5)
+    # But the DISPLAYED title must be the source loc, not the rank.
+    assert titles == ["11", "17", "3"]
+
+
+@pytest.mark.fast
+def test_panel_titles_consistent_when_scores_all_zero():
+    """Regex search returns DocSection with score=0.0 — original order kept,
+    titles must still be the source loc not the enumeration index."""
+    sections = [
+        DocSection(loc=2, doc="alpha"),
+        DocSection(loc=8, doc="beta"),
+        DocSection(loc=14, doc="gamma"),
+    ]
+    result = SearchResults(query="x", sections=sections)
+    titles = _titles(result)
+    assert titles == ["2", "8", "14"]
+
+
+@pytest.mark.fast
+def test_empty_results_renders_without_panels():
+    result = SearchResults(query="x", sections=[])
+    rendered = result.__rich__()
+    group = rendered.renderable
+    assert list(group.renderables) == []


### PR DESCRIPTION
## Summary

Addresses the bug component of #765 — BaraVaq noted *"when not using regex location indexes are wrong"* with screenshots showing the same query returning different content at "location 0" between BM25 and regex paths. Root cause is in the panel-title rendering, not the search indexes themselves.

This PR fixes the display bug only. The broader enhancement (highlighting matched terms in the rendered output) remains open as the P3 feature you classified as \`edgartools-gnzy\`.

## Root cause

\`SearchResults.__rich__\` (\`edgar/search/textsearch.py:192\`) titled each result panel with the enumeration index of the sorted display:

\`\`\`python
sorted_sections = sorted(self.sections, key=lambda s: s.score, reverse=True)
for i, doc_section in enumerate(sorted_sections):
    ...
    renderables.append(Panel(section, box=box.ROUNDED, title=f\"{i}\"))
\`\`\`

\`BM25Search.search\` populates a real score (line 232), \`RegexSearch.search\` leaves it at the \`DocSection\` default of \`0.0\` (line 247, 262 — \`score\` argument is never passed). So:

- BM25 path: sort by score descending → panel \"0\" = highest-scoring section, \`doc.loc\` could be anything
- Regex path: all scores 0 → stable sort preserves original order → panel \"0\" = first matching section in document order

Same query, two methods, \"location 0\" pointed at different sections of the corpus.

## Fix

Use \`doc_section.loc\` as the panel title instead of the enumeration index. The displayed number is now the section index in \`filing.sections()\`, consistent across both search methods. Users can pass the number back into \`filing.sections()[N]\` to access the same content regardless of which search path produced the result.

Sort order is unchanged (BM25 still ranks by score).

## Test plan

Synthetic regression test at \`tests/issues/regression/test_issue_765_search_loc_displayed.py\` (3 cases, \`@pytest.mark.fast\` — no network):

- [x] Mixed-score sections (BM25-like path): panel titles equal \`doc.loc\`, not the rank-after-sort
- [x] Zero-score sections (regex path): panel titles equal \`doc.loc\`, not the enumeration index
- [x] Empty results: renders an empty Group without panels

All 12 fast tests in \`test_textsearch.py\` + the new regression file pass. No behaviour change to BM25/Regex search internals — only the display label.