### PR TITLE
fix(xbrl): dedupe duplicate presentation arcs to same concept (#825)

### DIFF
--- a/edgar/xbrl/parsers/presentation.py
+++ b/edgar/xbrl/parsers/presentation.py
@@ -234,8 +234,21 @@ class PresentationParser(BaseParser):
             # Sort children by order
             children = sorted(from_map[element_id], key=lambda r: r['order'])
 
+            # Track child concepts already added under this parent. Some filers
+            # emit two presentation arcs from the same parent to the same concept
+            # (GH-825: CLW's balance sheet points AssetsAbstract at
+            # PropertyPlantAndEquipmentNet at both order 2 and order 4). Because
+            # nodes are keyed by element_id they collapse to a single node, so a
+            # duplicate child reference would render the identical line item twice.
+            # Keep the first occurrence (lowest order) and skip the rest.
+            seen_children = set()
+
             for rel in children:
                 child_id = rel['to_element']
+
+                if child_id in seen_children:
+                    continue
+                seen_children.add(child_id)
 
                 # Add child to parent's children list
                 node.children.append(child_id)

--- a/tests/issues/regression/test_issue_825.py
+++ b/tests/issues/regression/test_issue_825.py
@@ -1,0 +1,59 @@
+"""
+Regression test for Issue #825: PP&E line item duplicated on CLW balance sheet
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/825
+Reporter: GitHub user mkdeak
+
+Bug (FIXED): Clearwater Paper's (CLW) 10-K balance sheet rendered
+"Property, plant and equipment" twice with identical values, and the second
+occurrence stole a terse label that mislabeled the net PP&E line.
+
+Root cause: CLW's presentation linkbase emits two parent-child arcs from
+``us-gaap_AssetsAbstract`` to ``us-gaap_PropertyPlantAndEquipmentNet`` (order 2
+with a totalLabel, order 4 with a terseLabel). Because presentation nodes are
+keyed by element_id, both arcs collapse to a single node, but the parent's
+children list retained the duplicate reference -- so statement generation
+emitted the same concept twice.
+
+Fix: ``_build_presentation_subtree`` now deduplicates child references under a
+parent, keeping the first (lowest-order) occurrence.
+
+Note: the accumulated-depreciation line showing as a positive value is a filer
+presentation inconsistency (the face arc uses a plain terseLabel rather than a
+negatedTerseLabel), not an edgartools defect, and is intentionally out of scope
+for this fix.
+
+Filing: CIK 1441236, accession 0001441236-26-000007, FY2025 10-K.
+"""
+
+import pytest
+from edgar import Company
+
+
+@pytest.mark.network
+@pytest.mark.regression
+def test_issue_825_no_duplicate_ppe_line():
+    """CLW balance sheet must contain PropertyPlantAndEquipmentNet exactly once."""
+    filing = Company("CLW").get_filings(form="10-K").latest(1)
+    assert filing.accession_no == "0001441236-26-000007"
+
+    line_items = filing.xbrl().get_statement("BalanceSheet")
+    ppe_net = [
+        item
+        for item in line_items
+        if item.get("concept") == "us-gaap_PropertyPlantAndEquipmentNet"
+        and not item.get("is_dimension")
+    ]
+
+    assert len(ppe_net) == 1, (
+        f"PropertyPlantAndEquipmentNet should appear once, found {len(ppe_net)}"
+    )
+
+    # Ground-truth value from the SEC filing (in thousands): net PP&E = $1,001,800
+    values = ppe_net[0]["values"]
+    assert values["instant_2025-12-31"] == 1_001_800_000.0
+    assert values["instant_2024-12-31"] == 1_023_100_000.0
+
+    # The surviving line keeps the net (totalLabel) wording, not a bare "Property,
+    # plant and equipment" that would read as gross.
+    assert "net" in ppe_net[0]["label"].lower()


### PR DESCRIPTION
## Summary

Fixes #825. Clearwater Paper's (CLW) 10-K balance sheet rendered **"Property, plant and equipment" twice** with identical values, and the duplicate row stole a terse label that mislabeled the net PP&E line.

## Root cause

CLW's presentation linkbase emits **two** parent-child arcs from `us-gaap_AssetsAbstract` to `us-gaap_PropertyPlantAndEquipmentNet`:

| order | concept | preferredLabel |
|-------|---------|----------------|
| 2 | `PropertyPlantAndEquipmentNet` | totalLabel ("Property, plant and equipment, net") |
| 3 | `AccumulatedDepreciation...` | terseLabel |
| 4 | `PropertyPlantAndEquipmentNet` *(again)* | terseLabel ("Property, plant and equipment") |

Because presentation nodes are keyed by `element_id`, both PP&E-Net arcs collapse to a single node — but the parent's `children` list kept **both** references, so statement generation emitted the same concept twice. The order-4 arc also overwrote the node, mislabeling the surviving net line.

## Fix

`_build_presentation_subtree` now deduplicates child references under a parent, keeping the first (lowest-order) occurrence. PP&E net now renders **once**, correctly labeled "Property, plant and equipment, net" = \$1,001,800K.

## Out of scope

The accumulated-depreciation line displaying as a **positive** value is a filer presentation inconsistency — CLW used a plain `terseLabel` on the balance-sheet *face* arc rather than a `negatedTerseLabel` (they used the negated form only in the parenthetical role). edgartools faithfully honors the presentation linkbase. Auto-negating by the `balance=credit` attribute is risky (every liability/equity line is credit-balance too) and warrants separate discussion. The gross PP&E value isn't referenced on the filer's face presentation at all.

## Verification

- New regression test `tests/issues/regression/test_issue_825.py` asserts PP&E appears once with ground-truth values (\$1,001,800K / \$1,023,100K).
- No regressions: AAPL / JPM / XOM balance sheets render with no dropped or duplicated lines; the 120-test presentation/balance-sheet suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)