### PR TITLE
fix: decode bytes HTML so SixK.text() handles bytes exhibits (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SixK.text()` no longer crashes on bytes exhibit content** — 6-K exhibits whose `Attachment.download()` returns `bytes` raised `TypeError: a bytes-like object is required, not 'str'` in the legacy HTML parser's `<TEXT>` check; the parser now decodes bytes first, so bytes and str inputs parse identically. ([#844](https://github.com/dgunning/edgartools/issues/844))
+
 ## [5.35.1] - 2026-06-04
 
 10-K section detection and agent TOC parsing receive two targeted fixes that close gaps introduced in 5.34.0.

--- a/edgar/files/html_documents.py
+++ b/edgar/files/html_documents.py
@@ -456,6 +456,10 @@ class HtmlDocument:
 
     @classmethod
     def get_root(cls, html: str) -> Tag:
+        # Attachment.download() returns str | bytes; decode bytes so the
+        # string-based <TEXT> checks below don't raise TypeError (GH #844)
+        if isinstance(html, (bytes, bytearray)):
+            html = html.decode("utf-8", errors="replace")
         # First check if the html is inside a <DOCUMENT><TEXT> block
         if "<TEXT>" in html[:500]:
             html = get_text_between_tags(html, 'TEXT')

--- a/tests/issues/regression/test_issue_844.py
+++ b/tests/issues/regression/test_issue_844.py
@@ -1,0 +1,42 @@
+"""
+Regression test for Issue #844: SixK.text() raises TypeError on bytes exhibit content.
+
+``Attachment.download()`` is typed ``str | bytes`` and returns bytes for some 6-K
+exhibits. That value flows into ``Document.parse`` -> ``HtmlDocument.get_root``,
+whose ``"<TEXT>" in html[:500]`` check raised
+``TypeError: a bytes-like object is required, not 'str'`` instead of parsing.
+
+The parser now decodes bytes before those string checks, so bytes and str inputs
+behave identically. No network access required.
+"""
+
+import pytest
+
+from edgar.files.html import Document
+from edgar.files.html_documents import HtmlDocument
+
+INNER_HTML = "<html><body><p>Exhibit 99.1 content</p></body></html>"
+SEC_WRAPPED = "<DOCUMENT>\n<TYPE>EX-99.1\n<TEXT>\n" + INNER_HTML + "\n</TEXT>\n</DOCUMENT>\n"
+
+
+class TestIssue844BytesExhibitContent:
+    """Parsing must accept bytes HTML, matching Attachment.download()'s str|bytes return."""
+
+    @pytest.mark.parametrize("html", [INNER_HTML, SEC_WRAPPED])
+    def test_document_parse_accepts_bytes(self, html):
+        """Document.parse must not raise TypeError on bytes input (GH #844)."""
+        doc_bytes = Document.parse(html.encode("utf-8"))
+        doc_str = Document.parse(html)
+        assert doc_bytes is not None
+        # bytes input parses equivalently to the already-decoded str input
+        assert len(doc_bytes.nodes) == len(doc_str.nodes)
+
+    def test_get_root_accepts_bytes(self):
+        """HtmlDocument.get_root decodes bytes instead of raising at the crash site."""
+        root = HtmlDocument.get_root(SEC_WRAPPED.encode("utf-8"))
+        assert root is not None
+
+    def test_non_utf8_bytes_do_not_crash(self):
+        """Latin-1/cp1252 bytes degrade gracefully rather than raising."""
+        latin1 = "<html><body><p>café résumé</p></body></html>".encode("latin-1")
+        assert Document.parse(latin1) is not None


### PR DESCRIPTION
Fixes #844.

`SixK.text()` raises `TypeError: a bytes-like object is required, not 'str'` for 6-K filings whose exhibit content comes back as bytes.

`Attachment.download()` is typed `Optional[Union[str, bytes]]` and returns `bytes` for some exhibits. `SixK._get_exhibit_content` passes that straight into `Document.parse`, which reaches `HtmlDocument.get_root`:

```python
if "<TEXT>" in html[:500]:   # str in bytes -> TypeError
```

`BeautifulSoup` itself accepts bytes, so the only thing that breaks is the string-based `<TEXT>` SGML check above it. This decodes bytes once at the top of `get_root`, after which bytes and str inputs parse identically.

Reproducible offline (no SEC download needed):

```python
from edgar.files.html import Document
Document.parse(b"<html><body><p>hi</p></body></html>")   # was TypeError
```

**On the deprecation:** `edgar.files.html` / `edgar.files.html_documents` are marked deprecated for v6.0, but `SixK` (and the other `company_reports` objects) still route exhibit rendering through them on 5.x, so this is a live crash for current users. I put the fix at `get_root` since it's the shared crash site and covers every legacy-parser caller in one place — happy to move it to the `SixK._get_exhibit_content` boundary instead, or hold it, if you'd rather not touch the legacy parser.

Regression test in `tests/issues/regression/test_issue_844.py` (fast, no network): asserts `Document.parse` / `get_root` accept bytes, that bytes parses equivalently to str (both plain and `<DOCUMENT><TEXT>`-wrapped), and that non-UTF-8 bytes degrade gracefully. All four cases fail on `main` and pass here; the existing `tests/test_documents.py` offline suite is unchanged (63 pass — the 15 network/identity-gated failures are pre-existing and unrelated).

Thanks to @LuukBlom for the clear report and reproducer.
