### PR TITLE
fix: decode non-UTF-8 byte exhibits via cp1252/latin-1 fallback (#844 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`SixK.text()` no longer crashes on bytes exhibit content** — 6-K exhibits whose `Attachment.download()` returns `bytes` raised `TypeError: a bytes-like object is required, not 'str'` in the legacy HTML parser's `<TEXT>` check; the parser now decodes bytes first, so bytes and str inputs parse identically. ([#844](https://github.com/dgunning/edgartools/issues/844))
+- **`SixK.text()` no longer crashes on bytes exhibit content** — 6-K exhibits whose `Attachment.download()` returns `bytes` raised `TypeError: a bytes-like object is required, not 'str'` in the legacy HTML parser's `<TEXT>` check; the parser now decodes bytes first, so bytes and str inputs parse identically. Non-UTF-8 exhibits (cp1252/latin-1, common in older filings) decode correctly via a cp1252→latin-1 fallback instead of emitting replacement characters. ([#844](https://github.com/dgunning/edgartools/issues/844))
 
 ## [5.35.1] - 2026-06-04
 

--- a/edgar/files/html_documents.py
+++ b/edgar/files/html_documents.py
@@ -455,11 +455,20 @@ class HtmlDocument:
         return ixbrl_document
 
     @classmethod
-    def get_root(cls, html: str) -> Tag:
-        # Attachment.download() returns str | bytes; decode bytes so the
-        # string-based <TEXT> checks below don't raise TypeError (GH #844)
+    def get_root(cls, html: Union[str, bytes]) -> Tag:
+        # Attachment.download() returns str | bytes. Decode bytes before the
+        # string <TEXT> checks (GH #844); try cp1252 before latin-1 so the SEC's
+        # common non-UTF-8 exhibits decode correctly instead of being mojibaked
+        # by utf-8 + errors="replace".
         if isinstance(html, (bytes, bytearray)):
-            html = html.decode("utf-8", errors="replace")
+            for enc in ("utf-8", "cp1252"):
+                try:
+                    html = html.decode(enc)
+                    break
+                except UnicodeDecodeError:
+                    continue
+            else:
+                html = html.decode("latin-1")  # 1:1 mapping, never raises
         # First check if the html is inside a <DOCUMENT><TEXT> block
         if "<TEXT>" in html[:500]:
             html = get_text_between_tags(html, 'TEXT')

--- a/tests/issues/regression/test_issue_844.py
+++ b/tests/issues/regression/test_issue_844.py
@@ -36,7 +36,20 @@ class TestIssue844BytesExhibitContent:
         root = HtmlDocument.get_root(SEC_WRAPPED.encode("utf-8"))
         assert root is not None
 
-    def test_non_utf8_bytes_do_not_crash(self):
-        """Latin-1/cp1252 bytes degrade gracefully rather than raising."""
-        latin1 = "<html><body><p>café résumé</p></body></html>".encode("latin-1")
-        assert Document.parse(latin1) is not None
+    @pytest.mark.parametrize("encoding", ["cp1252", "latin-1"])
+    def test_non_utf8_bytes_preserve_characters(self, encoding):
+        """cp1252/latin-1 exhibits must decode to the right characters, not U+FFFD.
+
+        utf-8 + errors="replace" silently mojibaked these legacy filings; the
+        cp1252 -> latin-1 fallback keeps the original text.
+        """
+        html_bytes = "<html><body><p>café résumé</p></body></html>".encode(encoding)
+        parsed = HtmlDocument.get_root(html_bytes).get_text()
+        assert "café" in parsed and "résumé" in parsed
+        assert "�" not in parsed  # no replacement characters
+        assert Document.parse(html_bytes) is not None
+
+    def test_undecodable_bytes_do_not_crash(self):
+        """A byte invalid in utf-8 and cp1252 still degrades via latin-1, never raises."""
+        # 0x81 is undefined in cp1252 and an invalid utf-8 start byte
+        assert Document.parse(b"<html><body><p>\x81</p></body></html>") is not None


### PR DESCRIPTION
Follow-up to #845, addressing @dgunning's review.

The merged fix decoded byte exhibits with `utf-8` + `errors="replace"`, which stops the crash but mojibakes cp1252/latin-1 filings (`café` → `caf�`) — trading a loud crash for silent corruption on exactly the legacy exhibits most likely to arrive as bytes. This applies the suggested fallback chain (utf-8 → cp1252 → latin-1; latin-1 never raises), so non-UTF-8 exhibits decode correctly.

- `get_root` is now annotated `Union[str, bytes]`.
- Strengthened the regression test: `test_non_utf8_bytes_preserve_characters` asserts `café`/`résumé` survive and no `�` appears (this fails on the old utf-8+replace), plus `test_undecodable_bytes_do_not_crash` guards the latin-1 final fallback with a byte invalid in both utf-8 and cp1252.

All offline, no network. The `edgar/documents/` modern parser is untouched (out of scope, as noted).

Credit correction: the reporter is @warzoo, not @LuukBlom — I tagged the wrong handle in #845, sorry about that, and thanks @warzoo for the report and reproducer.
