### PR TITLE
Fix: Fund(ticker) fails to resolve any ETF ticker starting with "C" (ticker/Class-ID prefix collision) (GH #889)

### DIFF
--- a/edgar/funds/core.py
+++ b/edgar/funds/core.py
@@ -446,6 +446,10 @@ class Fund:
             self._class = None
             self._series = None
             self._company = self._entity
+        else:
+            self._class = None
+            self._series = None
+            self._company = None
 
     def _is_fund_ticker(self, identifier: str) -> bool:
         """Check if an identifier appears to be a fund ticker"""

--- a/edgar/funds/data.py
+++ b/edgar/funds/data.py
@@ -618,9 +618,9 @@ def _build_hierarchy_from_mf_tickers(cik: str, identifier_type: str, identifier:
             current_series.fund_classes.append(current_class)
 
             if identifier_type == 'Class':
-                if identifier.startswith('C') and current_class.class_id == identifier:
+                if re.match(r'^C\d+$', identifier) and current_class.class_id == identifier:
                     target_class = current_class
-                elif not identifier.startswith('C') and current_class.ticker and current_class.ticker.upper() == identifier.upper():
+                elif not re.match(r'^C\d+$', identifier) and current_class.ticker and current_class.ticker.upper() == identifier.upper():
                     target_class = current_class
 
         if identifier_type == 'Series' and current_series.series_id == identifier:
@@ -710,9 +710,9 @@ def get_fund_object(identifier: str) -> Optional[Union[FundCompany, FundSeries, 
             current_series.fund_classes.append(current_class)
 
             if identifier_type == 'Class':
-                if identifier.startswith('C') and current_class.class_id == identifier:
+                if re.match(r'^C\d+$', identifier) and current_class.class_id == identifier:
                     target_class = current_class
-                elif not identifier.startswith('C') and current_class.ticker and current_class.ticker.upper() == identifier.upper():
+                elif not re.match(r'^C\d+$', identifier) and current_class.ticker and current_class.ticker.upper() == identifier.upper():
                     target_class = current_class
 
         if identifier_type == 'Series' and current_series.series_id == identifier:


### PR DESCRIPTION
### Problem

`Fund(ticker)` fails to resolve the share class for **any** ETF ticker that starts with the letter "C" and has genuine SEC series/class registration — for example `CNEQ`, `CIBR`, `CQQQ`, `COPX`, `CARZ`, `CALF`, `CGW`, `CATH`, and `CUT` all reproduce this identically. The `Fund` object still constructs without raising, but is left in an inconsistent state: `fund.company`, `fund.series`, and `fund.share_class` all raise `AttributeError` instead of returning `None` (or the correct object), because `Fund.__init__` never assigns `self._company`/`self._series`/`self._class` in this case — violating both the properties' `Optional[...]` type hints and the [Fund Entities guide](https://edgartools.readthedocs.io/en/latest/guides/fund-entity-guide/)'s documented `FundCompany or None` / `FundSeries or None` / `FundClass or None` contract.

```python
>>> from edgar import Fund, set_identity
>>> set_identity("Your Name you@example.com")
>>> fund = Fund("CNEQ")   # does not raise
>>> fund.company
Traceback (most recent call last):
  ...
AttributeError: 'Fund' object has no attribute '_company'. Did you mean: 'company'?
```

Compare with a sibling ticker in the exact same trust that doesn't start with "C":
```python
>>> Fund("AWEG").company   # AWEG is a different share class of the same CIK 1807486 (Alger ETF Trust)
FundCompany(...)  # resolves correctly
```

### Root Cause

`Fund("CNEQ")` → `Fund.__init__` → `find_fund("CNEQ")` → `is_fund_class_ticker("CNEQ")` is `True` → routes to `get_fund_class("CNEQ")` → `get_fund_object("CNEQ")`. Inside `get_fund_object`, the fast path (`_build_hierarchy_from_mf_tickers`) correctly finds the underlying data row (`cik=1807486`, `seriesId=S000084280`, `classId=C000248577`, `ticker=CNEQ`) — but then fails to match it, because of this branch (present identically in both the fast path and the slow-path SEC-browse-edgar fallback):

```python
if identifier_type == 'Class':
    if identifier.startswith('C') and current_class.class_id == identifier:
        target_class = current_class
    elif not identifier.startswith('C') and current_class.ticker and current_class.ticker.upper() == identifier.upper():
        target_class = current_class
```

`identifier` is the **ticker** (`"CNEQ"`), not a Class ID. Real Class IDs look like `"C000248577"`. `identifier.startswith('C')` is being used as a proxy for "this is a Class ID," but any ticker that happens to start with "C" also satisfies it — so the code searches for `current_class.class_id == "CNEQ"` (never true) instead of taking the ticker-match branch (the `elif`), which never runs because its own guard (`not identifier.startswith('C')`) is `False`. `target_class` stays `None`, `get_fund_object` returns `None`, and `Fund.__init__`'s `isinstance` chain (which has no `else`) leaves `_company`/`_series`/`_class` unassigned entirely.

`get_fund_object` itself, one level up, already does this shape-check correctly: `re.match(r'^[CS]\d+$', identifier)`. The inner loop in both `_build_hierarchy_from_mf_tickers` and the slow-path fallback never reuses that check.

### Fix

Replace the naive prefix check with a proper Class-ID shape check, matching the pattern `get_fund_object` already uses correctly one level up. Applied identically to both occurrences (fast path and slow path) since they're currently duplicated verbatim.

**`edgar/funds/data.py`, inside `_build_hierarchy_from_mf_tickers()` (line 621):**
```diff
             if identifier_type == 'Class':
-                if identifier.startswith('C') and current_class.class_id == identifier:
+                if re.match(r'^C\d+$', identifier) and current_class.class_id == identifier:
                     target_class = current_class
-                elif not identifier.startswith('C') and current_class.ticker and current_class.ticker.upper() == identifier.upper():
+                elif not re.match(r'^C\d+$', identifier) and current_class.ticker and current_class.ticker.upper() == identifier.upper():
                     target_class = current_class
```

**`edgar/funds/data.py`, inside `get_fund_object()`'s slow-path fallback (line 713):**
```diff
             if identifier_type == 'Class':
-                if identifier.startswith('C') and current_class.class_id == identifier:
+                if re.match(r'^C\d+$', identifier) and current_class.class_id == identifier:
                     target_class = current_class
-                elif not identifier.startswith('C') and current_class.ticker and current_class.ticker.upper() == identifier.upper():
+                elif not re.match(r'^C\d+$', identifier) and current_class.ticker and current_class.ticker.upper() == identifier.upper():
                     target_class = current_class
```

`re` is already imported at the top of `data.py`, no new import needed. Note: a third `identifier.startswith('C')` occurrence exists in the same file, inside `resolve_fund_identifier()` (line 812) — that one is already correctly guarded (`identifier.startswith('C') and identifier[1:].isdigit()`) and was **not** changed; it isn't part of this bug (confirmed: it's absent from the actual diff applied to the branch).

### Optional complementary hardening (`edgar/funds/core.py`)

Independent of the fix above, `Fund.__init__`'s `isinstance` dispatch has no `else` branch, so if `find_fund()` ever returns something matching none of `FundClass`/`FundSeries`/`FundCompany` for *any* reason (this one or a future one), the instance silently ends up with `_company`/`_series`/`_class` never assigned, and the properties raise `AttributeError` instead of honoring their own "may be `None` if not resolved" docstrings. Adding an explicit `else` makes that contract actually hold:

```diff
         elif isinstance(self._entity, FundCompany):
             self._class = None
             self._series = None
             self._company = self._entity
+        else:
+            self._class = None
+            self._series = None
+            self._company = None
```

This is optional and orthogonal to the main fix above — the `data.py` fix alone resolves the reported bug for all tickers tested. This is defense-in-depth for any other, currently-unknown path that could leave `self._entity` unmatched. Both this and the `data.py` fix are applied together on the branch this PR would come from, but a maintainer could reasonably accept just the `data.py` change and drop this half if preferred — the two are independent.

### Testing Notes

Verified against a real, editable checkout of this branch (not just a scratch copy or the installed PyPI package), live against SEC data — not part of edgartools' own test suite;

**Before the fix:** `CNEQ`, `CIBR`, `CQQQ`, `COPX`, `CARZ`, `CALF`, `CGW`, `CATH`, `CUT` all raise `AttributeError` on `.company`.

**After the fix, all 9 resolve completely and correctly** — not just "no longer raises," the full company/series/class hierarchy comes back right:

| Ticker | `company.name` | `series.series_id` | `share_class.class_id` |
|---|---|---|---|
| `CNEQ` | Alger ETF Trust | S000084280 | C000248577 |
| `CIBR` | First Trust Exchange-Traded Fund II | S000050385 | C000159087 |
| `CQQQ` | Invesco Exchange-Traded Fund Trust II | S000060828 | C000197644 |
| `COPX` | Global X Funds | S000028727 | C000087858 |
| `CARZ` | First Trust Exchange-Traded Fund II | S000032974 | C000101722 |
| `CALF` | Pacer Funds Trust | S000055468 | C000174484 |
| `CGW` | Invesco Exchange-Traded Fund Trust II | S000060819 | C000197635 |
| `CATH` | Global X Funds | S000050646 | C000159972 |
| `CUT` | Invesco Exchange-Traded Fund Trust II | S000060818 | C000197634 |

**Regression-checked 8 previously-working tickers** with the fix applied: `QQQ`, `VTI`, `SPY`, and CNEQ's own trust siblings `FRTY`/`ATFV`/`AWEG`/`ALAI`/`INVN` — all unchanged.

**Regression-checked passing an actual Class ID directly** (rather than a ticker) still resolves correctly, since `re.match(r'^C\d+$', identifier)` matches real Class IDs the same way the old `identifier.startswith('C')` did: `Fund("C000248577")`, `Fund("C000159087")`, `Fund("C000101722")`, and `Fund("C000174484")` each resolve to the identical company/series/class as their ticker-based counterparts (`CNEQ`, `CIBR`, `CARZ`, `CALF` respectively), and `share_class.ticker` correctly round-trips back to the original ticker in each case.