### PR TITLE
fix: normalize MCP resource URIs

### DIFF
--- a/edgar/ai/mcp/server.py
+++ b/edgar/ai/mcp/server.py
@@ -41,6 +41,7 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import GetPromptResult, Prompt, TextContent
+from pydantic import AnyUrl
 
 # Set up logging
 logging.basicConfig(
@@ -211,14 +212,15 @@ async def list_resources() -> list[Resource]:
 
 
 @app.read_resource()
-async def read_resource(uri: str) -> str:
+async def read_resource(uri: AnyUrl) -> str:
     """Read a resource."""
-    if uri == "edgartools://docs/quickstart":
+    uri_string = str(uri)
+    if uri_string == "edgartools://docs/quickstart":
         return _get_quickstart_doc()
-    elif uri == "edgartools://docs/tools":
+    elif uri_string == "edgartools://docs/tools":
         return _get_tools_doc()
     else:
-        raise ValueError(f"Unknown resource: {uri}")
+        raise ValueError(f"Unknown resource: {uri_string}")
 
 
 @app.list_prompts()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,6 +8,7 @@ and routes tool calls.
 import json
 
 import pytest
+from pydantic import AnyUrl
 
 from edgar.ai.mcp.tools.base import ToolResponse, classify_error, error
 
@@ -122,6 +123,22 @@ class TestServerConfiguration:
         """main function is importable."""
         from edgar.ai.mcp.server import main
         assert callable(main)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("uri", "expected_heading"),
+        [
+            ("edgartools://docs/quickstart", "# EdgarTools MCP Quickstart"),
+            ("edgartools://docs/tools", "# EdgarTools MCP Tools Reference"),
+        ],
+    )
+    async def test_read_resource_accepts_mcp_any_url(self, uri, expected_heading):
+        """Resource handlers receive AnyUrl values from the MCP SDK."""
+        from edgar.ai.mcp.server import read_resource
+
+        content = await read_resource(AnyUrl(uri))
+
+        assert content.startswith(expected_heading)
 
 
 class TestToolResponseErrorCode:


### PR DESCRIPTION
## Summary

- accept the MCP SDK `AnyUrl` type in the resource handler
- normalize resource URIs to strings before matching known resources
- cover both documented resources with regression tests

## Problem

A standard MCP `ClientSession` can list both EdgarTools resources, but reading either listed URI fails with `Unknown resource`. The MCP SDK passes a Pydantic `AnyUrl` to registered resource handlers, and `AnyUrl` does not compare equal to the string literals currently used by the handler.

## Verification

- `pytest -q tests/test_mcp_server.py tests/test_mcp_intent_tools.py tests/test_ai_surface_verification.py` — 97 passed
- protocol-level stdio smoke test using `mcp.ClientSession` — both listed resources read successfully