### PR TITLE
Add /health liveness endpoint to MCP HTTP server

### DIFF
--- a/edgar/ai/mcp/server.py
+++ b/edgar/ai/mcp/server.py
@@ -472,6 +472,8 @@ def _run_http(host: str, port: int, version: str):
     import uvicorn
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
     from starlette.routing import Route
 
     # Set version on the Server so StreamableHTTPSessionManager picks it up
@@ -498,8 +500,14 @@ def _run_http(host: str, port: int, version: str):
             )
             yield
 
+    async def health(request: Request):
+        return JSONResponse({"status": "ok", "version": version})
+
     starlette_app = Starlette(
-        routes=[Route("/mcp", endpoint=_MCPEndpoint())],
+        routes=[
+            Route("/mcp", endpoint=_MCPEndpoint()),
+            Route("/health", endpoint=health),
+        ],
         lifespan=lifespan,
     )
 


### PR DESCRIPTION
## Summary

Adds a lightweight `GET /health` route to the MCP server when running in **HTTP transport mode**. It returns:

```json
{"status": "ok", "version": "<server version>"}
```

The existing `/mcp` endpoint requires a full MCP handshake, so it isn't suitable as a container healthcheck. A dedicated `/health` route gives orchestrators (Docker `HEALTHCHECK`, Kubernetes liveness/readiness probes, Dokploy, etc.) a cheap, unauthenticated liveness signal.

## Changes

- `edgar/ai/mcp/server.py` (`_run_http`): import `Request`/`JSONResponse`, add a `health` handler, register `Route("/health", ...)` alongside `/mcp`.

## Scope / safety

- **HTTP mode only** — stdio transport is completely unaffected.
- No new dependencies (Starlette is already used for the HTTP app).
- ~9 lines added.

## Test

```bash
# start the server in HTTP mode, then:
curl -s http://localhost:8000/health
# {"status": "ok", "version": "x.y.z"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)