### PR TITLE
fix: use context-relative offsets in SearchResult snippet (fixes #860)

### DIFF
--- a/edgar/documents/search.py
+++ b/edgar/documents/search.py
@@ -181,12 +181,15 @@ class DocumentSearch:
                 flags = 0 if case_sensitive else re.IGNORECASE
 
                 for match in re.finditer(pattern, text, flags):
+                    context, adj_start, adj_end = self._get_context_with_offsets(
+                        text, match.start(), match.end()
+                    )
                     results.append(SearchResult(
                         node=node,
                         text=match.group(),
-                        start_offset=match.start(),
-                        end_offset=match.end(),
-                        context=self._get_context(text, match.start(), match.end())
+                        start_offset=adj_start,
+                        end_offset=adj_end,
+                        context=context,
                     ))
             else:
                 # Simple substring search
@@ -196,12 +199,15 @@ class DocumentSearch:
                     if pos == -1:
                         break
 
+                    context, adj_start, adj_end = self._get_context_with_offsets(
+                        text, pos, pos + len(query)
+                    )
                     results.append(SearchResult(
                         node=node,
                         text=text[pos:pos + len(query)],
-                        start_offset=pos,
-                        end_offset=pos + len(query),
-                        context=self._get_context(text, pos, pos + len(query))
+                        start_offset=adj_start,
+                        end_offset=adj_end,
+                        context=context,
                     ))
 
                     start = pos + 1
@@ -233,12 +239,15 @@ class DocumentSearch:
 
             # Find all matches
             for match in regex.finditer(text):
+                context, adj_start, adj_end = self._get_context_with_offsets(
+                    text, match.start(), match.end()
+                )
                 results.append(SearchResult(
                     node=node,
                     text=match.group(),
-                    start_offset=match.start(),
-                    end_offset=match.end(),
-                    context=self._get_context(text, match.start(), match.end())
+                    start_offset=adj_start,
+                    end_offset=adj_end,
+                    context=context,
                 ))
 
         return results
@@ -396,8 +405,14 @@ class DocumentSearch:
 
         return filtered
 
-    def _get_context(self, text: str, start: int, end: int, context_size: int = 50) -> str:
-        """Get context around match."""
+    def _get_context_with_offsets(
+        self, text: str, start: int, end: int, context_size: int = 50
+    ) -> tuple[str, int, int]:
+        """Get context around match, returning (context, adjusted_start, adjusted_end).
+
+        The adjusted offsets are relative to the returned context string,
+        accounting for any truncation and ellipsis markers.
+        """
         # Calculate context boundaries
         context_start = max(0, start - context_size)
         context_end = min(len(text), end + context_size)
@@ -413,12 +428,17 @@ class DocumentSearch:
 
         # Adjust offsets for context
         if context_start > 0:
-            start = start - context_start + 3  # Account for "..."
-            end = end - context_start + 3
+            adj_start = start - context_start + 3  # Account for "..."
+            adj_end = end - context_start + 3
         else:
-            start = start - context_start
-            end = end - context_start
+            adj_start = start - context_start
+            adj_end = end - context_start
 
+        return context, adj_start, adj_end
+
+    def _get_context(self, text: str, start: int, end: int, context_size: int = 50) -> str:
+        """Get context around match (backward-compatible, returns context only)."""
+        context, _, _ = self._get_context_with_offsets(text, start, end, context_size)
         return context
 
     def _calculate_heading_score(self, heading: HeadingNode) -> float:

--- a/tests/issues/regression/test_issue_860_search_snippet_offsets.py
+++ b/tests/issues/regression/test_issue_860_search_snippet_offsets.py
@@ -6,7 +6,39 @@ string, not the original text. Otherwise SearchResult.snippet highlights the
 wrong characters.
 """
 
-from edgar.documents.search import DocumentSearch
+from edgar.documents.document import Document
+from edgar.documents.nodes import DocumentNode, ParagraphNode, TextNode
+from edgar.documents.search import DocumentSearch, SearchMode
+
+
+def _document_with_text(text: str) -> Document:
+    """Build a minimal one-paragraph document for end-to-end search tests."""
+    root = DocumentNode()
+    paragraph = ParagraphNode()
+    paragraph.add_child(TextNode(content=text))
+    root.add_child(paragraph)
+    return Document(root=root)
+
+
+def test_text_search_snippet_highlights_match_after_truncated_prefix():
+    """End-to-end: text search highlights the right characters in .snippet."""
+    text = f"{'a' * 60} target {'b' * 60}"
+    result = DocumentSearch(_document_with_text(text)).search("target")[0]
+
+    assert result.context[result.start_offset:result.end_offset] == "target"
+    assert "**target**" in result.snippet
+
+
+def test_regex_search_snippet_highlights_match_after_truncated_prefix():
+    """End-to-end: regex search highlights the right characters in .snippet."""
+    text = f"{'a' * 60} target phrase {'b' * 60}"
+    result = DocumentSearch(_document_with_text(text)).search(
+        r"target\s+phrase",
+        mode=SearchMode.REGEX,
+    )[0]
+
+    assert result.context[result.start_offset:result.end_offset] == "target phrase"
+    assert "**target phrase**" in result.snippet
 
 
 def test_get_context_with_offsets_adjusts_for_truncation():

--- a/tests/issues/regression/test_issue_860_search_snippet_offsets.py
+++ b/tests/issues/regression/test_issue_860_search_snippet_offsets.py
@@ -1,0 +1,51 @@
+"""Regression test for #860: search snippet offsets should be adjusted for context.
+
+When _get_context truncates text and adds ellipsis markers, the SearchResult
+start_offset and end_offset must reflect positions within the returned context
+string, not the original text. Otherwise SearchResult.snippet highlights the
+wrong characters.
+"""
+
+from edgar.documents.search import DocumentSearch
+
+
+def test_get_context_with_offsets_adjusts_for_truncation():
+    """Offsets should be adjusted when context is truncated."""
+    ds = DocumentSearch.__new__(DocumentSearch)
+
+    # Text with match far from start and end, so context is truncated both sides
+    text = "x" * 200 + "THE_MATCH" + "y" * 200
+    pos = 200  # start of THE_MATCH
+    context, start, end = ds._get_context_with_offsets(text, pos, pos + 9, 10)
+
+    # The adjusted offsets should point to THE_MATCH within context
+    assert context[start:end] == "THE_MATCH"
+    # The original offset would be wrong (pointing outside context)
+    assert start != pos
+
+
+def test_get_context_with_offsets_no_truncation():
+    """Offsets should be unchanged when context is not truncated."""
+    ds = DocumentSearch.__new__(DocumentSearch)
+
+    text = "hello world this is a test"
+    pos = 6
+    context, start, end = ds._get_context_with_offsets(text, pos, pos + 5, 10)
+
+    assert context[start:end] == "world"
+    # No truncation, offsets unchanged
+    assert start == pos
+    assert end == pos + 5
+
+
+def test_backward_compatible_get_context():
+    """Existing _get_context should still return just the string."""
+    ds = DocumentSearch.__new__(DocumentSearch)
+
+    text = "x" * 100 + "match" + "y" * 100
+    result = ds._get_context(text, 100, 105, 10)
+
+    assert isinstance(result, str)
+    assert "match" in result
+    assert result.startswith("...")
+    assert result.endswith("...")


### PR DESCRIPTION
_get_context computed adjusted offsets for truncated context but returned only the context string, discarding the adjustments. SearchResult.snippet then used the original (unadjusted) offsets against the truncated context, highlighting wrong characters for matches after a prefix context window.

Add _get_context_with_offsets that returns (context, adj_start, adj_end) and update text, regex, and whole-word search paths to use adjusted offsets.

Closes #860