### PR TITLE
fix(files): stop emitting DeprecationWarning at import edgar time

### DIFF
--- a/edgar/files/_deprecation.py
+++ b/edgar/files/_deprecation.py
@@ -1,0 +1,54 @@
+"""Frame-gated deprecation helper for legacy edgar.files.* modules.
+
+The legacy HTML stack (edgar.files.html, edgar.files.html_documents,
+edgar.files.htmltools) is deprecated in favor of edgar.documents, but
+edgartools' own code still instantiates these classes during normal
+operation. Naive module-top warnings.warn() calls fire on every
+internal import and pollute downstream test suites that run with
+``-W error`` — turning every ``import edgar`` into a failure.
+
+This helper suppresses the deprecation signal when the call site is
+edgartools-internal, and re-emits it for user code so the deprecation
+notice is preserved where it matters.
+"""
+
+import sys
+import warnings
+
+# Modules that are transparent to the caller check: the deprecated
+# modules themselves and (for dataclass-generated __init__ trampolines)
+# the standard library's dataclasses module. The dataclass machinery
+# emits an __init__ that runs in the *defining* module's namespace, so
+# we also skip the deprecated modules when walking up.
+_TRANSPARENT_MODULES = frozenset({
+    'edgar.files._deprecation',
+    'edgar.files.html',
+    'edgar.files.html_documents',
+    'edgar.files.htmltools',
+    'dataclasses',
+})
+
+
+def warn_legacy_html_usage(message: str) -> None:
+    """Emit a ``DeprecationWarning`` unless the call site is internal.
+
+    Walks up the call stack past the deprecation helper and the
+    deprecated modules themselves (and the ``dataclasses`` module that
+    hosts synthesized ``__init__`` trampolines) to find the first
+    non-transparent frame. If that frame's module is ``edgar`` or any
+    ``edgar.*`` submodule, the call is internal and the warning is
+    suppressed. Any other caller — user code, notebooks, third-party
+    libraries, tests — receives the standard ``DeprecationWarning`` at
+    its own call site.
+    """
+    frame = sys._getframe(1)
+    while frame is not None:
+        mod_name = frame.f_globals.get('__name__', '')
+        if mod_name in _TRANSPARENT_MODULES:
+            frame = frame.f_back
+            continue
+        if mod_name == 'edgar' or mod_name.startswith('edgar.'):
+            return  # edgartools-internal call — stay quiet
+        break
+
+    warnings.warn(message, DeprecationWarning, stacklevel=3)

--- a/edgar/files/_deprecation.py
+++ b/edgar/files/_deprecation.py
@@ -12,7 +12,7 @@ edgartools-internal, and re-emits it for user code so the deprecation
 notice is preserved where it matters.
 """
 
-import sys
+import inspect
 import warnings
 
 # Modules that are transparent to the caller check: the deprecated
@@ -41,7 +41,8 @@ def warn_legacy_html_usage(message: str) -> None:
     libraries, tests — receives the standard ``DeprecationWarning`` at
     its own call site.
     """
-    frame = sys._getframe(1)
+    current = inspect.currentframe()
+    frame = current.f_back if current is not None else None
     while frame is not None:
         mod_name = frame.f_globals.get('__name__', '')
         if mod_name in _TRANSPARENT_MODULES:

--- a/edgar/files/html.py
+++ b/edgar/files/html.py
@@ -15,18 +15,17 @@ from rich.table import Table
 from rich.text import Text
 
 from edgar.core import log
+from edgar.files._deprecation import warn_legacy_html_usage
 from edgar.files.html_documents import DocumentData, HtmlDocument
 from edgar.files.styles import StyleInfo, Width, get_heading_level, parse_style
 from edgar.files.tables import ColumnOptimizer, ProcessedTable, TableProcessor
 from edgar.richtools import repr_rich
 
-# Deprecation warning for legacy HTML parser
-warnings.warn(
-    "edgar.files.html module is deprecated and will be removed in v6.0. "
-    "Please use edgar.documents.HTMLParser instead. "
-    "See migration guide: https://edgartools.readthedocs.io/en/latest/migration/",
-    DeprecationWarning,
-    stacklevel=2
+_HTML_DEPRECATION_MSG = (
+    "edgar.files.html (including SECHTMLParser and Document) is deprecated "
+    "and will be removed in v6.0. Please use edgar.documents.HTMLParser "
+    "instead. See migration guide: "
+    "https://edgartools.readthedocs.io/en/latest/migration/"
 )
 
 __all__ = ['SECHTMLParser', 'Document', 'DocumentNode']
@@ -501,6 +500,9 @@ class Document:
     """Document class that works with the new node hierarchy"""
     nodes: List[BaseNode]
 
+    def __post_init__(self):
+        warn_legacy_html_usage(_HTML_DEPRECATION_MSG)
+
     def __len__(self):
         return len(self.nodes)
 
@@ -563,6 +565,7 @@ class StyledText:
 
 class SECHTMLParser:
     def __init__(self, root: Tag, extract_data: bool = True, include_page_breaks: bool = False):
+        warn_legacy_html_usage(_HTML_DEPRECATION_MSG)
         self.data:DocumentData = HtmlDocument.extract_data(root) if extract_data else None
         self.root:Tag = root
         self.base_font_size = 10.0  # Default base font size in pt

--- a/edgar/files/html.py
+++ b/edgar/files/html.py
@@ -1,6 +1,5 @@
 import re
 import textwrap
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property

--- a/edgar/files/html_documents.py
+++ b/edgar/files/html_documents.py
@@ -9,15 +9,13 @@ from rich import box
 from rich.table import Table
 
 from edgar.datatools import clean_column_text, table_html_to_dataframe
+from edgar.files._deprecation import warn_legacy_html_usage
 from edgar.richtools import repr_rich
 
-# Deprecation warning for legacy HtmlDocument
-warnings.warn(
-    "edgar.files.html_documents module (including HtmlDocument) is deprecated and will be removed in v6.0. "
-    "Please use edgar.documents.HTMLParser instead. "
-    "See migration guide: https://edgartools.readthedocs.io/en/latest/migration/",
-    DeprecationWarning,
-    stacklevel=2
+_HTML_DOCUMENTS_DEPRECATION_MSG = (
+    "edgar.files.html_documents (including HtmlDocument) is deprecated and "
+    "will be removed in v6.0. Please use edgar.documents.HTMLParser instead. "
+    "See migration guide: https://edgartools.readthedocs.io/en/latest/migration/"
 )
 
 warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
@@ -346,6 +344,7 @@ class HtmlDocument:
                  blocks: List[Block],
                  data: Optional[DocumentData] = None,
                  ):
+        warn_legacy_html_usage(_HTML_DOCUMENTS_DEPRECATION_MSG)
         assert isinstance(blocks, list), "blocks must be a list of Block objects"
         self.blocks: List[Block] = blocks  # The text blocks
         self.data: Optional[DocumentData] = data  # Any data in the document

--- a/edgar/files/htmltools.py
+++ b/edgar/files/htmltools.py
@@ -13,16 +13,14 @@ from rich.table import Table
 
 from edgar.core import pandas_version
 from edgar.datatools import compress_dataframe
+from edgar.files._deprecation import warn_legacy_html_usage
 from edgar.files.html_documents import Block, HtmlDocument, LinkBlock, TableBlock, table_to_markdown
 from edgar.richtools import repr_rich
 
-# Deprecation warning for legacy ChunkedDocument
-warnings.warn(
-    "edgar.files.htmltools module (including ChunkedDocument) is deprecated and will be removed in v6.0. "
-    "Please use edgar.documents.HTMLParser instead. "
-    "See migration guide: https://edgartools.readthedocs.io/en/latest/migration/",
-    DeprecationWarning,
-    stacklevel=2
+_HTMLTOOLS_DEPRECATION_MSG = (
+    "edgar.files.htmltools (including ChunkedDocument) is deprecated and "
+    "will be removed in v6.0. Please use edgar.documents.HTMLParser instead. "
+    "See migration guide: https://edgartools.readthedocs.io/en/latest/migration/"
 )
 
 __all__ = [
@@ -345,6 +343,7 @@ class ChunkedDocument:
         :param chunk_fn: A function that converts the chunks to a dataframe
         :param file_path: The path to the filing
         """
+        warn_legacy_html_usage(_HTMLTOOLS_DEPRECATION_MSG)
         self.chunks = chunk(html)
         self._chunked_data = chunk_fn(self.chunks)
         self.chunk_fn = chunk_fn

--- a/tests/test_internal_deprecation_silence.py
+++ b/tests/test_internal_deprecation_silence.py
@@ -16,6 +16,7 @@ inside edgartools. User code that instantiates these classes still
 receives the standard DeprecationWarning.
 """
 
+import contextlib
 import subprocess
 import sys
 import warnings
@@ -96,13 +97,11 @@ def test_user_instantiation_of_chunked_document_warns():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        try:
-            # ChunkedDocument's __init__ runs further processing that may
-            # surface unrelated issues on minimal HTML; the warning fires
-            # before any of that, so we tolerate downstream exceptions.
+        # ChunkedDocument's __init__ runs further processing that may
+        # surface unrelated AttributeErrors on minimal HTML; the warning
+        # fires before any of that, so we tolerate that specific error.
+        with contextlib.suppress(AttributeError):
             ChunkedDocument(html="<html><body><p>x</p></body></html>")
-        except Exception:
-            pass
 
     deprecations = [
         c for c in caught if issubclass(c.category, DeprecationWarning)

--- a/tests/test_internal_deprecation_silence.py
+++ b/tests/test_internal_deprecation_silence.py
@@ -1,0 +1,112 @@
+"""Regression tests for issue: DeprecationWarning emitted at `import edgar` time.
+
+Before the fix, edgar.files.html_documents, edgar.files.html, and
+edgar.files.htmltools each emitted a top-level `warnings.warn(...,
+DeprecationWarning)` on first import. Because edgartools itself imports
+these modules during its own startup cascade (edgar.__init__ ->
+edgar._filings -> edgar._markdown -> edgar.files.html_documents), the
+warnings fired on every `import edgar`. Downstream projects that run
+under `-W error` (a common, recommended pytest setup) saw their entire
+test suites break.
+
+The fix moves each warning out of the module top and into the relevant
+class `__init__` (or `__post_init__` for the @dataclass), with frame
+inspection that suppresses the signal when the call site is itself
+inside edgartools. User code that instantiates these classes still
+receives the standard DeprecationWarning.
+"""
+
+import subprocess
+import sys
+import warnings
+
+
+def _run_python(code: str, *args: str) -> subprocess.CompletedProcess:
+    """Run a snippet in a clean Python interpreter."""
+    return subprocess.run(
+        [sys.executable, *args, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_edgar_under_W_error():
+    """`python -W error -c "import edgar"` must succeed cleanly.
+
+    A fresh interpreter is required so module-import side effects run
+    end-to-end; doing this in-process would hit cached modules.
+    """
+    result = _run_python("import edgar", "-W", "error")
+    assert result.returncode == 0, (
+        f"import edgar under -W error failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_import_deprecated_submodules_under_W_error():
+    """Each deprecated submodule must also be importable under -W error."""
+    result = _run_python(
+        "import edgar.files.html_documents; "
+        "import edgar.files.html; "
+        "import edgar.files.htmltools",
+        "-W", "error",
+    )
+    assert result.returncode == 0, (
+        f"deprecated submodule import under -W error failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_user_instantiation_of_html_document_warns():
+    """User code that instantiates HtmlDocument must still see the warning."""
+    from edgar.files.html_documents import HtmlDocument
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        HtmlDocument(blocks=[])
+
+    deprecations = [
+        c for c in caught if issubclass(c.category, DeprecationWarning)
+    ]
+    assert deprecations, (
+        "HtmlDocument() must emit DeprecationWarning to user callers"
+    )
+    assert "edgar.documents" in str(deprecations[0].message)
+
+
+def test_user_instantiation_of_legacy_document_warns():
+    """User code that instantiates edgar.files.html.Document must still warn."""
+    from edgar.files.html import Document
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Document(nodes=[])
+
+    deprecations = [
+        c for c in caught if issubclass(c.category, DeprecationWarning)
+    ]
+    assert deprecations, (
+        "Document() must emit DeprecationWarning to user callers"
+    )
+
+
+def test_user_instantiation_of_chunked_document_warns():
+    """User code that instantiates ChunkedDocument must still warn."""
+    from edgar.files.htmltools import ChunkedDocument
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            # ChunkedDocument's __init__ runs further processing that may
+            # surface unrelated issues on minimal HTML; the warning fires
+            # before any of that, so we tolerate downstream exceptions.
+            ChunkedDocument(html="<html><body><p>x</p></body></html>")
+        except Exception:
+            pass
+
+    deprecations = [
+        c for c in caught if issubclass(c.category, DeprecationWarning)
+    ]
+    assert deprecations, (
+        "ChunkedDocument() must emit DeprecationWarning to user callers"
+    )


### PR DESCRIPTION
## Symptom

`python -W error -c "import edgar"` fails in a clean venv:

```
DeprecationWarning: edgar.files.html_documents module (including
HtmlDocument) is deprecated and will be removed in v6.0…
```

Downstream test suites that run under `-W error` (a common, recommended
pytest setup) cannot import edgar at all without installing manual
`warnings.filterwarnings(…)` calls just to silence three of edgartools'
*own* internal imports.

## Root cause

`edgar/files/html_documents.py`, `edgar/files/html.py`, and
`edgar/files/htmltools.py` each emit a top-level
`warnings.warn(…, DeprecationWarning)`. edgartools' own startup cascade
imports all three — for example:

```
edgar/__init__.py
  → edgar._filings
      → edgar._markdown
          → edgar.files.html_documents   # warning fires here
```

So the warning fires on every `import edgar`, with the caller being an
internal edgartools module. Worse, after the first import the module is
cached, so users who later access the deprecated API directly never get
the deprecation signal — the warning is loud where it shouldn't be and
silent where it should.

## Fix

Move the deprecation signal from module top into the relevant class
entry points (`HtmlDocument.__init__`, `ChunkedDocument.__init__`,
`SECHTMLParser.__init__`, and `Document.__post_init__` for the
`@dataclass`), via a small shared helper at
`edgar/files/_deprecation.py::warn_legacy_html_usage`.

The helper walks the call stack past the deprecation helper itself, the
three deprecated modules, and the `dataclasses` module (which hosts
synthesized `__init__` trampolines). If the first non-transparent frame
belongs to `edgar` or any `edgar.*` submodule, the call is internal and
the warning is suppressed. Any other caller — user code, notebooks,
tests, third-party libraries — receives the standard
`DeprecationWarning` pointing at its own call site.

This trades the "fires once at import" pattern for "fires per
user-driven instantiation," which is the standard Python pattern for
class-level deprecation and is what API consumers expect.

## Tests

`tests/test_internal_deprecation_silence.py`:

- `test_import_edgar_under_W_error` — subprocess: `python -W error
  -c "import edgar"` exits 0. Fails on `main`; passes with this change.
- `test_import_deprecated_submodules_under_W_error` — subprocess:
  importing each deprecated submodule directly under `-W error` is also
  silent.
- `test_user_instantiation_of_html_document_warns`,
  `test_user_instantiation_of_legacy_document_warns`,
  `test_user_instantiation_of_chunked_document_warns` — confirm that
  user-code instantiation still emits `DeprecationWarning`, so the
  user-facing deprecation notice is preserved.

All five pass with the fix; the import test fails on `main` (catches
the regression).
