### PR TITLE
fix: downgrade XBRL-absent warnings to debug level (fixes #857)

### DIFF
--- a/edgar/xbrl/xbrl.py
+++ b/edgar/xbrl/xbrl.py
@@ -594,7 +594,7 @@ class XBRL:
             XBRL object with parsed data
         """
         if filing.form.endswith("/A"):
-            log.warning(dedent(f"""
+            log.debug(dedent(f"""
             {filing}
             is an amended filing and may not contain full XBRL data e.g. some statements might be missing.
             Consider using the original filing instead if available with `get_filings(form="10-K", amendments=False)`
@@ -605,7 +605,7 @@ class XBRL:
         xbrl_attachments = XBRLAttachments(filing.attachments)
 
         if xbrl_attachments.empty:
-            log.warning(f"No XBRL attachments found in filing {filing}")
+            log.debug(f"No XBRL attachments found in filing {filing}")
             return None
 
         if xbrl_attachments.get('schema'):


### PR DESCRIPTION
Change log level from `WARNING` to `DEBUG` for two expected scenarios
where XBRL data is absent:

1. Amended filings (`form.endswith("/A")`) that may not contain full
   XBRL data (DEFA14A, S-4/A, etc.)
2. Filings with no XBRL attachments at all

These are normal, expected cases that should not alarm users at
`WARNING` level. The information is still available when debug
logging is enabled.

This pull request includes code written with the assistance of AI
under my direction.