### PR TITLE
fix: correct document search snippet offsets

### DIFF
--- a/edgar/documents/search.py
+++ b/edgar/documents/search.py
@@ -181,12 +181,15 @@ class DocumentSearch:
                 flags = 0 if case_sensitive else re.IGNORECASE
 
                 for match in re.finditer(pattern, text, flags):
+                    context, start_offset, end_offset = self._get_context_with_offsets(
+                        text, match.start(), match.end()
+                    )
                     results.append(SearchResult(
                         node=node,
                         text=match.group(),
-                        start_offset=match.start(),
-                        end_offset=match.end(),
-                        context=self._get_context(text, match.start(), match.end())
+                        start_offset=start_offset,
+                        end_offset=end_offset,
+                        context=context
                     ))
             else:
                 # Simple substring search
@@ -196,12 +199,15 @@ class DocumentSearch:
                     if pos == -1:
                         break
 
+                    context, start_offset, end_offset = self._get_context_with_offsets(
+                        text, pos, pos + len(query)
+                    )
                     results.append(SearchResult(
                         node=node,
                         text=text[pos:pos + len(query)],
-                        start_offset=pos,
-                        end_offset=pos + len(query),
-                        context=self._get_context(text, pos, pos + len(query))
+                        start_offset=start_offset,
+                        end_offset=end_offset,
+                        context=context
                     ))
 
                     start = pos + 1
@@ -233,12 +239,15 @@ class DocumentSearch:
 
             # Find all matches
             for match in regex.finditer(text):
+                context, start_offset, end_offset = self._get_context_with_offsets(
+                    text, match.start(), match.end()
+                )
                 results.append(SearchResult(
                     node=node,
                     text=match.group(),
-                    start_offset=match.start(),
-                    end_offset=match.end(),
-                    context=self._get_context(text, match.start(), match.end())
+                    start_offset=start_offset,
+                    end_offset=end_offset,
+                    context=context
                 ))
 
         return results
@@ -398,6 +407,12 @@ class DocumentSearch:
 
     def _get_context(self, text: str, start: int, end: int, context_size: int = 50) -> str:
         """Get context around match."""
+        context, _, _ = self._get_context_with_offsets(text, start, end, context_size)
+        return context
+
+    def _get_context_with_offsets(self, text: str, start: int, end: int,
+                                  context_size: int = 50) -> tuple[str, int, int]:
+        """Get context around match with match offsets adjusted to that context."""
         # Calculate context boundaries
         context_start = max(0, start - context_size)
         context_end = min(len(text), end + context_size)
@@ -419,7 +434,7 @@ class DocumentSearch:
             start = start - context_start
             end = end - context_start
 
-        return context
+        return context, start, end
 
     def _calculate_heading_score(self, heading: HeadingNode) -> float:
         """Calculate relevance score for heading."""

--- a/tests/test_textsearch_snippets.py
+++ b/tests/test_textsearch_snippets.py
@@ -1,0 +1,32 @@
+"""Regression tests for document search snippet highlighting."""
+
+from edgar.documents.document import Document
+from edgar.documents.nodes import DocumentNode, ParagraphNode, TextNode
+from edgar.documents.search import DocumentSearch, SearchMode
+
+
+def _document_with_text(text: str) -> Document:
+    root = DocumentNode()
+    paragraph = ParagraphNode()
+    paragraph.add_child(TextNode(content=text))
+    root.add_child(paragraph)
+    return Document(root=root)
+
+
+def test_text_search_snippet_highlights_match_after_truncated_prefix():
+    text = f"{'a' * 60} target {'b' * 60}"
+    result = DocumentSearch(_document_with_text(text)).search("target")[0]
+
+    assert result.context[result.start_offset:result.end_offset] == "target"
+    assert "**target**" in result.snippet
+
+
+def test_regex_search_snippet_highlights_match_after_truncated_prefix():
+    text = f"{'a' * 60} target phrase {'b' * 60}"
+    result = DocumentSearch(_document_with_text(text)).search(
+        r"target\s+phrase",
+        mode=SearchMode.REGEX,
+    )[0]
+
+    assert result.context[result.start_offset:result.end_offset] == "target phrase"
+    assert "**target phrase**" in result.snippet


### PR DESCRIPTION
## Summary
- Adjust document search result offsets to point into the generated context snippet instead of the original full text.
- Preserve the existing `_get_context()` string-returning helper and add an internal helper that returns the context plus adjusted offsets.
- Add focused text and regex search regression tests for matches after a truncated prefix.

## Why this matters
`SearchResult.snippet` highlights `context[start_offset:end_offset]` when context is available. `_get_context()` already computed adjusted offsets for truncated contexts, but those adjusted values were discarded, so matches after the leading context window could highlight the wrong characters in snippets.

## Validation
- `python -m py_compile edgar/documents/search.py tests/test_textsearch_snippets.py`
- `git diff --no-index` checked that the patch only touches `edgar/documents/search.py` and adds `tests/test_textsearch_snippets.py`.

Full pytest was not run locally because git fetch/clone from this environment repeatedly timed out before a complete checkout could be created.