### PR TITLE
feat(offerings): expose .sections on S-3 registration statements

### DIFF
--- a/edgar/documents/form_schema.py
+++ b/edgar/documents/form_schema.py
@@ -981,6 +981,12 @@ FOUR24B_SCHEMA = FormSchema(section_patterns=_S1_SECTION_PATTERNS, title_based=T
 # 424B, dissolving the same content-bleed by construction. Item forms keep
 # title_based=False and are untouched.
 S1_SCHEMA = FormSchema(section_patterns=_S1_SECTION_PATTERNS, title_based=True)
+# S-3 shelf registration statements are title-based prospectuses too (gh-877).
+# They incorporate financials by reference and run shorter than S-1s, but the
+# narrative titles (Risk Factors, Use of Proceeds, Plan of Distribution, ...) are
+# the same Reg S-K vocabulary, so S-3 reuses the shared prospectus patterns and
+# routes through the TOC engine exactly like S-1 / 424B.
+S3_SCHEMA = FormSchema(section_patterns=_S1_SECTION_PATTERNS, title_based=True)
 # DEF 14A / PRE 14A proxy statements (edgartools-x341 / gh-867). title_based=True
 # routes proxies through the TOC title engine. The flip was HELD until the proxy
 # failure modes were solved — body back-references (authoritative-TOC selection,
@@ -1004,6 +1010,9 @@ _SCHEMAS: Dict[str, FormSchema] = {
     "424B": FOUR24B_SCHEMA,
     "S-1": S1_SCHEMA,
     "S-1/A": S1_SCHEMA,
+    "S-3": S3_SCHEMA,
+    "S-3/A": S3_SCHEMA,
+    "S-3ASR": S3_SCHEMA,
     "DEF 14A": DEF14A_SCHEMA,
     "PRE 14A": DEF14A_SCHEMA,
 }

--- a/edgar/offerings/prospectus/registration_s3.py
+++ b/edgar/offerings/prospectus/registration_s3.py
@@ -19,23 +19,24 @@ from __future__ import annotations
 
 import logging
 from functools import cached_property
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
 from rich import box
 from rich.console import Group, Text
 from rich.panel import Panel
 from rich.table import Table
 
-from edgar.richtools import repr_rich
 # Re-imported here so `from edgar.offerings.prospectus.registration_s3 import S3CoverPage,
 # S3OfferingType, _is_checked, _extract_s3_cover_page` keeps resolving.
 from edgar.offerings.prospectus._s3_cover import (
-    S3OfferingType,
     S3CoverPage,
-    _is_checked,
-    _extract_s3_cover_page,
+    S3OfferingType,
     _classify_s3_offering,
+    _extract_s3_cover_page,
+    _is_checked,  # noqa: F401  re-exported for backwards compatibility
 )
+from edgar.offerings.prospectus._sections import ProspectusSectionsMixin
+from edgar.richtools import repr_rich
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ __all__ = ['RegistrationS3', 'S3OfferingType', 'S3CoverPage']
 # Main class
 # ---------------------------------------------------------------------------
 
-class RegistrationS3:
+class RegistrationS3(ProspectusSectionsMixin):
     """
     Data object for S-3 registration statement filings.
 
@@ -66,6 +67,7 @@ class RegistrationS3:
         s3.offering_type       -> S3OfferingType enum
         s3.fee_table           -> RegistrationFeeTable | None
         s3.total_offering      -> float | None (total registered amount)
+        s3.sections            -> Sections (Reg S-K narrative sections)
         s3.takedowns           -> Filings (424B filings under this shelf)
     """
 
@@ -197,6 +199,23 @@ class RegistrationS3:
         return []
 
     # ------------------------------------------------------------------
+    # Section-scoped text access (see ProspectusSectionsMixin: .sections / .section)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def _document(self):
+        """Parsed document backing ``.sections``.
+
+        ``filing.parse()`` seeds the parser with the S-3 form, which routes the
+        filing through the title-based section engine (see ``S3_SCHEMA`` in
+        ``edgar.documents.form_schema``).
+        """
+        try:
+            return self._filing.parse()
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
     # Lifecycle navigation
     # ------------------------------------------------------------------
 
@@ -320,6 +339,7 @@ class RegistrationS3:
             lines.append("  - .cover_page -> S3CoverPage (filer info, checkboxes)")
             lines.append("  - .fee_table -> RegistrationFeeTable (offering capacity)")
             lines.append("  - .total_offering -> float (total registered amount)")
+            lines.append("  - .sections -> Sections (risk_factors, use_of_proceeds, plan_of_distribution, ...; .section(name).text())")
             lines.append("  - .takedowns -> Filings (424B filings under this shelf)")
             lines.append("  - .related_filings -> Filings (all filings, same file number)")
 

--- a/tests/cassettes/TestS3SectionsGroundTruth.test_s3_sections_ground_truth.yaml
+++ b/tests/cassettes/TestS3SectionsGroundTruth.test_s3_sections_ground_truth.yaml
@@ -1,0 +1,3202 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - www.sec.gov
+    method: GET
+    uri: https://www.sec.gov/Archives/edgar/data/1827087/000119312525067858/0001193125-25-067858.txt
+  response:
+    body:
+      string: "<SEC-DOCUMENT>0001193125-25-067858.txt : 20250331\n<SEC-HEADER>0001193125-25-067858.hdr.sgml
+        : 20250331\n<ACCEPTANCE-DATETIME>20250331074630\nACCESSION NUMBER:\t\t0001193125-25-067858\nCONFORMED
+        SUBMISSION TYPE:\tS-3\nPUBLIC DOCUMENT COUNT:\t\t5\nFILED AS OF DATE:\t\t20250331\nDATE
+        AS OF CHANGE:\t\t20250331\n\nFILER:\n\n\tCOMPANY DATA:\t\n\t\tCOMPANY CONFORMED
+        NAME:\t\t\tVigil Neuroscience, Inc.\n\t\tCENTRAL INDEX KEY:\t\t\t0001827087\n\t\tSTANDARD
+        INDUSTRIAL CLASSIFICATION:\tBIOLOGICAL PRODUCTS (NO DIAGNOSTIC SUBSTANCES)
+        [2836]\n\t\tORGANIZATION NAME:           \t03 Life Sciences\n\t\tEIN:\t\t\t\t000000000\n\t\tSTATE
+        OF INCORPORATION:\t\t\tDE\n\t\tFISCAL YEAR END:\t\t\t1231\n\n\tFILING VALUES:\n\t\tFORM
+        TYPE:\t\tS-3\n\t\tSEC ACT:\t\t1933 Act\n\t\tSEC FILE NUMBER:\t333-286243\n\t\tFILM
+        NUMBER:\t\t25788955\n\n\tBUSINESS ADDRESS:\t\n\t\tSTREET 1:\t\t100 FORGE ROAD\n\t\tSTREET
+        2:\t\tSUITE 700\n\t\tCITY:\t\t\tWATERTOWN\n\t\tSTATE:\t\t\tMA\n\t\tZIP:\t\t\t02472\n\t\tBUSINESS
+        PHONE:\t\t857-254-4445\n\n\tMAIL ADDRESS:\t\n\t\tSTREET 1:\t\t100 FORGE ROAD\n\t\tSTREET
+        2:\t\tSUITE 700\n\t\tCITY:\t\t\tWATERTOWN\n\t\tSTATE:\t\t\tMA\n\t\tZIP:\t\t\t02472\n</SEC-HEADER>\n<DOCUMENT>\n<TYPE>S-3\n<SEQUENCE>1\n<FILENAME>d832814ds3.htm\n<DESCRIPTION>S-3\n<TEXT>\n<HTML><HEAD>\n<TITLE>S-3</TITLE>\n</HEAD>\n
+        <BODY BGCOLOR=\"WHITE\" STYLE=\"line-height:Normal\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>As filed
+        with the Securities and Exchange Commission on March&nbsp;31, 2025 </B></P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\" ALIGN=\"right\"><B>Registration No.&nbsp;333-&#8195;&#8195;&#8195;
+        </B></P> <P STYLE=\"font-size:2pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<P
+        STYLE=\"line-height:1.0pt;margin-top:0pt;margin-bottom:0pt;border-bottom:1px
+        solid #000000\">&nbsp;</P> <P STYLE=\"line-height:3.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1px
+        solid #000000\">&nbsp;</P>\n<P STYLE=\"margin-top:2pt; margin-bottom:0pt;
+        font-size:16pt; font-family:Times New Roman\" ALIGN=\"center\"><B>UNITED STATES
+        </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:16pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>SECURITIES\nAND EXCHANGE COMMISSION </B></P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>Washington, D.C. 20549 </B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"margin-top:3pt; margin-bottom:0pt;
+        font-size:16pt; font-family:Times New Roman\" ALIGN=\"center\"><B>FORM <FONT\nSTYLE=\"white-space:nowrap\">S-3</FONT>
+        </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:16pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>REGISTRATION STATEMENT </B></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><I>UNDER
+        </I></B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><I>THE\nSECURITIES ACT OF
+        1933 </I></B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>
+        <P STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center>\n<P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:22pt; font-family:Times New Roman\" ALIGN=\"center\"><B>VIGIL
+        NEUROSCIENCE, INC. </B></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>(Exact name
+        of registrant as specified in its charter) </B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:7pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"50%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"48%\"></TD></TR>\n\n\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"top\" ALIGN=\"center\"><B>Delaware</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"top\" ALIGN=\"center\"><B><FONT STYLE=\"white-space:nowrap\">85-1880494</FONT></B></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:7pt\">\n<TD
+        VALIGN=\"top\" ALIGN=\"center\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\"><B>(State or
+        other jurisdiction of</B></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\"><B>incorporation
+        or organization)</B></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        ALIGN=\"center\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:7pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B>(I.R.S. Employer</B></P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>Identification Number)</B></P></TD></TR>\n</TABLE>
+        <P STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>100 Forge Road, Suite 700 </B></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Watertown,
+        MA 02472 </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:8pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B>(857) <FONT\nSTYLE=\"white-space:nowrap\">254-4445</FONT>
+        </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>(Address, including zip code, and telephone
+        number, including area code, of\nregistrant&#146;s principal executive offices)
+        </B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"margin-top:3pt; margin-bottom:0pt;
+        font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Ivana\nMagov&#269;evi&#263;-Liebisch
+        </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>100 Forge Road, Suite 700 </B></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Watertown,
+        MA 02472 </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:8pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B>(857) <FONT\nSTYLE=\"white-space:nowrap\">254-4445</FONT>
+        </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>(Name, address, including zip code, and telephone
+        number, including area code, of agent\nfor service) </B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>
+        <P STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center>\n<P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B><I>Copies
+        to: </I></B></P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"99%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:8pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"50%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"48%\"></TD></TR>\n\n\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"top\" ALIGN=\"center\"><B>Kingsley L. Taft, Esq.</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"top\" ALIGN=\"center\"><B>Michael A. Cohen</B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>Jacqueline
+        Mercier, Esq.</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        ALIGN=\"center\"><B>VP, Associate General Counsel</B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>Gabriela
+        Morales-Rivera, Esq.</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        ALIGN=\"center\"><B>Vigil Neuroscience, Inc.</B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>Goodwin
+        Procter LLP</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        ALIGN=\"center\"><B>100 Forge Road, Suite 700</B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>100
+        Northern Avenue</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        ALIGN=\"center\"><B>Watertown, MA 02472</B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>Boston,
+        MA 02210</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>(857)
+        <FONT STYLE=\"white-space:nowrap\">254-4445</FONT></B></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"><B>(617)
+        <FONT STYLE=\"white-space:nowrap\">570-1000</FONT></B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"top\"></TD></TR>\n</TABLE> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>
+        <P STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center>\n<P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\">Approximate
+        date of commencement proposed sale to the public: From time to time after
+        the effective date of this Registration Statement. </P>\n<P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\">If the only
+        securities being registered on this Form are being offered pursuant to dividend
+        or interest reinvestment plans, please check the following\nbox.&#8194;&#9744;
+        </P> <P STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\">If any of the securities being registered on this Form are to
+        be offered on a delayed or continuous basis pursuant to Rule 415 under the\nSecurities
+        Act of 1933, other than securities offered only in connection with dividend
+        or interest reinvestment plans, check the following box.&#8194;&#9746; </P>\n<P
+        STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\">If this Form is filed to register additional securities for an
+        offering pursuant to Rule 462(b) under the Securities Act, please check the
+        following box and\nlist the Securities Act registration statement number of
+        the earlier effective registration statement for the same offering.&#8194;&#9744;
+        </P> <P STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\">If this Form is\na post-effective amendment filed pursuant to
+        Rule 462(c) under the Securities Act, check the following box and list the
+        Securities Act registration statement number of the earlier effective registration
+        statement for the same offering.&#8194;&#9744;\n</P> <P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\">If this Form
+        is a registration statement pursuant to General Instruction I.D. or a post-effective
+        amendment thereto that shall become effective upon filing\nwith the Commission
+        pursuant to Rule 462(e) under the Securities Act, check the following box.&#8194;&#9744;
+        </P> <P STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\">If this Form is a post-effective amendment to\na registration
+        statement filed pursuant to General Instruction I.D. filed to register additional
+        securities or additional classes of securities pursuant to Rule 413(b) under
+        the Securities Act, check the following box.&#8194;&#9744; </P>\n<P STYLE=\"margin-top:3pt;
+        margin-bottom:0pt; font-size:8pt; font-family:Times New Roman\">Indicate by
+        check mark whether the registrant is a large accelerated filer, an accelerated
+        filer, a <FONT STYLE=\"white-space:nowrap\">non-accelerated</FONT>\nfiler,
+        a smaller reporting company, or an emerging growth company. See the definitions
+        of &#147;large accelerated filer,&#148; &#147;accelerated filer,&#148; &#147;smaller
+        reporting company&#148; and &#147;emerging growth company&#148; in Rule <FONT\nSTYLE=\"white-space:nowrap\">12b-2</FONT>
+        of the Exchange Act: </P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:8pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"16%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"59%\"></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"20%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"1%\"></TD>\n<TD WIDTH=\"2%\"></TD></TR>\n\n\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"bottom\">Large&nbsp;accelerated&nbsp;filer</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&#9744;</TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">Accelerated&nbsp;filer</TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&#9744;</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"bottom\">Non-accelerated
+        filer</TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&#9746;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\">Smaller&nbsp;reporting&nbsp;company</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&#9746;</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\">Emerging&nbsp;growth&nbsp;company</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&#9746;</TD></TR>\n</TABLE>
+        <P STYLE=\"margin-top:3pt; margin-bottom:0pt; font-size:8pt; font-family:Times
+        New Roman\">If an emerging growth company, indicate by check mark if the registrant
+        has elected not to use the extended transition period\nfor complying with
+        any new or revised financial accounting standards provided pursuant to Section&nbsp;7(a)(2)(B)
+        of Securities Act.&#8194;&#9744; </P> <P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"margin-top:3pt; margin-bottom:0pt;
+        font-size:8pt; font-family:Times New Roman\"><B>The Registrant hereby amends\nthis
+        Registration Statement on such date or dates as may be necessary to delay
+        its effective date until the Registrant shall file a further amendment which
+        specifically states that this Registration Statement shall thereafter become
+        effective in\naccordance with Section&nbsp;8(a) of the Securities Act of 1933
+        or until this Registration Statement shall become effective on such date as
+        the Commission, acting pursuant to said Section&nbsp;8(a), may determine.
+        </B></P>\n<P STYLE=\"font-size:3pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>
+        <P STYLE=\"line-height:1.0pt;margin-top:0pt;margin-bottom:0pt;border-bottom:1px
+        solid #000000\">&nbsp;</P>\n<P STYLE=\"line-height:3.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1px
+        solid #000000\">&nbsp;</P>\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <DIV STYLE=\"position:relative; overflow:visible; width:651pt;
+        height:30pt; transform-origin:bottom left; transform: rotate(-90deg) translate(-100%,
+        100%) translateX(30pt);\">\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Arial Narrow\"><FONT COLOR=\"#ff4338\"><B>The
+        information contained in this preliminary prospectus is not complete and may
+        be changed. Neither we nor the selling securityholder\nmay sell these securities
+        until the registration statement filed with the Securities and Exchange Commission
+        is effective. This preliminary prospectus is not an offer to sell these securities
+        and is not soliciting offers to buy these securities in\nany jurisdiction
+        where the offer or sale is not permitted. </B></FONT></P></DIV><DIV STYLE=\"position:relative;
+        overflow:visible; margin-left:48pt; margin-right:48pt; transform: translateY(-30pt);\">\n<p
+        STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"51%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"2%\"></TD>\n<TD WIDTH=\"47%\"></TD></TR>\n\n\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"><FONT COLOR=\"#ff4338\"><B>Preliminary Prospectus</B></FONT></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\" ALIGN=\"right\"><FONT
+        COLOR=\"#ff4338\"><B>Subject to Completion, dated March 31, 2025</B></FONT></TD></TR>\n</TABLE>
+        <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P> <P
+        STYLE=\"margin-top:0pt;margin-bottom:0pt\" ALIGN=\"center\">\n\n\n<IMG SRC=\"g832814g03g03.jpg\"
+        ALT=\"LOGO\" STYLE=\"width:1.36842in;height:0.75in;\">\n </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; font-size:18pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Up
+        to 5,376,340 Shares of Common Stock </B></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:18pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Offered
+        by the Selling Stockholder </B></P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">This
+        prospectus\nrelates to the offer and resale, from time to time, of up to 5,376,340
+        shares of our common stock, par value $0.0001 per share (the &#147;Common
+        Stock&#148;), issuable upon conversion of 537,634 shares of Series A\n<FONT
+        STYLE=\"white-space:nowrap\">Non-Voting</FONT> Convertible Preferred Stock,
+        par value $0.0001 per share (the &#147;Series A Preferred Stock&#148;), by
+        the selling stockholder identified in this prospectus, including its transferees,
+        pledgees or\ndonees or its respective successors. The shares of Series A Preferred
+        Stock were sold and issued to the selling stockholder in a private placement
+        on July&nbsp;1, 2024 pursuant to a Securities Purchase Agreement dated June&nbsp;27,
+        2024. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">The selling stockholder identified
+        in this prospectus may offer the shares of common stock pursuant to this prospectus
+        from time to time\nthrough public or private transactions at fixed prices,
+        at market prices prevailing at the time of sale, at prices related to prevailing
+        market prices or at privately negotiated prices. The selling stockholder may
+        sell shares to or through\nunderwriters, broker-dealers or agents, who may
+        receive compensation in the form of discounts, concessions or commissions
+        from the selling stockholder, the purchasers of the shares, or both. For additional
+        information on the methods of sale that may\nbe used by the selling stockholder,
+        see the section entitled &#147;Plan of Distribution&#148; on page 7. </P>
+        <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We are not selling any shares of\ncommon stock
+        under this prospectus and will not receive any proceeds from the sale by the
+        selling stockholder of such shares. We are paying the cost of registering
+        the shares of common stock covered by this prospectus as well as various related\nexpenses.
+        The selling stockholder is responsible for all selling commissions, transfer
+        taxes and other costs related to the offer and sale of its shares. </P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">You should carefully read this prospectus and
+        any amendments or supplements accompanying this prospectus, together with
+        any documents\nincorporated by reference herein or therein, before you make
+        your investment decision. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">The selling
+        stockholder may sell any, all or none\nof the securities offered by this prospectus
+        and we do not know when or in what amount the selling stockholder may sell
+        its common shares hereunder following the effective date of the registration
+        statement of which this prospectus forms a part.\n</P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">Our
+        common stock is listed on the Nasdaq Global Select Market under the symbol
+        &#147;VIGL.&#148; On March&nbsp;28, 2025 the closing price\nfor our common
+        stock, as reported on the Nasdaq Global Select Market, was $1.91 per share.
+        </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We may amend or supplement this prospectus\nfrom
+        time to time by filing amendments or supplements as required. You should read
+        this prospectus, together with additional information described under the
+        headings &#147;<A HREF=\"#tx832814_13\">Where You Can Find Additional Information</A>&#148;\ncarefully
+        before you invest in any of our securities. </P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><center>\n<P
+        STYLE=\"line-height:6.0pt;margin-top:0pt;margin-bottom:2pt;border-bottom:1.00pt
+        solid #000000;width:21%\">&nbsp;</P></center> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; font-size:11pt; font-family:Times New Roman\"><B>INVESTING
+        IN OUR SECURITIES\nINVOLVES RISKS. PLEASE CAREFULLY READ THE INFORMATION UNDER
+        THE HEADINGS &#147;<A HREF=\"#tx832814_5\">RISK FACTORS</A>&#148; BEGINNING
+        ON PAGE 1 OF THIS PROSPECTUS AND &#147;ITEM 1A &#150; RISK FACTORS&#148; OF
+        OUR MOST RECENT REPORT ON FORM <FONT\nSTYLE=\"white-space:nowrap\">10-K</FONT>
+        OR <FONT STYLE=\"white-space:nowrap\">10-Q</FONT> THAT IS INCORPORATED BY
+        REFERENCE IN THIS PROSPECTUS BEFORE YOU INVEST IN OUR SECURITIES. </B></P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\"><B>Neither the Securities and Exchange Commission nor any state
+        securities commission has approved or disapproved of these securities or determined
+        if this\nprospectus is truthful or complete. Any representation to the contrary
+        is a criminal offense. </B></P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Prospectus\ndated&#8195;&#8195;&#8195;&#8195;,
+        2025 </B></P></DIV> <p STYLE=\"clear:both; font-size:1pt; height:0\">&nbsp;</p>\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"toc\"></A>TABLE
+        OF CONTENTS </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:8pt;
+        font-family:Times New Roman\" ALIGN=\"right\"><B>Page </B></P> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"96%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD></TR>\n\n\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em;
+        text-indent:-1.00em; font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_1\">About
+        This Prospectus</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">ii</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_2\">Cautionary
+        Note Regarding Forward Looking Statements</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">iii</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_3\">Prospectus
+        Summary</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">iv</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_4\">The
+        Offering</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">viii</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_5\">Risk
+        Factors</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">1</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_6\">Use
+        of Proceeds</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">2</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_7\">Dividend
+        Policy</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">3</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em;
+        text-indent:-1.00em; font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_8\">Selling
+        Stockholders</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">4</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_9\">Description
+        of Capital Stock</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">6</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_10\">Plan
+        of Distribution</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">7</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_11\">Legal
+        Matters</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">9</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_12\">Experts</A></P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">9</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em;
+        text-indent:-1.00em; font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_13\">Where
+        You Can Find Additional Information</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">9</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\"><A HREF=\"#tx832814_14\">Incorporation
+        of Documents By Reference</A></P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">9</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n</TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">i </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_1\"></A>ABOUT
+        THIS PROSPECTUS </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">We urge you to read carefully
+        this prospectus, together with the information incorporated herein by reference
+        as described under the heading\n&#147;Where You Can Find Additional Information,&#148;
+        before buying any of the securities being offered. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">You
+        should rely only on the\ninformation contained or incorporated by reference
+        in this prospectus. The selling stockholder has not authorized any other person
+        to provide you with different information. If anyone provides you with different
+        or inconsistent information, you\nshould not rely on it. This prospectus may
+        only be used where it is legal to offer and sell shares of our common stock.
+        If it is against the law in any jurisdiction to make an offer to sell these
+        shares, or to solicit an offer from someone to buy\nthese shares, then this
+        prospectus does not apply to any person in that jurisdiction, and no offer
+        or solicitation is made by this prospectus to any such person. You should
+        assume that the information appearing in this prospectus is accurate only
+        as\nof the date on the front cover of this prospectus, regardless of the time
+        of delivery of this prospectus or of any sale of common stock. Our business,
+        financial condition, results of operations and prospects may have changed
+        since such date.\nInformation contained on our website is not a part of this
+        prospectus. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">Neither we nor the selling stockholder
+        have authorized any person\nto provide you any information or to make any
+        representations other than those contained in this prospectus or any applicable
+        prospectus supplement or any free writing prospectuses prepared by or on behalf
+        of us or to which we have referred you.\nNeither we nor the selling stockholder
+        take responsibility for, and can provide assurance as to the reliability of,
+        any other information that others may give you. Neither we nor the selling
+        stockholder are making an offer to sell these securities\nin any jurisdiction
+        where the offer or sale is not permitted. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">This
+        prospectus is part of a registration statement on Form <FONT\nSTYLE=\"white-space:nowrap\">S-3</FONT>
+        that we filed with the Securities and Exchange Commission (the &#147;SEC&#148;)
+        using the &#147;shelf&#148; registration process. Under this shelf registration
+        process, the selling stockholder hereunder may,\nfrom time to time, issue,
+        offer and sell, as applicable, the common stock described in this prospectus
+        in one or more offerings. The selling stockholder may use this prospectus
+        to sell up to an aggregate of 5,376,340 shares of common stock from time\nto
+        time through any means described in the section entitled &#147;Plan of Distribution.&#148;
+        We will not receive any proceeds from the sale by such selling stockholder
+        of the securities offered by it described in this prospectus. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        may also provide a prospectus supplement or post-effective amendment to the
+        registration statement to add information to, or update or\nchange information
+        contained in, this prospectus. Before purchasing any securities, you should
+        read both this prospectus and any applicable prospectus supplement or post-effective
+        amendment to the registration statement together with the additional\ninformation
+        to which we refer you in the section of this prospectus titled &#147;Where
+        You Can Find Additional Information.&#148; </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">Information
+        contained in this prospectus concerning the market and the industry in which
+        we compete, including our market position, general\nexpectations of market
+        opportunity and market size, is based on information from various third-party
+        sources, on assumptions made by us based on such sources and our knowledge
+        of the markets for our services and solutions. Any estimates provided\nherein
+        involve numerous assumptions and limitations, and you are cautioned not to
+        give undue weight to such information. Third-party sources generally state
+        that the information contained in such source has been obtained from sources
+        believed to be\nreliable; however, we have not verified the accuracy or completeness
+        of third-party data. The industry in which we operate is subject to a high
+        degree of uncertainty and risk. As a result, the estimates and market and
+        industry information provided\nin this prospectus are subject to change based
+        on various factors, including those described in the risk factors incorporated
+        herein in the sections entitled &#147;Risk Factors-Risks Related to Our Business&#148;
+        and &#147;Risks Related to Our\nCommon Stock&#148; and elsewhere in this prospectus.
+        </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">ii </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_2\"></A>CAUTIONARY
+        NOTE REGARDING FORWARD LOOKING STATEMENTS </B></P>\n<P STYLE=\"margin-top:10pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">This
+        prospectus and any accompanying prospectus or prospectus supplement and the
+        documents incorporated by reference herein and therein may\ncontain forward
+        looking statements that involve significant risks and uncertainties. All statements
+        other than statements of historical fact contained in this prospectus and
+        any accompanying prospectus supplement and the documents incorporated by\nreference
+        herein, including statements regarding future events, our future financial
+        performance, business strategy, and plans and objectives of management for
+        future operations, are forward-looking statements. We have attempted to identify\nforward-looking
+        statements by terminology including &#147;anticipates,&#148; &#147;believes,&#148;
+        &#147;can,&#148; &#147;continue,&#148; &#147;could,&#148; &#147;estimates,&#148;
+        &#147;expects,&#148; &#147;intends,&#148; &#147;may,&#148;\n&#147;plans,&#148;
+        &#147;potential,&#148; &#147;predicts,&#148; &#147;should,&#148; or &#147;will&#148;
+        or the negative of these terms or other comparable terminology. Although we
+        do not make forward looking statements unless we believe we have a\nreasonable
+        basis for doing so, we cannot guarantee their accuracy. These statements are
+        only predictions and involve known and unknown risks, uncertainties and other
+        factors, including the risks outlined under &#147;Risk Factors&#148; or elsewhere\nin
+        this prospectus and the documents incorporated by reference herein, which
+        may cause our or our industry&#146;s actual results, levels of activity, performance
+        or achievements expressed or implied by these forward-looking statements.
+        Moreover, we\noperate in a highly regulated, very competitive, and rapidly
+        changing environment. New risks emerge from time to time and it is not possible
+        for us to predict all risk factors, nor can we address the impact of all factors
+        on our business or the\nextent to which any factor, or combination of factors,
+        may cause our actual results to differ materially from those contained in
+        any forward-looking statements. </P>\n<P STYLE=\"margin-top:10pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">We have based
+        these forward-looking statements largely on our current expectations and assumptions
+        about future events and financial trends\nthat we believe may affect our financial
+        condition, results of operations, business strategy, short term and long term
+        business operations, and financial needs. These forward-looking statements
+        are subject to certain risks and uncertainties that\ncould cause our actual
+        results to differ materially from those reflected in the forward-looking statements.
+        Factors that could cause or contribute to such differences include, but are
+        not limited to, those discussed in this prospectus, and in\nparticular, the
+        risks discussed below and under the heading &#147;<A HREF=\"#tx832814_5\">Risk
+        Factors</A>&#148; and those discussed in other documents we file with the
+        SEC which are incorporated by reference herein. This prospectus, and any\naccompanying
+        prospectus or prospectus supplement, should be read in conjunction with the
+        consolidated financial statements for the fiscal years ended December&nbsp;31,
+        2024 and 2023 and related notes, which are incorporated by reference herein.
+        </P>\n<P STYLE=\"margin-top:10pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We undertake no obligation to revise or publicly
+        release the results of any revision to these forward-looking statements, except
+        as required\nby law. In light of the significant risks, uncertainties and
+        assumptions that accompany forward-looking statements, the forward-looking
+        events and circumstances discussed in this prospectus and any accompanying
+        prospectus or prospectus supplement\nmay not occur and actual results could
+        differ materially and adversely from those anticipated or implied in the forward-looking
+        statement. </P>\n<P STYLE=\"margin-top:10pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">You should not place undue reliance
+        on any forward-looking statement, each of which applies only as of the date
+        of this prospectus, or any\naccompanying prospectus or any prospectus supplement.
+        Except as required by law, we undertake no obligation to update or revise
+        publicly any of the forward-looking statements after the date of this prospectus
+        to conform our statements to actual\nresults or changed expectations. </P>
+        <P STYLE=\"margin-top:10pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Any forward-looking statement you read in this
+        prospectus, any accompanying prospectus, or any\nprospectus supplement or
+        any document incorporated by reference reflects our current views with respect
+        to future events and is subject to these and other risks, uncertainties and
+        assumptions relating to our operations, operating results, growth\nstrategy
+        and liquidity. You should not place undue reliance on these forward-looking
+        statements because such statements speak only as to the date when made. We
+        assume no obligation to publicly update or revise these forward-looking statements
+        for\nany reason, or to update the reasons actual results could differ materially
+        from those anticipated in these forward-looking statements, even if new information
+        becomes available in the future, except as otherwise required by applicable
+        law. You are\nadvised, however, to consult any further disclosures we make
+        on related subjects in our reports on our most recent Annual Report on Form
+        <FONT STYLE=\"white-space:nowrap\">10-K,</FONT> our subsequent Quarterly Reports
+        on Form <FONT\nSTYLE=\"white-space:nowrap\">10-Q,</FONT> and our Current Reports
+        on Form <FONT STYLE=\"white-space:nowrap\">8-K</FONT> filed with the SEC.
+        You should understand that it is not possible to predict or identify all risk
+        factors. Consequently, you should\nnot consider any such list to be a complete
+        set of all potential risks or uncertainties.</P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">iii </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_3\"></A>PROSPECTUS
+        SUMMARY </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\"><I>This summary highlights selected
+        information that is presented in greater detail elsewhere, or incorporated
+        by reference, in this\nprospectus. It does not contain all of the information
+        that may be important to you and your investment decision. Before investing
+        in our securities, you should carefully read this entire prospectus, including
+        the matters set forth in the section\ntitled &#147;Risk Factors&#148; and
+        the financial statements and related notes and other information that we incorporate
+        by reference herein, including our Annual Report on Form <FONT STYLE=\"white-space:nowrap\">10-K</FONT>
+        and our Quarterly Reports\non Form <FONT STYLE=\"white-space:nowrap\">10-Q.</FONT>
+        </I></P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\"><I>As used herein, and any amendment or supplement
+        hereto, unless otherwise\nindicated, &#147;we,&#148; &#147;us,&#148; &#147;our,&#148;
+        the &#147;Company,&#148; or &#147;Vigil&#148; means Vigil Neuroscience, Inc.
+        and, where appropriate, our subsidiary. </I></P>\n<P STYLE=\"margin-top:18pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\"><B>Overview
+        </B></P> <P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We are a clinical-stage\nbiotechnology company
+        dedicated to improving the lives of patients, caregivers, and families affected
+        by rare and common neurodegenerative diseases by pursuing the development
+        of disease-modifying therapeutics to restore the vigilance of microglia.\nMicroglia
+        are the sentinel immune cells of the brain and play a critical role in maintaining
+        central nervous system (&#147;CNS&#148;) health and responding to damage caused
+        by disease. Leveraging recent research implicating microglial dysfunction
+        in\nneurodegenerative diseases, we utilize a precision medicine approach to
+        develop a pipeline of therapeutic candidates, initially addressing genetically
+        defined patient subpopulations, that we believe will activate and restore
+        microglial function. Our\nfirst therapeutic candidates are designed to activate
+        Triggering Receptor Expressed on Myeloid Cells 2 (&#147;TREM2&#148;), a key
+        microglial receptor protein that mediates responses to environmental signals
+        in order to maintain brain health and\nwhose dysfunction is linked to neurodegeneration.
+        We have two clinical programs that are designed to target TREM2. Our lead
+        clinical candidate, iluzanebart, is a fully human monoclonal antibody (&#147;mAb&#148;)
+        TREM2 agonist that is currently being\nstudied in a Phase 2 clinical trial
+        in patients with adult-onset leukoencephalopathy with axonal spheroids and
+        pigmented glia (&#147;ALSP&#148;), a rare and fatal neurodegenerative disease.
+        We plan to report data from the Phase 2 trial in ALSP in\nthe second quarter
+        of 2025. Our second clinical candidate, <FONT STYLE=\"white-space:nowrap\">VG-3927,</FONT>
+        is an orally bioavailable small molecule TREM2 agonist that is being developed
+        for the potential treatment of Alzheimer&#146;s disease (AD).\nWe reported
+        Phase 1 data from our <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT> program
+        in January 2025 and plan to initiate a Phase 2 trial in AD patients in the
+        third quarter of 2025. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">Our lead clinical
+        candidate, iluzanebart, is currently being studied in IGNITE, a Phase 2 clinical
+        trial and the first-ever interventional\ntrial in ALSP patients. ALSP is a
+        rare, inherited, autosomal dominant neurological disease with high penetrance.
+        ALSP is caused by a <FONT STYLE=\"white-space:nowrap\"><FONT STYLE=\"white-space:nowrap\">loss-of-function</FONT></FONT>
+        mutation in the\nColony Stimulating Factor 1 Receptor (&#147;CSF1R&#148;),
+        a receptor that shares a common downstream signaling pathway with TREM2. Based
+        on analysis from the UK Biobank genome sequencing data published in Neurology
+        Genetics by Wade et al. (2024), we\nestimate the U.S. prevalence of ALSP to
+        be approximately 19,000 with an estimated combined EU and UK prevalence of
+        approximately 29,000. There are currently no approved therapies for ALSP,
+        underscoring the unmet need for people living with this\nserious, rapidly
+        progressing disease. The Food and Drug Administration (&#147;FDA&#148;) has
+        granted Fast Track designation and orphan drug designation for iluzanebart
+        for the treatment of ALSP. The European Commission has also granted orphan
+        drug\ndesignation for iluzanebart. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">In November
+        2023, we reported interim data from the ongoing Phase 2 IGNITE trial from
+        the first 6 patients\nfollowing 6 months of treatment with 20 mg/kg of iluzanebart.
+        These data further supported the favorable safety, tolerability, pharmacokinetics
+        (&#147;PK&#148;) and pharmacodynamics (&#147;PD&#148;) profile of iluzanebart
+        previously demonstrated in\nthe Phase 1 single ascending dose/multiple ascending
+        dose (&#147;SAD/MAD&#148;) trial of iluzanebart in healthy volunteers. Importantly,
+        iluzanebart demonstrated clear target engagement as measured by changes in
+        soluble TREM2 (&#147;sTREM2&#148;),\nsoluble CSF1R (&#147;sCSF1R&#148;), and
+        osteopontin/secreted phosphoprotein 1 (&#147;SPP1&#148;) in cerebral spinal
+        fluid (&#147;CSF&#148;). Individual ALSP patients treated with iluzanebart
+        also demonstrated directionally supportive changes in\nmagnetic resonance
+        imaging (&#147;MRI&#148;) and neurofilament light chain (&#147;NfL&#148;)
+        </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">iv </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\">\nbiomarkers. Enrollment for the Phase 2 IGNITE
+        trial was completed in March 2024 with 20 patients enrolled in the trial.
+        The final analysis from the Phase 2 IGNITE trial is planned for the second\nquarter
+        of 2025 and will include data from all patients at 12 months dosed with either
+        20 mg/kg or 40 mg/kg of iluzanebart. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">In addition\nto
+        IGNITE, we are also conducting ILLUMINATE, a natural history study of symptomatic
+        and prodromal carriers of CSF1R mutations that are pathogenic for ALSP. We
+        define individuals as being symptomatic if they have MRI evidence and three
+        or more\ncharacteristic clinical symptoms of ALSP or as being prodromal if
+        they have early MRI evidence of ALSP and less than three clinical symptoms.
+        The purpose of this study is to better characterize disease progression, inform
+        our clinical trial design,\nand facilitate recruitment into our clinical trials.
+        The ILLUMINATE study is focused on understanding MRI findings and certain
+        fluid biomarker levels in symptomatic ALSP participants and the potential
+        for those biomarkers to act as measurable\ndescriptors of ALSP disease pathophysiology
+        and progression. In November 2023, we reported findings from the ongoing ILLUMINATE
+        study. These results provided critical insights on MRI and fluid biomarkers
+        and how they present in ALSP. Specifically,\nsCSF1R levels were altered in
+        both prodromal and symptomatic ALSP patients, positioning this measure as
+        an emerging biomarker of ALSP disease pathology. Similarly, NfL levels were
+        highly elevated in symptomatic ALSP patients, suggesting this\nbiomarker may
+        be useful in characterizing active neurodegeneration in ALSP. These data also
+        showed that MRI measurements on ventricular volume and gray matter volume
+        are also emerging as measurable indicators of disease progression. Based on
+        <FONT\nSTYLE=\"white-space:nowrap\">12-month</FONT> data from ILLUMINATE we
+        have also observed a statistically significant correlation between MRI biomarkers
+        and cognitive changes. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">In addition
+        to iluzanebart, we are developing <FONT STYLE=\"white-space:nowrap\">VG-3927,</FONT>
+        our orally bioavailable small molecule TREM2\nagonist for the treatment of
+        common neurodegenerative diseases associated with microglial dysfunction,
+        with initial development for the treatment of AD. In January 2025, we reported
+        complete data from the Phase 1 clinical trial evaluating <FONT\nSTYLE=\"white-space:nowrap\">VG-3927</FONT>
+        for the potential treatment of AD. The Phase 1 SAD/MAD trial assessed the
+        safety, tolerability, PK, and PD of <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT>
+        across 14 cohorts, including 8 SAD cohorts of\nhealthy volunteers up to a
+        140 mg dose and 4 MAD cohorts of healthy volunteers up to a 50 mg dose. The
+        trial also included a multiple dose elderly cohort and a single dose cohort
+        of AD patients, including some participants who carry TREM2 or other\ngenetic
+        risk factors for AD. The trial enrolled a total of 115 participants with 89
+        participants receiving <FONT STYLE=\"white-space:nowrap\">VG-3927,</FONT>
+        including 34 participants that were 55 years of age and older. These data
+        demonstrated a\nfavorable safety and tolerability profile across all cohorts,
+        including the elderly cohort. All related adverse events were mild or moderate
+        in severity and self-resolving without drug discontinuations. No serious AEs
+        were reported. In addition, <FONT\nSTYLE=\"white-space:nowrap\">VG-3927</FONT>
+        was observed to be highly CNS penetrant with a favorable and predictable PK
+        profile that supports once-daily dosing. Importantly, <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT>
+        achieved a robust and\ndose-dependent reduction of sTREM2 of up to approximately
+        50% in the CSF demonstrating a strong PK/PD relationship, sustained target
+        engagement and TREM2 agonist activity. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">Genome wide
+        association studies (&#147;GWAS&#148;) have shown that a specific mutation
+        in a TREM2 variant (&#147;R47H&#148;) is one of the\nstrongest genetic risk
+        factors for AD, second in magnitude only to that associated with the apolipoprotein
+        E4 (&#147;ApoE4&#148;) genotype. We included genetic variants of TREM2 in
+        our Phase 1 trial, the data from which indicated that the PK profile\nand
+        sTREM2 reduction of <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT> observed
+        in AD patients were consistent with results from healthy volunteers and similar
+        across evaluated TREM2 and ApoE genetic variants supporting development in
+        AD across\ngenotypes. The PK profile and sTREM2 reduction observed in the
+        elderly cohort were also consistent with results from healthy volunteers.
+        Based on the Phase 1 results and preclinical profile of <FONT STYLE=\"white-space:nowrap\">VG-3927,</FONT>
+        we plan\nto advance a once-daily oral dose of 25 mg that fully engages the
+        desired pharmacology and expect to initiate the Phase 2 trial in the third
+        quarter of 2025. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\"><FONT STYLE=\"white-space:nowrap\">VG-3927</FONT>
+        has a novel mode of action that acts as both an agonist and a positive allosteric
+        modulator\n(&#147;PAM&#148;), which may amplify functional responses around
+        sites of pathology leading to strong modulation of microglia and potentially
+        greater neuroprotection. <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT>
+        is designed to enhance protective\nmicroglial responses to aggregated amyloid
+        and tau without increasing inflammation. In contrast to antibody TREM2 agonists,
+        <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT> maximizes receptor activation
+        and microglial function because it does not\nbind to sTREM2, which may increase
+        its access to the site of therapeutic action in AD. Additionally, <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT>
+        does not have an Fc </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">v </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\">\n(fragmented crystallizable region) domain,
+        which engages elements of the immune system that have been associated with
+        increased risk of amyloid-related imaging abnormalities (&#147;ARIA&#148;).\nCollectively
+        across preclinical and clinical data, these key differentiators create a compelling
+        profile for <FONT STYLE=\"white-space:nowrap\">VG-3927</FONT> as an investigational
+        next-generation therapy for the treatment of AD. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        believe our microglia focus, precision medicine approach, and pipeline, which
+        spans multiple modalities, strongly position us to become a\ndifferentiated
+        leader in the neurodegenerative therapeutic space. Over time, we plan to expand
+        our pipeline through internal discovery and development and/or through strategic
+        collaborations or alliances with academic organizations or pharmaceutical\nor
+        biotechnology companies. </P> <P STYLE=\"margin-top:18pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\"><B>Private Placement and Securities
+        Purchase Agreement </B></P>\n<P STYLE=\"margin-top:6pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">On June&nbsp;27,
+        2024, we entered into a securities purchase agreement with Aventis Inc. (&#147;Aventis&#148;),
+        the selling stockholder named\nin this prospectus, pursuant to which we sold
+        537,634 shares of Series A <FONT STYLE=\"white-space:nowrap\">Non-Voting</FONT>
+        Convertible Preferred Stock, par value $0.0001 per share (the &#147;Series
+        A Preferred Stock&#148;), which are convertible\ninto shares of common stock,
+        par value $0.0001 per, at a purchase price of $7.44 per share (on an <FONT
+        STYLE=\"white-space:nowrap\">as-converted</FONT> to common stock basis) for
+        gross proceeds of approximately $40.0&nbsp;million, in a private\nplacement.
+        The Series A Preferred Stock is convertible at the option of Aventis at any
+        time into 10 shares of common stock for each share of Series A Preferred Stock,
+        subject to appropriate adjustment in the event of any stock dividend, stock
+        split,\ncombination or other similar recapitalization. The Series A Preferred
+        Stock will not be convertible by Aventis to the extent Aventis or any of its
+        affiliates would beneficially own in excess of 4.99% (the &#147;Maximum Percentage&#148;)
+        of the\ncommon stock outstanding immediately after giving effect to such conversion.
+        Aventis may increase or decrease the Maximum Percentage to any other percentage
+        (not in excess of 19.99% of the issued and outstanding common stock immediately
+        after giving\neffect to the issuance of the common stock issuable upon conversion
+        of the Series A Preferred Stock) by delivering a written notice to us, provided
+        that (i)&nbsp;any such increase in the Maximum Percentage will not be effective
+        until the 61st day\nafter such notice is delivered to us and (ii)&nbsp;any
+        such increase or decrease does not apply to any other holder of Series A Preferred
+        Stock or the validity of any prior conversion of the Series A Preferred Stock.
+        </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">In connection with the private placement and
+        pursuant to the securities purchase agreement, we granted Aventis certain
+        registration rights for\nthe resale of the shares of common stock issuable
+        upon conversion of the Series A Preferred Stock. We agreed to file a registration
+        statement registering such shares with the Securities and Exchange Commission
+        (the &#147;SEC&#148;) no later than\nApril&nbsp;1, 2025 (the &#147;Filing
+        Date&#148;). We agreed to keep the registration statement continuously effective
+        from the date on which the SEC declares the registration statement effective
+        until the earlier of (a)&nbsp;the date as of which the\nregistrable shares
+        (as defined in the securities purchase agreement) have been sold pursuant
+        to the registration statement and (b)&nbsp;the date as of which no registrable
+        shares remain outstanding. We also agreed to certain piggyback registration\nrights
+        following the expiration of the Filing Date allowing holders to include their
+        unregistered conversion shares in underwritten secondary offerings that the
+        Company undertakes on behalf of holders of the Company&#146;s common stock.</P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Additionally, pursuant to the securities purchase
+        agreement, we granted Aventis a right of first negotiation for an exclusive
+        license, grant\nor transfer of rights to research, develop, manufacture and
+        commercialize the Company&#146;s small molecule TREM2 agonist program, including
+        our clinical candidate, <FONT STYLE=\"white-space:nowrap\">VG-3927.</FONT>
+        </P>\n<P STYLE=\"margin-top:18pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\"><B>Emerging Growth Company under the JOBS Act </B></P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        qualify as an &#147;emerging growth company&#148; as defined in the Jumpstart
+        our Business Startups Act of 2012 (the &#147;JOBS Act&#148;).\nAn emerging
+        growth company may take advantage of specified reduced reporting and other
+        burdens that are otherwise applicable generally to public companies. These
+        provisions include: </P>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">inclusion
+        of only two years, as compared to three years, of audited financial statements
+        in addition to any\nrequired unaudited interim financial statements with correspondingly
+        reduced &#147;Management&#146;s Discussion and Analysis of Financial Condition
+        and Results of Operations&#148; disclosure; </P></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">vi </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n\n<TABLE STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" BORDER=\"0\" CELLPADDING=\"0\"
+        CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style = \"page-break-inside:avoid\">\n<TD
+        WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\" VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD
+        WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">
+        <P ALIGN=\"left\" STYLE=\" margin-top:0pt ; margin-bottom:0pt; font-family:Times
+        New Roman; font-size:10pt\">an exemption from the auditor attestation requirement
+        in the assessment of our internal control over financial\nreporting pursuant
+        to the Sarbanes-Oxley Act of 2002 (the &#147;Sarbanes-Oxley Act&#148;); </P></TD></TR></TABLE>
+        <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">an exemption
+        from compliance with any new requirements adopted by the Public Company Accounting
+        Oversight Board\n(the &#147;PCAOB&#148;) requiring mandatory audit firm rotation;
+        </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">reduced disclosure
+        about executive compensation arrangements; and </P></TD></TR></TABLE>\n<P
+        STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">an exemption
+        from the requirement to seek <FONT STYLE=\"white-space:nowrap\">non-binding</FONT>
+        advisory votes on\nexecutive compensation or golden parachute arrangements.
+        </P></TD></TR></TABLE> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">We may take advantage of these
+        provisions until we are no\nlonger an emerging growth company. We will remain
+        an emerging growth company until the earliest of (1)&nbsp;the last day of
+        the fiscal year (a)&nbsp;following the fifth anniversary of the completion
+        of our initial public offering in January 2022,\n(b) in which we have total
+        annual gross revenue of at least $1.235&nbsp;billion or (c)&nbsp;in which
+        we are deemed to be a large accelerated filer, which means the market value
+        of our common stock that is held by\n<FONT STYLE=\"white-space:nowrap\">non-affiliates</FONT>
+        exceeds $700&nbsp;million as of the prior December 31st, and (2)&nbsp;the
+        date on which we have issued more than $1.0&nbsp;billion in <FONT STYLE=\"white-space:nowrap\">non-convertible</FONT>
+        debt\nduring the prior three-year period. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        have taken advantage of the reduced reporting requirements in this prospectus
+        and in the documents\nincorporated by reference into this prospectus. Accordingly,
+        the information contained herein may be different from the information you
+        receive from other public companies that are not emerging growth companies.
+        </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">The JOBS Act permits an emerging growth company
+        such as us to take advantage of an extended transition period to comply with
+        new or revised\naccounting standards applicable to public companies until
+        those standards would otherwise apply to private companies. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        are also a\n&#147;smaller reporting company&#148; meaning that the market
+        value of our stock held by <FONT STYLE=\"white-space:nowrap\">non-affiliates</FONT>
+        is less than $700&nbsp;million and our annual revenue was less than $100&nbsp;million
+        during the most\nrecently completed fiscal year. We may continue to be a smaller
+        reporting company if either (i)&nbsp;the market value of our stock held by
+        <FONT STYLE=\"white-space:nowrap\">non-affiliates</FONT> is less than $250&nbsp;million
+        or (ii)&nbsp;our annual\nrevenue was less than $100&nbsp;million during the
+        most recently completed fiscal year and the market value of our stock held
+        by <FONT STYLE=\"white-space:nowrap\">non-affiliates</FONT> is less than $700&nbsp;million.
+        If we are a smaller reporting\ncompany at the time we cease to be an emerging
+        growth company, we may continue to rely on exemptions from certain disclosure
+        requirements that are available to smaller reporting companies. Specifically,
+        as a smaller reporting company we may choose\nto present only the two most
+        recent fiscal years of audited financial statements in our Annual Report on
+        Form <FONT STYLE=\"white-space:nowrap\">10-K</FONT> and, similar to emerging
+        growth companies, smaller reporting companies have reduced disclosure\nobligations
+        regarding executive compensation. </P> <P STYLE=\"margin-top:18pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\"><B>Corporate Information </B></P>\n<P
+        STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We were incorporated under the laws of the State
+        of Delaware on June&nbsp;22, 2020 under the name &#147;Vigil Neuroscience,
+        Inc.&#148; Our\nprincipal corporate office is located at 100 Forge Road, Suite
+        700, Watertown, MA 02472, and our telephone number is (857) <FONT STYLE=\"white-space:nowrap\">254-4445.</FONT>
+        Our website address is www.vigilneuro.com. The information contained in, or\nthat
+        can be accessed through, our website is not incorporated by reference and
+        is not a part of this prospectus. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">vii </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_4\"></A>THE
+        OFFERING </B></P>\n<P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR VALIGN=\"TOP\">\n<TD
+        WIDTH=\"38%\"> <P STYLE=\" margin-top:0pt; margin-bottom:1pt; margin-left:2%;
+        text-indent:-2%; font-size:10pt; font-family:Times New Roman\">Securities
+        Offered by the Selling Stockholders </P></TD>\n<TD>Up to 5,376,340 shares
+        of common stock issuable upon the conversion of 537,634 shares of Series A
+        Preferred Stock. </TD></TR></TABLE> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR VALIGN=\"TOP\">\n<TD
+        WIDTH=\"38%\"> <P STYLE=\" margin-top:0pt; margin-bottom:1pt; margin-left:2%;
+        text-indent:-2%; font-size:10pt; font-family:Times New Roman\">Offering Price
+        </P></TD>\n<TD>The Selling Stockholder may sell all or a portion of the shares
+        of common stock issuable upon the conversion of shares of Series A Preferred
+        Stock through public or private transactions at prevailing market prices or
+        at privately negotiated\nprices </TD></TR></TABLE> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR VALIGN=\"TOP\">\n<TD
+        WIDTH=\"38%\"> <P STYLE=\" margin-top:0pt; margin-bottom:1pt; margin-left:2%;
+        text-indent:-2%; font-size:10pt; font-family:Times New Roman\">Use of Proceeds
+        </P></TD>\n<TD>We will not receive any proceeds from the sale of shares of
+        common stock by the selling stockholder pursuant to this prospectus. See &#147;Use
+        of Proceeds&#148; and Selling Shareholder&#148; </TD></TR></TABLE>\n<P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR VALIGN=\"TOP\">\n<TD
+        WIDTH=\"38%\"> <P STYLE=\" margin-top:0pt; margin-bottom:1pt; margin-left:2%;
+        text-indent:-2%; font-size:10pt; font-family:Times New Roman\">Nasdaq Global
+        Select Market Symbol </P></TD>\n<TD>&#147;VIGL&#148; </TD></TR></TABLE> <P
+        STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR VALIGN=\"TOP\">\n<TD
+        WIDTH=\"38%\"> <P STYLE=\" margin-top:0pt; margin-bottom:1pt; margin-left:2%;
+        text-indent:-2%; font-size:10pt; font-family:Times New Roman\">Risk Factors
+        </P></TD>\n<TD>Investing in our securities involves a high degree of risk.
+        See &#147;<A HREF=\"#tx832814_5\">Risk&nbsp;Factors</A>&#148; beginning on
+        page 1 of this prospectus for a discussion of factors you should carefully
+        consider before deciding to invest in\nour securities. </TD></TR></TABLE>
+        <P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">The selling stockholder named in this prospectus may offer and
+        sell up to 5,376,340 shares of our common stock. Throughout\nthis prospectus,
+        when we refer to the shares of our common stock being registered on behalf
+        of the selling stockholder for offer and resale, we are referring to the shares
+        of common stock issuable to the selling stockholder upon conversion of the\nSeries
+        A Preferred Stock issued in the private placement as described above. When
+        we refer to the selling stockholder in this prospectus, we are referring to
+        the selling stockholder identified in this prospectus and, as applicable,
+        its permitted\ntransferees or other <FONT STYLE=\"white-space:nowrap\"><FONT
+        STYLE=\"white-space:nowrap\">successors-in-interest</FONT></FONT> that may
+        be identified in a supplement to this prospectus or, if required, a post-effective
+        amendment to the registration\nstatement of which this prospectus is a part.
+        </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">viii </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_5\"></A>RISK
+        FACTORS </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">Investing in our common stock
+        involves a high degree of risk. You should carefully consider the risks and
+        uncertainties described below, and\nthe risk factors set forth under &#147;Risk
+        Factors&#148; in our Annual Report on Form <FONT STYLE=\"white-space:nowrap\">10-K</FONT>
+        and subsequently filed Quarterly Reports on Form <FONT STYLE=\"white-space:nowrap\">10-Q,</FONT>
+        which are incorporated\nby reference in this prospectus, together with all
+        other information included or incorporated by reference in this prospectus,
+        as updated by our subsequent filings under the Securities and Exchange Act
+        of 1934 (the &#147;Exchange Act&#148;), and the\nrisk factors and other information
+        contained in any applicable prospectus supplement, before making an investment
+        decision. The risks and uncertainties described below may not be the only
+        ones we face. If any of the risks actually occur, our\nbusiness, financial
+        condition, operating results, cash flows and prospects could be materially
+        and adversely affected. In that event, the market price of our common stock
+        could decline, and you could lose part or all of your investment. </P>\n<P
+        STYLE=\"margin-top:18pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\"><B>Risks Related to This Offering. </B></P>\n<P STYLE=\"margin-top:6pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\"><B><I>The
+        number of shares of common stock being registered for sale upon conversion
+        of the shares of Series A Preferred Stock is significant\nin relation to the
+        number of outstanding shares of our common stock. </I></B></P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        have filed a registration statement of which this\nprospectus is a part to
+        register the shares offered hereunder for sale into the public market by the
+        selling stockholder. Upon effectiveness of the registration statement, 5,376,340
+        shares of the common stock registered hereunder may be resold in\nthe public
+        market immediately without restriction. These shares represent a large number
+        of shares of our common stock and, if sold in the market all at once or at
+        about the same time, could depress the market price of our common stock during
+        the\nperiod the registration statement remains effective and could also affect
+        our ability to raise equity capital. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">1 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_6\"></A>USE
+        OF PROCEEDS </B></P>\n<P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">All of the shares of common
+        stock offered by the Selling Stockholder pursuant to this prospectus will
+        be sold by the Selling Stockholder for\nits respective account. We will not
+        receive any of the proceeds from these sales. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">The
+        Selling Stockholder will pay any underwriting\ndiscounts and commissions and
+        expenses incurred by them for brokerage, accounting, tax or legal services
+        or any other expenses incurred in disposing of the securities. We will bear
+        the costs, fees and expenses incurred in effecting the registration\nof the
+        shares covered by this prospectus, including all registration and filing fees,
+        Nasdaq listing fees and fees and expenses of our counsel and our independent
+        registered public accounting firm. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">2 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_7\"></A>DIVIDEND
+        POLICY </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">We have never declared or paid
+        cash dividends on our capital stock. We currently plan to retain all of our
+        future earnings, if any, to finance\nthe operation, development and growth
+        of our business. We do not expect to pay any cash dividends on our common
+        stock in the foreseeable future. Payment of future dividends, if any, will
+        be at the discretion of our board of directors and will depend\non our financial
+        condition, results of operations, capital requirements, restrictions contained
+        in current or future financing instruments, provisions of applicable law and
+        other factors the board deems relevant. Our ability to pay dividends on our\ncommon
+        stock may be restricted by the terms of any of our future indebtedness. </P>\n
+        <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P> <P
+        STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">3 </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_8\"></A>SELLING
+        STOCKHOLDERS </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">This prospectus covers the offer
+        and resale or other disposition of shares of our common stock by the selling
+        stockholder named below, and its\ndonees, pledgees, transferees or other <FONT
+        STYLE=\"white-space:nowrap\"><FONT STYLE=\"white-space:nowrap\">successors-in-interest,</FONT></FONT>
+        or interests in shares of such shares received after the date of this prospectus
+        from the selling\nstockholder as a gift, pledge, partnership distribution
+        or other transfer. The shares of common stock being offered by the selling
+        stockholder are those shares of common stock issuable upon conversion of the
+        Series A Preferred Stock previously\nissued to the selling stockholder. See
+        &#147;Prospectus Summary&#151; Private Placement and Stock Purchase Agreement&#148;
+        for additional information regarding the issuance of the Series A Preferred
+        Stock and the shares of common stock issuable upon\nconversion thereof. </P>
+        <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">The table below sets forth, to our knowledge,
+        information concerning the beneficial ownership of shares of our common\nstock
+        by the selling stockholder as of March&nbsp;31, 2025. The information in the
+        table below with respect to the selling stockholder has been obtained from
+        the selling stockholder. The selling stockholder may sell all, some or none
+        of the shares\nof common stock subject to this prospectus. See &#147;Plan
+        of Distribution&#148; as may be supplemented and amended from time to time.
+        We do not know how long the selling stockholder will hold the shares before
+        selling them, and we currently have no\nagreements, arrangements or understandings
+        with the selling stockholder regarding the sale or other disposition of any
+        of the shares. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">The\nnumber of shares of common
+        stock beneficially owned prior to the offering for the selling stockholder
+        includes (i)&nbsp;all shares of our common stock beneficially held by such
+        selling stockholder as of March&nbsp;31, 2025, (ii) the number of shares\nof
+        our common stock that may be offered under this prospectus, and (iii)&nbsp;the
+        number and percentage of our common stock beneficially owned by the selling
+        stockholder assuming all of the shares of our common stock registered hereunder
+        are sold.\nThe table below and footnotes assume that the selling stockholder
+        will sell all of the shares listed. However, because the selling stockholder
+        may sell all or some of the shares of common stock held or issuable to it
+        under this prospectus from time\nto time, or in another permitted manner,
+        we cannot assure you as to the actual number of shares of common stock that
+        will be sold by the selling stockholder or that will be held by the selling
+        stockholder after completion of any sales. The\npercentages of shares of common
+        stock owned after the offering are based on 49,122,759 shares of common stock
+        outstanding as of March&nbsp;1, 2025, which includes the shares of common
+        stock issuable upon conversion of the Series A Preferred Stock\npreviously
+        issued to the selling stockholder. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">Beneficial ownership
+        is determined in accordance with the rules of the SEC and includes\nvoting
+        or investment power with respect to our common stock. Generally, a person
+        &#147;beneficially owns&#148; shares of our common stock if the person has
+        or shares with others the right to vote those shares or to dispose of them,
+        or if the person\nhas the right to acquire voting or disposition rights within
+        60 days. The inclusion of any shares in this table does not constitute an
+        admission of beneficial ownership for any selling stockholder named below.
+        </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Information about the selling stockholder may
+        change over time. Any changed information will be set forth in an amendment
+        to the registration\nstatement or supplement to this prospectus, to the extent
+        required by law. </P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:8pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"43%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"bottom\" NOWRAP> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:8pt;
+        font-family:Times New Roman\"><B>Name of Selling</B></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; border-bottom:1.00pt solid #000000; display:table-cell;
+        font-size:8pt; font-family:Times New Roman; \"><B>Stockholder</B></P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"6\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Number of Shares of<BR>Common
+        Stock<BR>Beneficially Owned<BR>Prior to<BR>Offering<SUP STYLE=\"font-size:75%;
+        vertical-align:top\">(1)</SUP></B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Maximum&nbsp;Number&nbsp;of&nbsp;Shares&nbsp;of<BR>Common
+        Stock<BR>to be Offered Pursuant to<BR>this\nProspectus<SUP STYLE=\"font-size:75%;
+        vertical-align:top\">(2)</SUP></B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"6\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Number&nbsp;of&nbsp;Shares&nbsp;of<BR>Common
+        Stock<BR>Owned After<BR>Offering<SUP STYLE=\"font-size:75%; vertical-align:top\">(3)</SUP></B></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid ;
+        font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Number</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Percent</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD COLSPAN=\"2\" VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\" STYLE=\"border-bottom:1.00pt
+        solid #000000\"><B>Number</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Percent</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD></TR>\n\n\n<TR
+        BGCOLOR=\"#cceeff\" STYLE=\"page-break-inside:avoid ; font-family:Times New
+        Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em; font-size:10pt;
+        font-family:Times New Roman\">Aventis Inc.<SUP STYLE=\"font-size:75%; vertical-align:top\">(4)</SUP></P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">2,451,225</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">4.99</TD>\n<TD NOWRAP VALIGN=\"bottom\">%&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">5,376,340</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">&#151;&#8194;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">&#151;&#8194;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n</TABLE>
+        <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(1)</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman; \" ALIGN=\"left\">The selling
+        stockholder and its related entities own 537,634 shares of Series A Preferred
+        Stock convertible\ninto up 5,376,340 shares of common stock. The shares of
+        Series A Preferred Stock are subject to terms that limit conversion, if, after
+        such conversion, the holder and its affiliates would beneficially own more
+        than 4.99% of the number of shares of\ncommon stock then issued and outstanding
+        (which such percentage may </P></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">4 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n\n<TABLE STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" BORDER=\"0\" CELLPADDING=\"0\"
+        CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style = \"page-break-inside:avoid\">\n<TD
+        WIDTH=\"4%\">&nbsp;</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">\nbe increased
+        or decreased by the holder up, upon 61 days&#146; written notice, to a maximum
+        of 19.99%). As a result of the limitation in the previous sentence, for purposes
+        of the column entitled\n&#147;Shares of Common Stock Beneficially Owned Prior
+        to Offering&#148; in the table above, only 2,451,225 shares of common stock
+        issuable upon the conversion of shares of Series A Preferred Stock beneficially
+        owned by the selling stockholder are\nreflected. </TD></TR></TABLE>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(2)</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman; \" ALIGN=\"left\">The number
+        of shares of our common stock in the column &#147;Maximum Number of Shares
+        of Common Stock to be\nOffered Pursuant to this Prospectus&#148; represents
+        the shares of our common stock issuable upon conversion of the Series A Preferred
+        Stock, which the selling stockholder may at any time choose to convert into
+        shares of our common stock and\nthereafter offer and sell from time to time
+        under this prospectus. </P></TD></TR></TABLE>\n<TABLE STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" BORDER=\"0\" CELLPADDING=\"0\"
+        CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style = \"page-break-inside:avoid\">\n<TD
+        WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(3)</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">
+        <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman; \" ALIGN=\"left\">We do not know when or in what amounts the selling
+        stockholder may offer shares for sale. The selling\nstockholder might not
+        sell any or might sell all of the shares offered by this prospectus. Because
+        the selling stockholder may offer all or some of the shares pursuant to this
+        offering, and because, except as set forth elsewhere in this prospectus,\nthere
+        are currently no agreements, arrangements or understandings with respect to
+        the sale of any of the shares, we cannot estimate the number of the shares
+        that will be held by the selling stockholder after completion of the offering.
+        However, for\npurposes of this table, we have assumed that, after completion
+        of the offering, none of the shares covered by this prospectus will be held
+        by the selling stockholder. </P></TD></TR></TABLE>\n<TABLE STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" BORDER=\"0\" CELLPADDING=\"0\"
+        CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style = \"page-break-inside:avoid\">\n<TD
+        WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(4)</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">
+        <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman; \" ALIGN=\"left\">Consists of 2,451,225 shares of common stock
+        issuable upon conversion of Series A Preferred Stock owned by\nAventis Inc.,
+        a company organized and existing under the laws of Pennsylvania. Aventis Inc.
+        is a wholly owned subsidiary of Sanofi S.A., a French soci&eacute;t&eacute;
+        anonyme (limited liability company), which may be deemed to have voting and\ndispositive
+        power over the securities held by Aventis Inc. The address of Aventis Inc.
+        is c/o Sanofi &#150; Global Alliance Management, 450 Water Street, Cambridge,
+        MA 02141. </P></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">5 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_9\"></A>DESCRIPTION
+        OF CAPITAL STOCK </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">The description
+        of our common stock filed as Exhibit 4.3 to our Annual Report on Form <FONT
+        STYLE=\"white-space:nowrap\">10-K</FONT> for the\nfiscal year ended December&nbsp;31,
+        2024, filed with the SEC on March&nbsp;13, 2025 is incorporated herein by
+        reference. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">The description\nof our Series
+        A Convertible Preferred Stock set forth in Item 3.1 of our Current Report
+        on Form <FONT STYLE=\"white-space:nowrap\">8-K</FONT> filed with the SEC on
+        June&nbsp;27, 2024 is incorporated herein by reference. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">6 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_10\"></A>PLAN
+        OF DISTRIBUTION </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\"><B></B>The selling stockholder,
+        which as used herein includes donees, pledgees, transferees or other <FONT
+        STYLE=\"white-space:nowrap\"><FONT\nSTYLE=\"white-space:nowrap\">successors-in-interest</FONT></FONT>
+        selling shares of common stock or interests in shares of common stock received
+        after the date of this prospectus from a selling stockholder, may, from time
+        to time, sell, transfer, or\notherwise dispose of any or all of their any
+        or all of its shares of common stock or interests in shares of common stock
+        on any stock exchange, market or trading facility on which the shares are
+        traded or in private transactions. These dispositions\nmay be at fixed prices,
+        at prevailing market prices at the time of sale, at prices related to the
+        prevailing market price, at varying prices determined at the time of sale,
+        or at negotiated prices. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">The selling
+        stockholder may use any one or more of the following methods when disposing
+        of shares of common stock or interests therein: </P>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">ordinary
+        brokerage transactions and transactions in which the broker-dealer solicits
+        purchasers;\n</P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">block trades
+        in which the broker-dealer will attempt to sell the shares as agent, but may
+        position and resell a\nportion of the block as principal to facilitate the
+        transaction; </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">purchases
+        by a broker-dealer as principal and resale by the broker-dealer for its account;
+        </P></TD></TR></TABLE>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">an exchange
+        distribution in accordance with the rules of the applicable exchange; </P></TD></TR></TABLE>\n<P
+        STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">privately
+        negotiated transactions; </P></TD></TR></TABLE>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">short sales
+        effected after the date the registration statement of which this prospectus
+        is a part is declared\neffective by the SEC; </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">through the
+        writing or settlement of options or other hedging transactions, whether through
+        an options exchange\nor otherwise; </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">broker-dealers
+        may agree with the selling stockholder to sell a specified number of such
+        shares at a stipulated\nprice per share; </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">a combination
+        of any such methods of sale; and </P></TD></TR></TABLE>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any other
+        method permitted by applicable law. </P></TD></TR></TABLE>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">The
+        selling stockholder may, from time to time, pledge or grant a security interest
+        in some or all of the shares of common stock owned by them\nand, if they default
+        in the performance of its secured obligations, the pledgees or secured parties
+        may offer and sell the shares of common stock, from time to time, under this
+        prospectus, or under an amendment to this prospectus under Rule\n424(b)(3)
+        or other applicable provision of the Securities Act of 1933, as amended (the
+        &#147;Securities Act&#148;), amending the list of selling stockholder to include
+        the pledgee, transferee or other successors in interest as selling stockholder\nunder
+        this prospectus. The selling stockholder also may transfer the shares of common
+        stock in other circumstances, in which case the transferees, pledgees or other\n<FONT
+        STYLE=\"white-space:nowrap\"><FONT STYLE=\"white-space:nowrap\">successors-in-interest</FONT></FONT>
+        will be the selling stockholder for purposes of this prospectus. </P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">In connection with the sale of our common stock
+        or interests therein, the selling stockholder may enter into hedging transactions
+        with\nbroker-dealers or other financial institutions, which may in turn engage
+        in short sales of the common stock in the course of hedging the positions
+        they assume. The selling stockholder may also sell shares of our common stock
+        short and deliver these\nsecurities to close out its short positions, or loan
+        or pledge the common stock to broker-dealers that in turn may sell these securities.
+        The selling stockholder may also enter into option or other transactions with
+        broker-dealers or other financial\ninstitutions or the creation of one or
+        more derivative securities which require the delivery to such broker-dealer
+        or other financial institution of shares offered by this prospectus, which
+        shares such broker-dealer or other financial institution\nmay resell pursuant
+        to this prospectus (as supplemented or amended to reflect such transaction).
+        </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Broker-dealers engaged by the selling\nstockholder
+        may arrange for other broker-dealers to participate in sales. Broker-dealers
+        may receive commissions in the form of discounts, concessions or commissions
+        from the </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">7 </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\">\nselling stockholder or commissions from purchasers
+        of the shares of common stock for whom they may act as agent or to whom they
+        may sell as principal. Such commissions will be in amounts to be\nnegotiated,
+        but, except as set forth in a further prospectus supplement or an amendment
+        to this prospectus, in the case of an agency transaction not in excess of
+        a customary brokerage commission in compliance with FINRA Rule 2121; and in
+        the case of\na principal transaction, a markup or markdown in compliance with
+        FINRA Rule 2121.01 </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">The aggregate proceeds to the
+        selling stockholder\nfrom the sale of the common stock offered by them will
+        be the purchase price of the common stock less discounts or commissions, if
+        any. The selling stockholder reserves the right to accept and, together with
+        its agents from time to time, to reject,\nin whole or in part, any proposed
+        purchase of common stock to be made directly or through agents. We will not
+        receive any of the proceeds from this offering. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">The
+        selling stockholder also may resell all or a portion of the shares of common
+        stock in open market transactions in reliance upon Rule 144\nunder the Securities
+        Act, <U>provided</U> that they meet the criteria and conform to the requirements
+        of that rule, or another available exemption from the registration requirements
+        of the Securities Act. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">The selling
+        stockholder and any underwriters, broker-dealers or agents that participate
+        in the sale of the common stock or interests therein\nmay be &#147;underwriters&#148;
+        within the meaning of Section&nbsp;2(a)(11) of the Securities Act. Any discounts,
+        commissions, concessions or profit they earn on any resale of the shares may
+        be underwriting discounts and commissions under the\nSecurities Act. Selling
+        stockholder who are &#147;underwriters&#148; within the meaning of Section&nbsp;2(a)(11)
+        of the Securities Act will be subject to the prospectus delivery requirements
+        of the Securities Act. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">To the extent
+        required, the shares of our common stock to be sold, the names of the selling
+        stockholder, the respective purchase prices and\npublic offering prices, the
+        names of any agents, dealer or underwriter, and any applicable commissions
+        or discounts with respect to a particular offer will be set forth in an accompanying
+        prospectus supplement or, if appropriate, a post-effective\namendment to the
+        registration statement that includes this prospectus. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">In
+        order to comply with the securities laws of some states, if\napplicable, the
+        common stock may be sold in these jurisdictions only through registered or
+        licensed brokers or dealers. In addition, in some states the common stock
+        may not be sold unless it has been registered or qualified for sale or an
+        exemption\nfrom registration or qualification requirements is available and
+        is complied with. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">We have agreed to indemnify
+        the selling stockholder\nagainst certain liabilities, including liabilities
+        under the Securities Act and state securities laws, relating to the registration
+        of the shares offered by this prospectus. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        have agreed with the selling stockholder to use commercially reasonable efforts
+        to cause the registration statement of which this\nprospectus constitutes
+        a part to become effective and to remain continuously effective until the
+        earlier of (1)&nbsp;such time as all of the shares covered by this prospectus
+        have been disposed of pursuant to and in accordance with such registration\nstatement
+        or (2)&nbsp;the date that all the shares covered by this prospectus cease
+        to be &#147;Registrable Shares&#148; as defined in the securities purchase
+        agreement. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">8 </P>\n\n</DIV></Center>\n\n\n<p style=\"margin-top:1em;
+        margin-bottom:0em; page-break-before:always\"> </p>\n<HR SIZE=\"3\" style=\"COLOR:#999999\"
+        WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\" style=\"font-size:10pt;font-weight:bold\"><a
+        href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_11\"></A>LEGAL
+        MATTERS </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">The validity of the shares of
+        common stock offered hereby will be passed upon for us by Goodwin Procter
+        LLP, Boston, Massachusetts. </P>\n<P STYLE=\"margin-top:24pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_12\"></A>EXPERTS
+        </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">The financial statements incorporated in this
+        Prospectus by reference to the Annual Report on Form\n<FONT STYLE=\"white-space:nowrap\">10-K</FONT>
+        for the year ended December&nbsp;31, 2024 have been so incorporated in reliance
+        on the report (which contains an explanatory paragraph relating to the Company&#146;s
+        ability to continue as a going concern\nas described in Note 1 to the financial
+        statements) of PricewaterhouseCoopers LLP, an independent registered public
+        accounting firm, given on the authority of said firm as experts in auditing
+        and accounting. </P>\n<P STYLE=\"margin-top:24pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_13\"></A>WHERE
+        YOU CAN FIND ADDITIONAL INFORMATION </B></P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        file annual, quarterly and current reports, proxy statements and other information
+        with the SEC. Our SEC filings are available to the\npublic over the Internet
+        at the SEC&#146;s website at www.sec.gov and on our investor website at www.vigilneuro.com.
+        Our website is not a part of this prospectus and is not incorporated by reference
+        in this prospectus. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">This prospectus is part of a
+        registration statement that we have filed with the SEC. Certain information
+        in the registration statement has\nbeen omitted from this prospectus in accordance
+        with the rules of the SEC. For more detail about us and any securities that
+        may be offered by this prospectus, you may examine the registration statement
+        of which this prospectus forms a part,\nincluding its exhibits and schedules.
+        Statements contained in this prospectus as to the contents of any contract
+        or other document are not necessarily complete, and in each instance we refer
+        you to the copy of the contract or document filed as an\nexhibit to the registration
+        statement, each such statement being qualified in all respects by such reference.
+        </P>\n<P STYLE=\"margin-top:24pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B><A NAME=\"tx832814_14\"></A>INCORPORATION
+        OF DOCUMENTS BY REFERENCE </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">The SEC allows
+        us to incorporate by reference in this prospectus much of the information
+        we file with the SEC, which means that we can\ndisclose important information
+        to you by referring you to those publicly available documents. The information
+        that we incorporate by reference in this prospectus is considered to be part
+        of this prospectus. Because we are incorporating by reference\nfuture filings
+        with the SEC, this prospectus is continually updated and those future filings
+        may modify or supersede some of the information included or incorporated in
+        this prospectus. This means that you must look at all of the SEC filings that
+        we\nincorporate by reference to determine if any of the statements in this
+        prospectus or in any document previously incorporated by reference have been
+        modified or superseded. </P> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">Annual Report
+        on <A HREF=\"http://www.sec.gov/Archives/edgar/data/../../../ix?doc=/Archives/edgar/data/1827087/000095017025038329/vigl-20241231.htm\">Form\n
+        <FONT STYLE=\"white-space:nowrap\">10-K</FONT></A> for the fiscal year ended
+        December&nbsp;31, 2024, filed with the SEC on March&nbsp;13, 2025; </P></TD></TR></TABLE>
+        <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">The information
+        specifically incorporated by reference into our Annual Report on\n<FONT STYLE=\"white-space:nowrap\">Form&nbsp;10-K&nbsp;for</FONT>
+        the year ended December&nbsp;\n31, 2024 from our <A HREF=\"http://www.sec.gov/Archives/edgar/data/../../../ix?doc=/Archives/edgar/data/1827087/000119312525067733/d918323ddef14a.htm\">definitive&nbsp;proxy
+        statement</A>&nbsp;on Schedule 14A (other than information furnished rather\nthan
+        filed), which was filed with the SEC on March&nbsp;31, 2025; </P></TD></TR></TABLE>
+        <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">Current Report
+        on Form <FONT STYLE=\"white-space:nowrap\">8-K</FONT> filed with the SEC on
+        <A HREF=\"http://www.sec.gov/Archives/edgar/data/../../../ix?doc=/Archives/edgar/data/1827087/000119312525010817/d810501d8k.htm\">January\n<U></U>&nbsp;23,
+        2025</A>; and </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">The description
+        of our common stock contained in <A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000095017025038329/vigl-ex4_3.htm\">Exhibit\n
+        4.3</A> to our Form <FONT STYLE=\"white-space:nowrap\">10-K</FONT> for the
+        fiscal year ended December&nbsp;31, 2024, filed with the SEC on March&nbsp;13,
+        2025, including any amendments or reports filed for the purpose of updating
+        this description.\n</P></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">9 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">We also incorporate
+        by reference any filings made after the date of effectiveness of the\nregistration
+        statement with the SEC under Sections 13(a), 13(c), 14 or 15(d) of the Exchange
+        Act, except as to any portion of any future report or document that is not
+        deemed filed under such provisions, until the offering of the securities made
+        by\nthis prospectus is completed or terminated. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">You
+        may request a copy of these filings, at no cost, by writing or telephoning
+        us at the\nfollowing address or telephone number: </P> <P STYLE=\"margin-top:6pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">Vigil
+        Neuroscience, Inc. </P>\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\">100 Forge Road, Suite 700 </P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">Watertown, Massachusetts 02472 </P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">Attn:
+        Investor Relations </P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\">(857) <FONT\nSTYLE=\"white-space:nowrap\">254-4445</FONT>
+        </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">You may also access these documents, free of
+        charge on the SEC&#146;s website at www.sec.gov\nor on our website at www.vigilneuro.com.
+        Information contained on our website is not incorporated by reference into
+        this prospectus, and you should not consider any information on, or that can
+        be accessed from, our website as part of this prospectus\nor any accompanying
+        prospectus supplement. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">Notwithstanding
+        the foregoing, unless specifically stated to the contrary, information that
+        we\nfurnish (and that is not deemed &#147;filed&#148; with the SEC) under
+        Items 2.02 and 7.01 of any Current Report on Form <FONT STYLE=\"white-space:nowrap\">8-K,</FONT>
+        including the related exhibits under Item 9.01, is not incorporated by reference\ninto
+        this prospectus or the registration statement of which this prospectus is
+        a part. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">This prospectus is part of a
+        registration\nstatement we filed with the SEC. We have incorporated exhibits
+        into this registration statement. You should read the exhibits carefully for
+        provisions that may be important to you. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">You
+        should rely only on the information incorporated by reference or provided
+        in this prospectus or any prospectus supplement. We have not\nauthorized anyone
+        to provide you with different information. We are not making an offer of these
+        securities in any state where the offer is not permitted. You should not assume
+        that the information in this prospectus or in the documents incorporated\nby
+        reference is accurate as of any date other than the date on the front of this
+        prospectus or those documents. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">In accordance
+        with Rule\n412 of the Securities Act, any statement contained in a document
+        incorporated by reference herein shall be deemed modified or superseded to
+        the extent that a statement contained herein or in any other subsequently
+        filed document which also is or is\ndeemed to be incorporated by reference
+        herein modifies or supersedes such statement. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">10 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B>PART II
+        </B></P>\n<P STYLE=\"margin-top:6pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>INFORMATION NOT REQUIRED IN PROSPECTUS </B></P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\"><B>Item&#8201;14. Other Expenses of Issuance and Distribution.
+        </B></P>\n<P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">The following table sets forth the expenses
+        incurred or expected to be incurred in connection with the offering described
+        in this registration\nstatement and the private placement, other than placement
+        agent fees, all of which will be paid by us. All amounts are estimates except
+        the Securities and Exchange Commission&#146;s registration fee. </P>\n<P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"68%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"79%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD></TD>\n<TD></TD>\n<TD></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" COLSPAN=\"2\" ALIGN=\"center\" STYLE=\"border-bottom:1.00pt
+        solid #000000\"><B>Amount</B></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD></TR>\n\n\n<TR
+        BGCOLOR=\"#cceeff\" STYLE=\"page-break-inside:avoid ; font-family:Times New
+        Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em; font-size:10pt;
+        font-family:Times New Roman\">SEC registration fee</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">$</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">1,485.73</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\">Accounting fees and expenses</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">25,000.00</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR
+        BGCOLOR=\"#cceeff\" STYLE=\"page-break-inside:avoid ; font-family:Times New
+        Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em; font-size:10pt;
+        font-family:Times New Roman\">Legal fees and expenses</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">140,000.00</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"
+        margin-top:0pt ; margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em;
+        font-size:10pt; font-family:Times New Roman\">Miscellaneous fees and expenses</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">15,000.00</TD>\n<TD NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"font-size:1px; \">\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; border-top:1.00px
+        solid #000000\">&nbsp;</P></TD>\n<TD VALIGN=\"bottom\"> <P STYLE=\" margin-top:0pt
+        ; margin-bottom:0pt; border-top:1.00px solid #000000\">&nbsp;</P></TD>\n<TD>&nbsp;</TD></TR>\n<TR
+        BGCOLOR=\"#cceeff\" STYLE=\"page-break-inside:avoid ; font-family:Times New
+        Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; margin-left:1.00em; text-indent:-1.00em; font-size:10pt;
+        font-family:Times New Roman\">Total</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">$</TD>\n<TD NOWRAP VALIGN=\"bottom\" ALIGN=\"right\">181,485.73</TD>\n<TD
+        NOWRAP VALIGN=\"bottom\">&nbsp;</TD></TR>\n<TR STYLE=\"font-size:1px; \">\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\">
+        <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; border-top:3.00px double #000000\">&nbsp;</P></TD>\n<TD
+        VALIGN=\"bottom\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; border-top:3.00px
+        double #000000\">&nbsp;</P></TD>\n<TD>&nbsp;</TD></TR>\n</TABLE> <P STYLE=\"margin-top:18pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\"><B>Item&#8201;15.
+        Indemnification of Directors and Officers. </B></P>\n<P STYLE=\"margin-top:6pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">Section&nbsp;145
+        of the Delaware General Corporation Law, or DGCL, authorizes a corporation
+        to indemnify its directors and officers against\nliabilities arising out of
+        actions, suits and proceedings to which they are made or threatened to be
+        made a party by reason of the fact that they have served or are currently
+        serving as a director or officer to a corporation. The indemnity may cover\nexpenses
+        (including attorneys&#146; fees) judgments, fines and amounts paid in settlement
+        actually and reasonably incurred by the director or officer in connection
+        with any such action, suit or proceeding. Section&nbsp;145 permits corporations
+        to\npay expenses (including attorneys&#146; fees) incurred by directors and
+        officers in advance of the final disposition of such action, suit or proceeding.
+        In addition, Section&nbsp;145 provides that a corporation has the power to
+        purchase and maintain\ninsurance on behalf of its directors and officers against
+        any liability asserted against them and incurred by them in their capacity
+        as a director or officer, or arising out of their status as such, whether
+        or not the corporation would have the\npower to indemnify the director or
+        officer against such liability under Section&nbsp;145. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">We
+        have adopted provisions in our certificate\nof incorporation and bylaws that
+        limit or eliminate the personal liability of our directors to the fullest
+        extent permitted by the DGCL, as it now exists or may in the future be amended.
+        Consequently, a director will not be personally liable to us\nor our stockholders
+        for monetary damages or breach of fiduciary duty as a director, except for
+        liability for: </P> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any breach
+        of the director&#146;s duty of loyalty to us or our stockholders; </P></TD></TR></TABLE>\n<P
+        STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any act or
+        omission not in good faith or that involves intentional misconduct or a knowing
+        violation of law;\n</P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any unlawful
+        payments related to dividends or unlawful stock purchases, redemptions or
+        other distributions; or\n</P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any transaction
+        from which the director derived an improper personal benefit.</P></TD></TR></TABLE>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Similarly, our officers who at the time of an
+        act or omission as to which liability is asserted consented to or are deemed
+        to have consented\nto certain service of process rules under Delaware law
+        will not be personally liable to us or our stockholders for monetary damages
+        for any breach of fiduciary duties as officers, except for liability in connection
+        with: </P>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any breach
+        of their duty of loyalty to us or our stockholders; </P></TD></TR></TABLE>\n<P
+        STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any act or
+        omission not in good faith or that involves intentional misconduct or a knowing
+        violation of law;\n</P></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">II-1 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n\n<TABLE STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" BORDER=\"0\" CELLPADDING=\"0\"
+        CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style = \"page-break-inside:avoid\">\n<TD
+        WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\" VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD
+        WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">
+        <P ALIGN=\"left\" STYLE=\" margin-top:0pt ; margin-bottom:0pt; font-family:Times
+        New Roman; font-size:10pt\">any transaction from which they derived an improper
+        personal benefit; or </P></TD></TR></TABLE>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">any action
+        by or in the right of the corporation. </P></TD></TR></TABLE>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:4%; font-size:10pt; font-family:Times New Roman\">These
+        limitations of liability do not alter director liability under the federal
+        securities laws and do not affect the availability of\nequitable remedies
+        such as an injunction or rescission.</P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">In addition,
+        our bylaws provide that: </P>\n<P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">we will indemnify
+        our directors, officers and, in the discretion of our board of directors,
+        certain employees to\nthe fullest extent permitted by the DGCL, as it now
+        exists or may in the future be amended; and </P></TD></TR></TABLE> <P STYLE=\"font-size:6pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"5%\">&nbsp;</TD>\n<TD WIDTH=\"3%\"
+        VALIGN=\"top\" ALIGN=\"left\">&#149;</TD>\n<TD WIDTH=\"1%\" VALIGN=\"top\">&nbsp;</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P ALIGN=\"left\" STYLE=\" margin-top:0pt ;
+        margin-bottom:0pt; font-family:Times New Roman; font-size:10pt\">we will advance
+        reasonable expenses, including attorneys&#146; fees, to our directors and,
+        in the discretion of\nour board of directors, to our officers and certain
+        employees, in connection with legal proceedings relating to their service
+        for or on behalf of us, subject to limited exceptions. </P></TD></TR></TABLE>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">We have entered into indemnification agreements
+        with each of our directors and executive officers. These agreements provide
+        that we will\nindemnify each of our directors, our executive officers and,
+        at times, their affiliates to the fullest extent permitted by Delaware law.
+        We will advance expenses, including attorneys&#146; fees (but excluding judgments,
+        fines and settlement\namounts), to each indemnified director, executive officer
+        or affiliate in connection with any proceeding in which indemnification is
+        available and we will indemnify our directors and officers for any action
+        or proceeding arising out of that\nperson&#146;s services as a director or
+        officer brought on behalf of us or in furtherance of our rights. Additionally,
+        certain of our directors or officers may have certain rights to indemnification,
+        advancement of expenses or insurance provided by\ntheir affiliates or other
+        third parties, which indemnification relates to and might apply to the same
+        proceedings arising out of such director&#146;s or officer&#146;s services
+        as a director referenced herein. Nonetheless, we have agreed in the\nindemnification
+        agreements that our obligations to those same directors or officers are primary
+        and any obligation of such affiliates or other third parties to advance expenses
+        or to provide indemnification for the expenses or liabilities incurred\nby
+        those directors are secondary. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">We also maintain
+        general liability insurance which covers certain liabilities of our directors
+        and\nofficers arising out of claims based on acts or omissions in their capacities
+        as directors or officers, including liabilities under the Securities Act of
+        1933, as amended. </P>\n<P STYLE=\"margin-top:18pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\"><B>Item&#8201;16. Exhibits. </B></P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD WIDTH=\"90%\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"bottom\" NOWRAP
+        STYLE=\"border-bottom:1.00pt solid #000000\"><B>Exhibit<BR>Number</B></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"border-bottom:1.00pt
+        solid #000000\"> <P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:8pt;
+        font-family:Times New Roman\"><B>Description of Document</B></P></TD></TR>\n\n\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\" NOWRAP>&#8199;3.1</TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312522006732/d287585dex31.htm\">Third
+        Amended and Restated Certificate of Incorporation of the Registrant (incorporated
+        by reference to Exhibit 3.1 of the Registrant&#146;s Current\n Report on Form
+        <FONT STYLE=\"white-space:nowrap\">8-K</FONT> (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;001-41200)</FONT>
+        filed on January<U></U>&nbsp;11, 2022).</A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>&#8199;3.2</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312524156044/d675020dex31.htm\">Certificate
+        of Amendment to the Third Amended and Restated Certificate of Incorporation
+        (incorporated by reference to Exhibit 3.1 to the Registrant&#146;s\n Form
+        <FONT STYLE=\"white-space:nowrap\">8-K</FONT> (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;001-41200)</FONT>
+        filed on June<U></U>&nbsp;6, 2024). </A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>&#8199;3.3</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312524156044/d675020dex32.htm\">Amended
+        and Restated Bylaws of the Registrant (incorporated by reference to Exhibit
+        3.2 to the Registrant&#146;s Form <FONT\nSTYLE=\"white-space:nowrap\">8-K</FONT>
+        (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;001-41200)</FONT>
+        filed on June<U></U>&nbsp;6, 2024).</A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>&#8199;3.4</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312524170520/d792733dex31.htm\">Certificate
+        of Designation of Preferences, Rights and Limitations, of Series A <FONT STYLE=\"white-space:nowrap\">Non-Voting</FONT>
+        Convertible\n Preferred Stock, dated June<U></U>&nbsp;27, 2024. (incorporated
+        by reference to Exhibit 3.1 to the Registrant&#146;s Form <FONT STYLE=\"white-space:nowrap\">8-K</FONT>
+        (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;001-41200)</FONT>
+        filed on\nJune<U></U>&nbsp;27, 2024).</A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>&#8199;4.1</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312521335145/d186104dex41.htm\">Specimen
+        Common Stock Certificate (incorporated by reference to Exhibit 4.1 of the
+        Registrant&#146;s Registration Statement on Form <FONT\nSTYLE=\"white-space:nowrap\">S-1/A</FONT>
+        (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;333-261230)</FONT>
+        filed on January<U></U>&nbsp;3, 2022).</A></TD></TR></TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">II-2 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n\n<TABLE CELLSPACING=\"0\" CELLPADDING=\"0\"
+        WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times
+        New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"6%\"></TD>\n<TD WIDTH=\"90%\"></TD></TR>\n\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:8pt\">\n<TD
+        VALIGN=\"bottom\" NOWRAP STYLE=\"border-bottom:1.00pt solid #000000\"><B>Exhibit<BR>Number</B></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"border-bottom:1.00pt
+        solid #000000\"> <P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:8pt;
+        font-family:Times New Roman\"><B>Description of Document</B></P></TD></TR>\n\n\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\" NOWRAP>&#8199;4.2</TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"top\"><A HREF=\"http://www.sec.gov/Archives/edgar/data/1827087/000119312524170520/d792733dex101.htm\">Securities
+        Purchase Agreement, dated June<U></U>&nbsp;\n27, 2024, by and between Vigil
+        Neuroscience, Inc. and Aventis Inc. (incorporated by reference to Exhibit
+        10.1 to the Registrant&#146;s Form <FONT STYLE=\"white-space:nowrap\">8-K</FONT>
+        (File No.<U></U><FONT STYLE=\"white-space:nowrap\">&nbsp;\n001-41200)</FONT>
+        filed on June<U></U>&nbsp;27, 2024).</A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>&#8199;5.1*</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"d832814dex51.htm\">Opinion
+        of Goodwin Procter LLP </A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>23.1*</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"d832814dex231.htm\">Consent
+        of PricewaterhouseCoopers LLP, independent registered public accounting firm
+        </A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>23.2*</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"d832814dex51.htm\">Consent
+        of Goodwin Procter LLP (included in Exhibit 5.1) </A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"8\"></TD>\n<TD HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>24.1*</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"d832814ds3.htm#sig\">Power
+        of Attorney (included on the signature page to this Registration Statement)
+        </A></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"8\"></TD>\n<TD
+        HEIGHT=\"8\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" NOWRAP>107*</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\"><A HREF=\"d832814dexfilingfees.htm\">Filing
+        Fee Table </A></TD></TR>\n</TABLE> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"2%\" VALIGN=\"top\" ALIGN=\"left\">*</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman; \" ALIGN=\"left\">Filed herewith.
+        </P></TD></TR></TABLE>\n<P STYLE=\"margin-top:18pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\"><B>Item&#8201;17. Undertakings. </B></P> <P
+        STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">(a) The\nundersigned registrant hereby undertakes:
+        </P> <P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:9%; font-size:10pt;
+        font-family:Times New Roman\">(1) to file, during any period in which offers
+        or sales are being made, a post-effective\namendment to this registration
+        statement: </P> <P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:13%;
+        font-size:10pt; font-family:Times New Roman\">(i) to include any prospectus
+        required by Section&nbsp;10(a)(3) of the Securities Act; </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:13%; font-size:10pt; font-family:Times New
+        Roman\">(ii) to reflect in the prospectus any facts or events arising after
+        the effective date of the registration statement (or the most recent\npost-effective
+        amendment thereof) which, individually or in the aggregate, represent a fundamental
+        change in the information set forth in the registration statement. Notwithstanding
+        the foregoing, any increase or decrease in volume of securities\noffered (if
+        the total dollar value of securities offered would not exceed that which was
+        registered) and any deviation from the low or high end of the estimated maximum
+        offering range may be reflected in the form of prospectus filed with the\nCommission
+        pursuant to Rule 424(b) if, in the aggregate, the changes in volume and price
+        represent no more than a 20% change in the maximum aggregate offering price
+        set forth in the &#147;Calculation of Filing Fee Tables&#148; or &#147;Calculation\nof
+        Registration Fee&#148; table, as applicable, in the effective registration
+        statement; and </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:13%;
+        font-size:10pt; font-family:Times New Roman\">(iii) to include any material
+        information\nwith respect to the plan of distribution not previously disclosed
+        in the registration statement or any material change to such information in
+        the registration statement; </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\"><I>provided</I>, <I>however</I>,
+        that paragraphs (a)(1)(i), (a)(1)(ii) and (a)(1)(iii) do not apply if the
+        information required to be included in a\npost-effective amendment by those
+        paragraphs is contained in reports filed with or furnished to the Commission
+        by the registrant pursuant to Section&nbsp;13 or Section&nbsp;15(d) of the
+        Exchange Act that are incorporated by reference in the\nregistration statement,
+        or is contained in a form of prospectus filed pursuant to Rule 424(b) that
+        is part of the registration statement. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:9%; font-size:10pt; font-family:Times New Roman\">(2) that, for
+        the purpose of determining any liability under the Securities Act, each such
+        post-effective amendment shall be deemed to be a\nnew registration statement
+        relating to the securities offered therein, and the offering of such securities
+        at that time shall be deemed to be the initial <I>bona fide </I>offering thereof.
+        </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:9%; font-size:10pt;
+        font-family:Times New Roman\">(3) to remove from registration by means of
+        a post-effective amendment any of the securities being registered which remain
+        unsold at the\ntermination of the offering. </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:9%; font-size:10pt; font-family:Times New Roman\">(4)
+        that, for the purpose of determining liability under the Securities Act to
+        any purchaser: </P>\n<P STYLE=\"margin-top:6pt; margin-bottom:0pt; text-indent:13%;
+        font-size:10pt; font-family:Times New Roman\">(i) each prospectus filed by
+        the registrant pursuant to Rule 424(b)(3) shall be deemed to be part of the
+        registration statement as of the date\nthe filed prospectus was deemed part
+        of and included in the registration statement; and </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">II-3 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        text-indent:13%; font-size:10pt; font-family:Times New Roman\">(ii) each prospectus
+        required to be filed pursuant to Rule 424(b)(2), (b)(5), or (b)(7) as\npart
+        of a registration statement in reliance on Rule 430B relating to an offering
+        made pursuant to Rule 415(a)(1)(i), (vii) or (x)&nbsp;for the purpose of providing
+        the information required by Section&nbsp;10(a) of the Securities Act shall
+        be deemed\nto be part of and included in the registration statement as of
+        the earlier of the date such form of prospectus is first used after effectiveness
+        or the date of the first contract of sale of securities in the offering described
+        in the prospectus. As\nprovided in Rule 430B, for liability purposes of the
+        issuer and any person that is at that date an underwriter, such date shall
+        be deemed to be a new effective date of the registration statement relating
+        to the securities in the registration\nstatement to which that prospectus
+        relates, and the offering of such securities at that time shall be deemed
+        to be the initial <I>bona fide </I>offering thereof. <I>Provided, however</I>,
+        that no statement made in a registration statement or\nprospectus that is
+        part of the registration statement or made in a document incorporated or deemed
+        incorporated by reference into the registration statement or prospectus that
+        is part of the registration statement will, as to a purchaser with a time\nof
+        contract of sale prior to such effective date, supersede or modify any statement
+        that was made in the registration statement or prospectus that was part of
+        the registration statement or made in any such document immediately prior
+        to such\neffective date. </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:9%; font-size:10pt; font-family:Times New Roman\">(5) that, for
+        the purpose of determining liability of the registrant under the Securities
+        Act to any purchaser in the\ninitial distribution of the securities, the undersigned
+        registrant undertakes that in a primary offering of securities of the undersigned
+        registrant pursuant to this registration statement, regardless of the underwriting
+        method used to sell the\nsecurities to the purchaser, if the securities are
+        offered or sold to such purchaser by means of any of the following communications,
+        the undersigned registrant will be a seller to the purchaser and will be considered
+        to offer or sell such\nsecurities to such purchaser: </P> <P STYLE=\"margin-top:6pt;
+        margin-bottom:0pt; text-indent:13%; font-size:10pt; font-family:Times New
+        Roman\">(i) any preliminary prospectus or prospectus of the undersigned registrant
+        relating to the offering\nrequired to be filed pursuant to Rule 424; </P>
+        <P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:13%; font-size:10pt;
+        font-family:Times New Roman\">(ii) any free writing prospectus relating to
+        the offering prepared by or on behalf of the\nundersigned registrant or used
+        or referred to by the undersigned registrant; </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; text-indent:13%; font-size:10pt; font-family:Times New
+        Roman\">(iii) the portion of any other free writing prospectus\nrelating to
+        the offering containing material information about the undersigned registrant
+        or its securities provided by or on behalf of the undersigned registrant;
+        and </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:13%;
+        font-size:10pt; font-family:Times New Roman\">(iv) any other communication
+        that is an offer in the offering made by the undersigned registrant to the
+        purchaser. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:9%;
+        font-size:10pt; font-family:Times New Roman\">(6) that, for purposes of determining
+        any liability under the Securities Act, each filing of the registrant&#146;s
+        annual report pursuant to\nSection&nbsp;13(a) or 15(d) of the Exchange Act
+        (and, where applicable, each filing of an employee benefit plan&#146;s annual
+        report pursuant to Section&nbsp;15(d) of the Exchange Act) that is incorporated
+        by reference in the registration statement\nshall be deemed to be a new registration
+        statement relating to the securities offered therein, and the offering of
+        such securities at that time shall be deemed to be the initial <I>bona fide</I>
+        offering thereof. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%;
+        font-size:10pt; font-family:Times New Roman\">(b) Insofar as indemnification
+        for liabilities arising under the Securities Act may be permitted to directors,
+        officers and controlling\npersons of the registrant pursuant to the foregoing
+        provisions, or otherwise, the registrant has been advised that in the opinion
+        of the Commission such indemnification is against public policy as expressed
+        in the Securities Act and is, therefore,\nunenforceable. In the event that
+        a claim for indemnification against such liabilities (other than the payment
+        by the registrant of expenses incurred or paid by a director, officer or controlling
+        person of the registrant in the successful defense of\nany action, suit or
+        proceeding) is asserted by such director, officer or controlling person in
+        connection with the securities being registered, the registrant will, unless
+        in the opinion of its counsel the matter has been settled by controlling\nprecedent,
+        submit to a court of appropriate jurisdiction the question whether such indemnification
+        by it is against public policy as expressed in the Securities Act and will
+        be governed by the final adjudication of such issue. </P>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">II-4 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B><A NAME=\"sig\"></A>SIGNATURES
+        </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; text-indent:4%; font-size:10pt;
+        font-family:Times New Roman\">Pursuant to the requirements of the Securities
+        Act of 1933, as amended, the Registrant certifies that it has reasonable grounds
+        to believe\nthat it meets all of the requirements for filing on Form <FONT
+        STYLE=\"white-space:nowrap\">S-3</FONT> and has duly caused this Registration
+        Statement to be signed on its behalf by the undersigned, thereunto duly authorized,
+        in the City of Watertown,\nMassachusetts, on the 31<SUP STYLE=\"font-size:75%;
+        vertical-align:top\">st</SUP> day of March, 2025. </P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><DIV
+        ALIGN=\"right\">\n<TABLE CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"40%\"
+        BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman;
+        font-size:10pt\">\n\n\n<TR>\n\n<TD WIDTH=\"7%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"1%\"></TD>\n<TD WIDTH=\"92%\"></TD></TR>\n\n\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" COLSPAN=\"3\"><B>VIGIL
+        NEUROSCIENCE, INC.</B></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\">By:</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"top\" STYLE=\"BORDER-BOTTOM:1px solid #000000\"><I>/s/ Ivana Magov&#269;evi&#263;-Liebisch</I></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">Ivana
+        Magov&#269;evi&#263;-Liebisch, Ph.D., J.D.</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\">President and Chief Executive
+        Officer</TD></TR>\n</TABLE></DIV>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt
+        ; font-size:8pt\">&nbsp;</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">II-5 </P>\n\n</DIV></Center>\n\n\n<p
+        style=\"margin-top:1em; margin-bottom:0em; page-break-before:always\"> </p>\n<HR
+        SIZE=\"3\" style=\"COLOR:#999999\" WIDTH=\"100%\" ALIGN=\"CENTER\">\n<h5 align=\"left\"
+        style=\"font-size:10pt;font-weight:bold\"><a href=\"#toc\">Table of Contents</a></h5>\n\n\n<Center><DIV
+        STYLE=\"width:8.5in\" align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\"><B>POWER OF
+        ATTORNEY AND SIGNATURES </B></P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        text-indent:4%; font-size:10pt; font-family:Times New Roman\">KNOW ALL BY
+        THESE PRESENT, that each individual whose signature appears below hereby constitutes
+        and appoints Ivana\nMagov&#269;evi&#263;-Liebisch and Jennifer Ziolkowski
+        and as such person&#146;s true and lawful <FONT STYLE=\"white-space:nowrap\"><FONT
+        STYLE=\"white-space:nowrap\">attorney-in-fact</FONT></FONT> and agent with
+        full power of substitution and\nresubstitution, for such person in such person&#146;s
+        name, place and stead, in any and all capacities, to sign any and all amendments
+        (including post-effective amendments) to this Registration Statement on Form\n<FONT
+        STYLE=\"white-space:nowrap\">S-3,</FONT> and to file the same, with all exhibits
+        thereto, and all documents in connection therewith, with the Securities and
+        Exchange Commission granting unto each said <FONT STYLE=\"white-space:nowrap\"><FONT\nSTYLE=\"white-space:nowrap\">attorney-in-fact</FONT></FONT>
+        and agent full power and authority to do and perform each and every act and
+        thing requisite and necessary to be done in and about the premises, as fully
+        to all intents and purposes as such\nperson might or could do in person, hereby
+        ratifying and confirming all that any said <FONT STYLE=\"white-space:nowrap\"><FONT
+        STYLE=\"white-space:nowrap\">attorney-in-fact</FONT></FONT> and agent, or
+        any substitute or substitutes of any of them, may\nlawfully do or cause to
+        be done by virtue hereof. Pursuant to the requirements of the Securities Act
+        of 1933, this Registration Statement has been signed by the following person
+        in the capacities and on the date indicated. </P>\n<P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"100%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\">\n\n\n<TR>\n\n<TD WIDTH=\"45%\"></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"35%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"2%\"></TD>\n<TD WIDTH=\"18%\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:8pt\">\n<TD VALIGN=\"bottom\" NOWRAP
+        ALIGN=\"center\" STYLE=\"border-bottom:1.00pt solid #000000\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Signature</B></P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"bottom\" ALIGN=\"center\"
+        STYLE=\"border-bottom:1.00pt solid #000000\"> <P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:8pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Title</B></P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"border-bottom:1.00pt
+        solid #000000\"> <P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:8pt;
+        font-family:Times New Roman\" ALIGN=\"center\"><B>Date</B></P></TD></TR>\n\n\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Ivana Magov&#269;evi&#263;-Liebisch</I></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:10pt; font-family:Times New Roman\">Ivana Magov&#269;evi&#263;-Liebisch,
+        Ph.D., J.D.</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">President and Chief Executive Officer</P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:10pt; font-family:Times New Roman\">(Principal
+        Executive Officer)</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        NOWRAP ALIGN=\"center\">March&nbsp;31, 2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\"
+        COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid ; font-family:Times
+        New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Jennifer Ziolkowski</I></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:10pt; font-family:Times New Roman\">Jennifer
+        Ziolkowski, CPA</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">Chief Financial Officer</P> <P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:10pt; font-family:Times New Roman\">(Principal Financial\nOfficer
+        and Principal Accounting Officer)</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD
+        VALIGN=\"top\" NOWRAP ALIGN=\"center\">March&nbsp;31, 2025</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Bruce Booth</I></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:10pt; font-family:Times New Roman\">Bruce Booth, D.Phil</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">Director, Chairperson</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\" NOWRAP ALIGN=\"center\">March&nbsp;31,
+        2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; border-bottom:1px
+        solid #000000; font-size:10pt; font-family:Times New Roman\"><I>/s/ Cheryl
+        Renee Blanchard</I></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:10pt;
+        font-family:Times New Roman\">Cheryl Renee Blanchard, Ph.D.</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">Director</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\" NOWRAP ALIGN=\"center\">March&nbsp;31,
+        2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; border-bottom:1px
+        solid #000000; font-size:10pt; font-family:Times New Roman\"><I>/s/ Suzanne
+        Bruhn</I></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:10pt;
+        font-family:Times New Roman\">Suzanne Bruhn, Ph.D.</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"top\">Director</TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        NOWRAP ALIGN=\"center\">March&nbsp;31, 2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\"
+        COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid ; font-family:Times
+        New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Samantha Budd Haeberlein</I></P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:10pt; font-family:Times New Roman\">Samantha
+        Budd Haeberlein, Ph.D.</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"top\">Director</TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        NOWRAP ALIGN=\"center\">March&nbsp;31, 2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\"
+        COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid ; font-family:Times
+        New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Gerhard Koenig</I></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:10pt; font-family:Times New Roman\">Gerhard Koenig, Ph.D.</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">Director</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\" NOWRAP ALIGN=\"center\">March&nbsp;31,
+        2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD>\n<TD
+        HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; border-bottom:1px
+        solid #000000; font-size:10pt; font-family:Times New Roman\"><I>/s/ Mary Thistle</I></P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:10pt; font-family:Times
+        New Roman\">Mary Thistle</P></TD>\n<TD VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"top\">Director</TD>\n<TD VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\"
+        NOWRAP ALIGN=\"center\">March&nbsp;31, 2025</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"16\"></TD>\n<TD HEIGHT=\"16\" COLSPAN=\"2\"></TD>\n<TD HEIGHT=\"16\"
+        COLSPAN=\"2\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid ; font-family:Times
+        New Roman; font-size:10pt\">\n<TD VALIGN=\"top\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; border-bottom:1px solid #000000; font-size:10pt; font-family:Times
+        New Roman\"><I>/s/ Stefan Vitorovic</I></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:1pt;
+        font-size:10pt; font-family:Times New Roman\">Stefan Vitorovic, MS, MBA</P></TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;&nbsp;</TD>\n<TD VALIGN=\"top\">Director</TD>\n<TD
+        VALIGN=\"bottom\">&nbsp;</TD>\n<TD VALIGN=\"top\" NOWRAP ALIGN=\"center\">March&nbsp;31,
+        2025</TD></TR>\n</TABLE>\n <p STYLE=\"margin-top:0pt;margin-bottom:0pt ; font-size:8pt\">&nbsp;</P>
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">II-6 </P>\n\n</DIV></Center>\n\n</BODY></HTML>\n</TEXT>\n</DOCUMENT>\n<DOCUMENT>\n<TYPE>EX-5.1\n<SEQUENCE>2\n<FILENAME>d832814dex51.htm\n<DESCRIPTION>EX-5.1\n<TEXT>\n<HTML><HEAD>\n<TITLE>EX-5.1</TITLE>\n</HEAD>\n
+        <BODY BGCOLOR=\"WHITE\" STYLE=\"line-height:Normal\">\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"right\"><B>Exhibit 5.1 </B></P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">March&nbsp;31, 2025 </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\">Vigil Neuroscience,
+        Inc.\n</P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">100 Forge Road, Suite 700 </P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\">Watertown, MA 02472 </P>\n<P
+        STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"4%\">&nbsp;</TD>\n<TD WIDTH=\"5%\"
+        VALIGN=\"top\" ALIGN=\"left\">Re:</TD>\n<TD ALIGN=\"left\" VALIGN=\"top\">
+        <P STYLE=\" margin-top:0pt ; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman; \" ALIGN=\"left\"><U>Securities Registered under Registration Statement
+        on Form <FONT STYLE=\"white-space:nowrap\">S-3</FONT></U>\n</P></TD></TR></TABLE>
+        <P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">We have acted as counsel to you in connection with your filing
+        of a Registration Statement on\n<FONT STYLE=\"white-space:nowrap\">Form&nbsp;S-3</FONT>
+        (as amended or supplemented, the &#147;Registration Statement&#148;) filed
+        on March&nbsp;31, 2025 with the Securities and Exchange Commission (the &#147;Commission&#148;)
+        pursuant to the\nSecurities Act of 1933, as amended (the &#147;Securities
+        Act&#148;), relating to the registration by Vigil Neuroscience, Inc., a Delaware
+        corporation (the &#147;Company&#148;), of up to 5,376,340 shares (the &#147;Shares&#148;)
+        of the Company&#146;s\ncommon stock, par value $0.0001 per share (&#147;Common
+        Stock&#148;), to be sold by the selling stockholders listed in the Registration
+        Statement under &#147;Selling Stockholders&#148; (the &#147;Selling Stockholders&#148;).
+        </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">We have reviewed such documents and made such examination of law
+        as we have deemed appropriate to give the opinions set forth below. We have
+        relied, without\nindependent verification, on certificates of public officials
+        and, as to matters of fact material to the opinions set forth below, on certificates
+        of officers of the Company. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\">The opinion set forth below
+        is limited to the Delaware General Corporation Law. </P>\n<P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\">Based on
+        the foregoing, we are of the opinion that the Shares have been duly authorized
+        and validly issued and are fully paid and <FONT\nSTYLE=\"white-space:nowrap\">non-assessable.</FONT>
+        </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">This opinion letter and the opinion it contains shall be interpreted
+        in accordance with the Core\nOpinion Principles as published in 74 <I>Business
+        Lawyer</I> 815 (Summer 2019). </P> <P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\">We hereby consent to the inclusion
+        of this opinion as Exhibit&nbsp;5.1 to\nthe Registration Statement and to
+        the references to our firm under the caption &#147;Legal Matters&#148; in
+        the Registration Statement. In giving our consent, we do not admit that we
+        are in the category of persons whose consent is required under\nSection&nbsp;7
+        of the Securities Act or the rules and regulations thereunder. </P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P><DIV
+        ALIGN=\"right\">\n<TABLE CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"40%\"
+        BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman;
+        font-size:10pt\">\n\n\n<TR>\n\n<TD WIDTH=\"100%\"></TD></TR>\n\n\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\">Very
+        truly yours,</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\">/s/ G<SMALL>OODWIN</SMALL> P<SMALL>ROCTER</SMALL> LLP</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"16\"></TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\">GOODWIN
+        PROCTER <SMALL>LLP</SMALL></TD></TR>\n</TABLE></DIV>\n</DIV></Center>\n\n</BODY></HTML>\n</TEXT>\n</DOCUMENT>\n<DOCUMENT>\n<TYPE>EX-23.1\n<SEQUENCE>3\n<FILENAME>d832814dex231.htm\n<DESCRIPTION>EX-23.1\n<TEXT>\n<HTML><HEAD>\n<TITLE>EX-23.1</TITLE>\n</HEAD>\n
+        <BODY BGCOLOR=\"WHITE\" STYLE=\"line-height:Normal\">\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"right\"><B>Exhibit 23.1 </B></P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">CONSENT OF INDEPENDENT REGISTERED PUBLIC ACCOUNTING
+        FIRM </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\">We hereby consent to the incorporation by reference
+        in this Registration Statement on <FONT STYLE=\"white-space:nowrap\">Form&nbsp;S-3</FONT>
+        of Vigil\nNeuroscience, Inc. of our report dated March&nbsp;13, 2025 relating
+        to the financial statements, which appears in Vigil Neuroscience, Inc.&#146;s
+        Annual Report on Form <FONT STYLE=\"white-space:nowrap\">10-K</FONT> for the
+        year ended December&nbsp;31,\n2024. We also consent to the reference to us
+        under the heading &#147;Experts&#148;<SUP STYLE=\"font-size:75%; vertical-align:top\">
+        </SUP>in such Registration Statement. </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\">/s/ PricewaterhouseCoopers LLP
+        </P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\">Boston, Massachusetts </P>\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman\">March&nbsp;31, 2025 </P>\n</DIV></Center>\n\n</BODY></HTML>\n</TEXT>\n</DOCUMENT>\n<DOCUMENT>\n<TYPE>EX-FILING
+        FEES\n<SEQUENCE>4\n<FILENAME>d832814dexfilingfees.htm\n<DESCRIPTION>EX-FILING
+        FEES\n<TEXT>\n<HTML><HEAD>\n<TITLE>EX-FILING FEES</TITLE>\n</HEAD>\n <BODY
+        BGCOLOR=\"WHITE\" STYLE=\"line-height:Normal\">\n\n\n<Center><DIV STYLE=\"width:8.5in\"
+        align=\"left\">\n <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"right\"><B>Exhibit 107 </B></P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:14pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>Calculation of Filing Fee Tables </B></P>\n<P
+        STYLE=\"margin-top:12pt; margin-bottom:0pt; font-size:14pt; font-family:Times
+        New Roman\" ALIGN=\"center\"><B>Form <FONT STYLE=\"white-space:nowrap\">S-3</FONT>
+        </B></P>\n<P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">(Form Type) </P> <P STYLE=\"margin-top:12pt;
+        margin-bottom:0pt; font-size:14pt; font-family:Times New Roman\" ALIGN=\"center\"><B>Vigil\nNeuroscience,
+        Inc. </B></P> <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt;
+        font-family:Times New Roman\" ALIGN=\"center\">(Exact Name of Registrant as
+        Specified in its Charter) </P>\n<P STYLE=\"margin-top:12pt; margin-bottom:0pt;
+        font-size:12pt; font-family:Times New Roman\" ALIGN=\"center\"><U>Table 1:
+        Newly Registered Securities </U></P> <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        CELLSPACING=\"0\" CELLPADDING=\"0\" WIDTH=\"99%\" BORDER=\"0\" STYLE=\"BORDER-COLLAPSE:COLLAPSE;
+        font-family:Times New Roman; font-size:10pt\" ALIGN=\"center\">\n\n\n<TR>\n\n<TD
+        WIDTH=\"13%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"6%\"></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"7%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"1%\"></TD>\n<TD WIDTH=\"6%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD
+        WIDTH=\"7%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"6%\"></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"11%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"1%\"></TD>\n<TD WIDTH=\"8%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD
+        WIDTH=\"7%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"5%\"></TD>\n\n<TD
+        VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD WIDTH=\"5%\"></TD>\n\n<TD VALIGN=\"bottom\"
+        WIDTH=\"1%\"></TD>\n<TD WIDTH=\"5%\"></TD>\n\n<TD VALIGN=\"bottom\" WIDTH=\"1%\"></TD>\n<TD
+        WIDTH=\"6%\"></TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD
+        HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px
+        solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:7pt\">\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-LEFT:1px solid #000000; padding-left:8pt\">&nbsp;&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Security<BR>Type</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\">Security</P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\">Class&nbsp;Title</P></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Fee<BR>Calculation<BR>or Carry<BR>Forward<BR>Rule</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Amount<BR>Registered</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Proposed<BR>Maximum<BR>Offering<BR>Price
+        Per<BR>Unit</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\"> <P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\">Maximum<BR>Aggregate<BR>Offering</P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\">Price</P></TD>\n<TD VALIGN=\"bottom\" STYLE=\"
+        BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" ALIGN=\"center\"
+        STYLE=\"padding-bottom:1pt ;\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\">Fee</P>\n<P
+        STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:7pt; font-family:Times
+        New Roman\" ALIGN=\"center\">Rate</P></TD>\n<TD VALIGN=\"bottom\" STYLE=\"
+        BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" ALIGN=\"center\"
+        STYLE=\"padding-bottom:1pt ;\">Amount of<BR>Registration<BR>Fee</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Carry<BR>Forward<BR>Form<BR>Type</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Carry<BR>Forward<BR>File<BR>Number</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">Carry<BR>Forward<BR>Initial<BR>effective<BR>date</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-RIGHT:1px
+        solid #000000; padding-right:2pt\"> <P STYLE=\"margin-top:0pt; margin-bottom:0pt;
+        font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\">Filing\nFee<BR>Previously<BR>Paid
+        In<BR>Connection<BR>with<BR>Unsold<BR>Securities<BR>to be</P> <P STYLE=\"margin-top:0pt;
+        margin-bottom:1pt; font-size:7pt; font-family:Times New Roman\" ALIGN=\"center\">Carried<BR>Forward</P></TD></TR>\n\n\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\" COLSPAN=\"25\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000; BORDER-RIGHT:1px solid #000000;
+        padding-left:8pt\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid ;
+        font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" COLSPAN=\"25\"
+        ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-LEFT:1px solid #000000;
+        BORDER-RIGHT:1px solid #000000; padding-left:8pt; padding-right:2pt\">Newly
+        Registered Securities</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\"
+        STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD
+        HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px
+        solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-LEFT:1px
+        solid #000000; padding-left:8pt\">Fees to Be Paid</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#8201;Equity&#8201;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">
+        <P STYLE=\"margin-top:0pt; margin-bottom:0pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">Common Stock,</P>\n<P STYLE=\"margin-top:0pt;
+        margin-bottom:0pt; font-size:10pt; font-family:Times New Roman\" ALIGN=\"center\">par
+        value</P> <P STYLE=\"margin-top:0pt; margin-bottom:1pt; font-size:10pt; font-family:Times
+        New Roman\" ALIGN=\"center\">$0.0001 per\nshare</P></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">457(c)</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">5,376,340 (1)</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">$1.805
+        (2)</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">$9,704,293.70</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">0.0001531</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">$1,485.73</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-RIGHT:1px
+        solid #000000; padding-right:2pt\">&#151;</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid #000000;
+        padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"
+        STYLE=\"padding-bottom:1pt ;BORDER-LEFT:1px solid #000000; padding-left:8pt\">Fees
+        Previously Paid</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt
+        ;\">&#151;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-RIGHT:1px
+        solid #000000; padding-right:2pt\">&#151;</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"1\" COLSPAN=\"25\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px
+        solid #000000; BORDER-RIGHT:1px solid #000000; padding-left:8pt\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\" COLSPAN=\"25\" ALIGN=\"center\" STYLE=\"padding-bottom:1pt
+        ;BORDER-LEFT:1px solid #000000; BORDER-RIGHT:1px solid #000000; padding-left:8pt;
+        padding-right:2pt\">Carry Forward Securities</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid #000000;
+        padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" ALIGN=\"center\"
+        STYLE=\"padding-bottom:1pt ;BORDER-LEFT:1px solid #000000; padding-left:8pt\">Carry
+        Forward Securities</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt
+        ;\">&#151;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;BORDER-RIGHT:1px
+        solid #000000; padding-right:2pt\">&#151;</TD></TR>\n<TR STYLE=\"font-size:1pt\">\n<TD
+        HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid #000000;
+        padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"8\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"page-break-inside:avoid ; font-family:Times New Roman; font-size:10pt\">\n<TD
+        VALIGN=\"top\" STYLE=\"BORDER-LEFT:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" COLSPAN=\"7\" NOWRAP ALIGN=\"right\" STYLE=\"padding-bottom:1pt
+        ;\">Total Offering Amounts&#8201;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">$9,704,293.70</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt
+        ;\">$1,485.73</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-RIGHT:1px solid #000000; padding-right:2pt\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000;
+        BORDER-TOP:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"8\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"
+        BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"7\"
+        NOWRAP ALIGN=\"right\" STYLE=\"padding-bottom:1pt ;\">Total Fees Previously
+        Paid&#8201;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-RIGHT:1px solid #000000; padding-right:2pt\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000;
+        BORDER-TOP:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"8\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"
+        BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"7\"
+        NOWRAP ALIGN=\"right\" STYLE=\"padding-bottom:1pt ;\">Total Fee Offsets&#8201;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" NOWRAP ALIGN=\"center\" STYLE=\"padding-bottom:1pt ;\">&#151;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid
+        #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"></TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-RIGHT:1px solid #000000; padding-right:2pt\">&nbsp;</TD></TR>\n<TR
+        STYLE=\"font-size:1pt\">\n<TD HEIGHT=\"1\" STYLE=\"BORDER-LEFT:1px solid #000000;
+        BORDER-TOP:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"8\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\" COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-TOP:1px solid #000000\">&nbsp;</TD>\n<TD HEIGHT=\"1\"
+        COLSPAN=\"2\" STYLE=\"BORDER-LEFT:1px solid #000000; BORDER-TOP:1px solid
+        #000000; BORDER-RIGHT:1px solid #000000\">&nbsp;</TD></TR>\n<TR STYLE=\"page-break-inside:avoid
+        ; font-family:Times New Roman; font-size:10pt\">\n<TD VALIGN=\"top\" STYLE=\"BORDER-LEFT:1px
+        solid #000000; BORDER-BOTTOM:1px solid #000000; padding-left:8pt\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" COLSPAN=\"7\" NOWRAP ALIGN=\"right\"
+        STYLE=\"padding-bottom:1pt ;BORDER-BOTTOM:1px solid #000000\">Net Fee Due&#8201;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px
+        solid #000000; BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\"BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" NOWRAP ALIGN=\"center\"
+        STYLE=\"padding-bottom:1pt ;BORDER-BOTTOM:1px solid #000000\">$1,485.73</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px
+        solid #000000; BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\"BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\"
+        STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\"BORDER-BOTTOM:1px solid #000000\">&nbsp;</TD>\n<TD
+        VALIGN=\"bottom\" STYLE=\" BORDER-LEFT:1px solid #000000; BORDER-BOTTOM:1px
+        solid #000000\">&nbsp;</TD>\n<TD VALIGN=\"bottom\" STYLE=\"BORDER-RIGHT:1px
+        solid #000000; BORDER-BOTTOM:1px solid #000000; padding-right:2pt\">&nbsp;</TD></TR>\n</TABLE>
+        <P STYLE=\"font-size:12pt;margin-top:0pt;margin-bottom:0pt\">&nbsp;</P>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(1)</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman; \" ALIGN=\"left\">Represents
+        the shares of common stock, $0.0001 par value per share of Vigil Neuroscience,
+        Inc. (the\n&#147;Company&#148;) issuable upon conversion of the Series A <FONT
+        STYLE=\"white-space:nowrap\">Non-Voting</FONT> Convertible Preferred Stock
+        of the Company, which the selling stockholder may at any time choose to convert
+        and offer for resale\npursuant to the prospectus to which this exhibit is
+        attached. Pursuant to Rule 416 under the Securities Act of 1933, as amended
+        (the &#147;Securities Act&#148;), the registrant is also registering an indeterminate
+        number of additional shares of\ncommon stock issuable by reason of any stock
+        dividend, stock split, recapitalization or other similar transaction. </P></TD></TR></TABLE>\n<TABLE
+        STYLE=\"BORDER-COLLAPSE:COLLAPSE; font-family:Times New Roman; font-size:10pt\"
+        BORDER=\"0\" CELLPADDING=\"0\" CELLSPACING=\"0\" WIDTH=\"100%\">\n<TR style
+        = \"page-break-inside:avoid\">\n<TD WIDTH=\"4%\" VALIGN=\"top\" ALIGN=\"left\">(2)</TD>\n<TD
+        ALIGN=\"left\" VALIGN=\"top\"> <P STYLE=\" margin-top:0pt ; margin-bottom:0pt;
+        font-size:10pt; font-family:Times New Roman; \" ALIGN=\"left\">Estimated solely
+        for the purpose of calculating the registration fee in accordance with Rule
+        457(c) under the\nSecurities Act. The price per share and aggregate offering
+        price are based on the average of the high and low prices of the registrant&#146;s
+        common stock on March&nbsp;26, 2025, as reported on The Nasdaq Global Select
+        Market. </P></TD></TR></TABLE>\n</DIV></Center>\n\n</BODY></HTML>\n</TEXT>\n</DOCUMENT>\n<DOCUMENT>\n<TYPE>GRAPHIC\n<SEQUENCE>5\n<FILENAME>g832814g03g03.jpg\n<DESCRIPTION>GRAPHIC\n<TEXT>\nbegin
+        644 g832814g03g03.jpg\nM_]C_X  02D9)1@ ! 0$ 3 !,  #_[1.R4&AO=&]S:&]P(#,N,
+        \ X0DE-! 0\nM     \"$< @   @  ' )0  U-:6-H865L($-O:&5N' (%  -3+3, .$))300E\nM
+        \      0'KGYD5\"6MP_12N/=*T_=C#A\"24T$.@      Y0   !     !\nM   +<')I;G1/=71P=70
+        \   %     %!S=%-B;V]L 0    !);G1E96YU;0\nM  !);G1E     $-L<FT    /<')I;G13:7AT965N0FET8F]O;
+        \     +<')I\nM;G1E<DYA;65415A4     0      #W!R:6YT4')O;V93971U<$]B:F,    ,\nM
+        %  <@!O &\\ 9@ @ %, 90!T '4 <       \"G!R;V]F4V5T=7     !\nM $)L=&YE;G5M    #&)U:6QT:6Y0<F]O9@
+        \   EP<F]O9D--64L .$))300[\nM      (M    $     $      !)P<FEN=$]U='!U=$]P=&EO;G,
+        \   7\nM $-P=&YB;V]L      !#;&)R8F]O;       4F=S36)O;VP      $-R;D-B\nM;V]L
+        \     !#;G1#8F]O;       3&)L<V)O;VP      $YG='9B;V]L\nM  !%;6Q$8F]O;       26YT<F)O;VP
+        \     $)C:V=/8FIC     0\nM %)'0D,    #     %)D(\"!D;W5B0&_@            1W)N(&1O=6)
+        ;^\nM          !\";\" @9&]U8D!OX            $)R9%15;G1&(U)L=\nM         $)L9\"!5;G1&(U)L=
+        \               %)S;'15;G1&(U!X;$!3\nM            \"G9E8W1O<D1A=&%B;V]L 0
+        \   !09U!S96YU;0    !09U!S\nM     %!G4$,     3&5F=%5N=$8C4FQT                5&]P(%5N=$8C\nM4FQT
+        \               4V-L(%5N=$8C4')C0%D            08W)O<%=H\nM96Y0<FEN=&EN9V)O;VP
+        \    #F-R;W!296-T0F]T=&]M;&]N9P         ,\nM8W)O<%)E8W1,969T;&]N9P         -8W)O<%)E8W12:6=H=&QO;F<\nM
+        \   \"V-R;W!296-T5&]P;&]N9P      .$))30/M       0 $P    !  $\nM3     $  3A\"24T$)@
+        \     #@             _@   .$))300-       $\nM    6CA\"24T$&0      !    !XX0DE-
+        _,       D           $ .$))\nM32<0       *  $          3A\"24T#]0      2  O9F8
+        \ 0!L9F8 !@\nM     0 O9F8  0\"AF9H !@       0 R     0!:    !@       0 U\nM
+        0 M    !@       3A\"24T#^       <   ________________________\nM_____P/H     /____________________________\\#Z
+        \    #_________\nM____________________ ^@     _____________________________P/H\nM
+        \  X0DE-! @      !     !   \"0    D      .$))300>       $\nM #A\"24T$&@     #00
+        \   8              #D   !H    !@!G #  ,P!G\nM #  ,P    $                          0
+        \             :    #D\nM                     0                         0     0\nM
+        &YU;&P    \"    !F)O=6YD<T]B:F,    !        4F-T,0    0\nM5&]P(&QO;F<          $QE9G1L;VYG
+        \         !\"=&]M;&]N9P   #D\nM    4F=H=&QO;F<   !H    !G-L:6-E<U9L3',    !3V)J8P
+        \   $\nM  5S;&EC90   !(    '<VQI8V5)1&QO;F<         !V=R;W5P241L;VYG\nM          9O<FEG:6YE;G5M
+        \   #$53;&EC94]R:6=I;@    UA=71O1V5N\nM97)A=&5D     %1Y<&5E;G5M    \"D53;&EC951Y<&4
+        \    26UG(     9B\nM;W5N9'-/8FIC     0       %)C=#$    $     %1O<\"!L;VYG\nM
+        \ !,969T;&]N9P          0G1O;6QO;F<    Y     %)G:'1L;VYG\nM:     -U<FQ415A4
+        \    0       &YU;&Q415A4     0       $US9V54\nM15A4     0      !F%L=%1A9U1%6%0
+        \   !       .8V5L;%1E>'1)<TA4\nM34QB;V]L 0    AC96QL5&5X=%1%6%0    !       ):&]R>D%L:6=N96YU\nM;0
+        \   ]%4VQI8V5(;W)Z06QI9VX    '9&5F875L=     EV97)T06QI9VYE\nM;G5M    #T53;&EC959E<G1!;&EG;@
+        \   =D969A=6QT    \"V)G0V]L;W)4\nM>7!E96YU;0   !%%4VQI8V5\"1T-O;&]R5'EP90
+        \   !.;VYE    \"71O<$]U\nM='-E=&QO;F<         \"FQE9G1/=71S971L;VYG          QB;W1T;VU/\nM=71S971L;VYG
+        \         MR:6=H=$]U='-E=&QO;F<      #A\"24T$*\nM    #     (_\\        #A\"24T$$0
+        \      0$ .$))3004       $\nM!#A\"24T$#      )3P    $   !C    -@   2P  #](
+        \  ),P 8  '_V/_M\nM  Q!9&]B95]#30 \"_^X #D%D;V)E &2      ?_; (0 # @(\" D(#
+        D)#!$+\nM\"@L1%0\\,# \\5&!,3%1,3&!$,# P,# P1# P,# P,# P,# P,# P,# P,# P,\nM#
+        P,# P,# $-\"PL-#@T0#@X0% X.#A04#@X.#A01# P,# P1$0P,# P,#!$,\nM# P,# P,# P,#
+        P,# P,# P,# P,# P,# P,_\\  $0@ -@!C P$B  (1 0,1\nM ?_=  0 !__$ 3\\   $% 0$!
+        0$!          ,  0($!08'\" D*\"P$  04!\nM 0$! 0$          0 \" P0%!@<(\"0H+$
+        \ !! $# @0\"!0<&\" 4###,!  (1\nM P0A$C$%05%A$R)Q@3(&%)&AL4(C)!52P6(S-'*\"T4,')9)3\\.'Q8W,U%J*R\nM@R9$DU1D1<*C=#87TE7B9?*SA,/3=>/S1B>4I(6TE<34Y/2EM<75Y?569G:&\nMEJ:VQM;F]C='5V=WAY>GM\\?7Y_<1
+        \ (\" 0($! ,$!08'!P8%-0$  A$#(3$2\nM!$%187$B$P4R@9$4H;%\"(\\%2T? S)&+A<H*20U,58W,T\\24&%J*R@P<F-<+2\nM1)-4HQ=D154V=&7B\\K.$P]-UX_-&E*2%M)7$U.3TI;7%U>7U5F9VAI:FML;6\nMYO8G-T=79W>'EZ>WQ__:
+        \ P# 0 \"$0,1 #\\ ]1OOJQZ7W7.V5U@N<X]@%G]*\nMRNHYUK\\VP\"G!>V,>DCWG7^?<[\\W<@]1:>I=5JZ8?Z-0!D90[./\\
+        @:BK75.L\nM8O26-=D57.KVN<7TU.L:QK(W.L+/YOE2$\"$!I<YB_P\"Y#_OI, ,LF0D$QQXC\nM6G^5R?I<7]2'_3=!)#HNKR**[Z7;ZK6A['>+7#<TH&3U/$Q<S%PK2?M&:7BA\nMC03_
+        #;?4L<_]QK6J-G1/ZNQG7*^C^B\\OLH.0+Q&P '9L_K+065@_6'I^;FM\nMPFUW4Y+F&QK+ZG5DL!^F-_YJNY_4,+IV,[*S;6T4,T+W>)X:UH]SW_R&)*;\"\nM2YW_
+        )[=/#1<_#SF8A_[5NH_11^_(=ZFW_K:M7?6GI59J%)MR_M%7KU_9JW6\nMS7.QSO9]'8[Z?[B2FQU/J[.G9&#0ZE]IS[A0US(AA/Y[Y_-5#ZS=0Z[TRFS/\nMPSC'\"J:P.98'&TO<[8=NTAFSW,5J[ZPX%/4&8%]=S+7VBFI[JG\"M[R
+        ?T5OT\nM7?25;Z[_ /B:ROC7_P\"?&)*=3(&7=@'[+8VG)>P%CR) )@_1*I874<S-8_'E\nMN-U'&TOI>):9^C:S\\[8M/'_H]?\\
+        4;^19?7J78YKZQCB+\\,CU0/SZ28>QW]5\nM2XJ/H(%GY)?UOW9?U9,&?BC^M!/#$?K( _Y/]^/^LA_SW0]/-_TK/YG;]'_#\nM?Z7G^;_X-)-]NQO'_
+        _:/^M^*2CU[=>W5ET[]._Z/=__T.]Z5!ZSU4N_G-]8\nM']7;[5K/8U[',>-S7 AS3P0>0L?.=^S>L5=0=IBY;11D'LUP_F;'?]2MGE29\nM=>&7241_S!P28.7T$X'YH3F3_=RR.6$O^<X7U4+L2O+Z%:27]*M+*2>^/9^F\nMQ'_RO8?3_P\"MJ/21^TOK#U#J[M:<3_)^&?ZGZ3,L']:UVQCU#ZQMS>GY]76.\nMG4OOMNI?@WUU-W&7^_!N<T?F4Y'\\X_\\
+        T=BU>B].;TOI>-@@RZI@]1_[UCO?\nM?9_;M<]RC9W+O_\\ %WC?^$'?]64.REG5OKE93E@/QND45V4TG5IMNG],]O\\\nMP;&[4:ZJX_7?'N%3S2,)S3;M.P.WGV>I]'>EUO!ZCB=3JZ_TBO[1:ROT<W#F\nM#=5.YKJW?Z>K\\U)3OG40=5RO3^G4=.^N]U6,T5T7XAO;6W0-+GAMC6M_-8Y[\nM=^U6/^>V&6[68.:[*X&-Z!#]W@[]UO\\
+        *5'HO[2/UO=?U1K:LK*Q#:*&G=Z5\nM>\\,JH<[_ $C=OO24W_K3_P H]!_\\/-_(B?7C_P 365\\:_P#SXQ1^LU-UG4.A\nMFNI]C:\\T.L<QI<&MCZ=FWZ#43ZZ576_5W)936^VPFN&5M+G&'LX8U)3L8_\\\nM,5_U&_D0NI!AZ?DBSZ'I/W?#:46B116\"((8V0>>%F=?O=:ROI6.9R,T[71^;\nM4/YVQR?CC<P/&R>P&Y8\\\\Q''(G72@/WI2],8_P\"$X>Z[T.3/['_]'?\\
+        D4EU\nM'[-QO _S'V;^PDG^Z.W^4]SZ=F'[O+][_(^Q_A?O/__1]0R<>G*H?CWMW5V\"\nM'!4.E5=2P[78%X];%K;NQ\\J==LP*;&_O-6HDG\"9$3'<'OTE^\\%DL8,XSLB4=\nM+'Z4?W)?U5))*LW,8;KJ2TM=48:3P_V^I^C_
+        )3?SD \"=NBXR JSOH&RJ/5L\nM_*P,=N11B/S6M>!>RHCU&UGZ5M59'Z=S/]$G=G[<3'R P-^T%@ASH#=XGW._\nMDHEF6:\\9ET->7N:WV.EON=LEKD>\"7;K2WW(ZZ[#B_P
+        %S'?73ZN\"CU1E%QC2\nMEM=GJ$_N>ELW;E#H.)G974LGK_4:CC69#&T8F*[Z==#3NW7?NW6O]RUFV5G,\nMN;Z0WU,:[U(&X[MWM_Z\"AAYYR'-:Y@:7UBUNT[@
+        3MVO_=>EPFB:V_:GCC8%\nM[V/\\7=N)*@<[)>U]]% LQZR1]*'O#='OJ;]';^YO=^D5RJUEM;+:S+'@.:?(\nMZH&)&ZHSC+0>?F.\\4>;;D4XMEF-5Z]S1[*YB2JG2NFV8[GYF8_UL_(_G7]FC\nMM37_
+        \"&K221$R(F(TO<]:_=0<8E,3-GA^6/Z,9?O_P!]2222:O?_TO54E\\JI\nM)*?JI4',QIRO4M)WV#Z((<Q^QH;Z42Y]FWW^Q?,B2=#KO]/-CR5IMN?F_NR?\nMIFRJK[%AM%X#6/K].Q[)#R
+        =H>SV;=Z+DLK=A-99:&$N;LLJ;H'[AZ>UGZ3\\\nM]?,*2?K8W^;^JLTJ6WR#]^JX7Z=QJ]M^0;KA9DN:W?M:6M:R'>GL:2_^7_A$\nM/I5>,TO.)<+*P&MN:UL
+        V@\";=?HO>S^<8OF9)(W4M]H_N\\/\\OW4#AXL>V\\Z^\nM?C_E_G.-^F&4/./9]ER=N&\\O)_1DO:)/JMQWZ>S=NV?HK?\\
+        @U=QO1^SU?9_\nMYG8WTX_=CV\\KY:20G=:]_P\"K_P _A_378JL5^[_6_P#&^/\\ R;]5)+Y524;,\nM_522^54DE/\\
+        _]D .$))300A      !7     0$    / $$ 9 !O &( 90 @\nM %  : !O '0 ;P!S &@ ;P!P
+        \   % !! &0 ;P!B &4 ( !0 &@ ;P!T &\\\nM<P!H &\\ <  @ #( ,  R #$    ! #A\"24T$(@
+        \    !2DU- \"H    (  @!\nM$@ #     0 !   !&@ %     0   &X!&P %     0   '8!*
+        \ #     0 \"\nM   !,0 \"    'P   'X!,@ \"    %    )T!.P \"    #@   +&':0 $\nM
+        0   ,    #L    3     $   !,     4%D;V)E(%!H;W1O<VAO<\" R,BXP\nM(\"A7:6YD;W=S*0
+        R,#(U.C S.C(X(# Q.C$Q.C0W $UI8VAA96P@0V]H96X\nM   #H $  P    '__P  H ( !     $
+        \  !HH , !     $    Y\nM  8! P #     0 &   !&@ %     0   3H!&P %     0   4(!*
+        \ #\nM 0 \"   \" 0 $     0   4H\" @ $     0              2     $   !(\nM     3A\"24T#_0
+        \     \"           _^$!4D5X:68  $U- \"H    (  @!\nM$@ #     0 !   !&@ %     0
+        \  &X!&P %     0   '8!*  #     0 \"\nM   !,0 \"    'P   'X!,@ \"    %    )T!.P
+        \"    #@   +&':0 $\nM 0   ,    #L    3     $   !,     4%D;V)E(%!H;W1O<VAO<\"
+        R,BXP\nM(\"A7:6YD;W=S*0 R,#(U.C S.C(X(# Q.C$Q.C0W $UI8VAA96P@0V]H96X\nM   #H
+        $  P    '__P  H ( !     $   !HH , !     $    Y\nM  8! P #     0 &   !&@ %
+        \    0   3H!&P %     0   4(!*  #\nM 0 \"   \" 0 $     0   4H\" @ $     0              2
+        \    $   !(\nM     ?_A/YYH='1P.B\\O;G,N861O8F4N8V]M+WAA<\"\\Q+C O #P_>'!A8VME\nM=\"!B96=I;CTB[[N_(B!I9#TB5S5-,$UP0V5H:4AZ<F53>DY48WIK8SED(C\\^\nM\"CQX.GAM<&UE=&$@>&UL;G,Z>#TB861O8F4Z;G,Z;65T82\\B('@Z>&UP=&L]\nM(D%D;V)E(%A-4\"!#;W)E(#8N,\"UC,#
+        R(#<Y+C$V-#0X.\"P@,C R,\"\\P-R\\Q\nM,\"TR,CHP-CHU,R @(\" @(\" @(CX*(\" @/')D9CI21$8@>&UL;G,Z<F1F/2)H\nM='1P.B\\O=W=W+G<S+F]R9R\\Q.3DY+S
+        R+S(R+7)D9BUS>6YT87@M;G,C(CX*\nM(\" @(\" @/')D9CI$97-C<FEP=&EO;B!R9&8Z86)O=70](B(*(\"
+        @(\" @(\" @\nM(\" @>&UL;G,Z<&1F>#TB:'1T<#HO+VYS+F%D;V)E+F-O;2]P9&9X+S$N,R\\B\nM\"B
+        @(\" @(\" @(\" @('AM;&YS.GAM<#TB:'1T<#HO+VYS+F%D;V)E+F-O;2]X\nM87 O,2XP+R(*(\"
+        @(\" @(\" @(\" @>&UL;G,Z<&1F/2)H='1P.B\\O;G,N861O\nM8F4N8V]M+W!D9B\\Q+C,O(@H@(\"
+        @(\" @(\" @(\"!X;6QN<SID8STB:'1T<#HO\nM+W!U<FPN;W)G+V1C+V5L96UE;G1S+S$N,2\\B\"B
+        @(\" @(\" @(\" @('AM;&YS\nM.GAM<$U-/2)H='1P.B\\O;G,N861O8F4N8V]M+WAA<\"\\Q+C
+        O;6TO(@H@(\" @\nM(\" @(\" @(\"!X;6QN<SIS=$5V=#TB:'1T<#HO+VYS+F%D;V)E+F-O;2]X87
+        O\nM,2XP+W-4>7!E+U)E<V]U<F-E179E;G0C(@H@(\" @(\" @(\" @(\"!X;6QN<SIS\nM=%)E9CTB:'1T<#HO+VYS+F%D;V)E+F-O;2]X87
+        O,2XP+W-4>7!E+U)E<V]U\nM<F-E4F5F(R(*(\" @(\" @(\" @(\" @>&UL;G,Z<&AO=&]S:&]P/2)H='1P.B\\O\nM;G,N861O8F4N8V]M+W!H;W1O<VAO<\"\\Q+C
+        O(CX*(\" @(\" @(\" @/'!D9G@Z\nM05!42U9%4CXQ,2XQ+C N,C(Q,SD@4')O(%!R;V1U8W1I;VXM,S(\\+W!D9G@Z\nM05!42U9%4CX*(\"
+        @(\" @(\" @/'AM<#I#<F5A=&5$871E/C(P,C4M,#,M,C=4\nM,3 Z,#DM,#<Z,# \\+WAM<#I#<F5A=&5$871E/@H@(\"
+        @(\" @(\" \\>&UP.D-R\nM96%T;W)4;V]L/E1O;VQK:70@:'1T<#HO+W=W=RYA8W1I=F5P9&8N8V]M/\"]X\nM;7
+        Z0W)E871O<E1O;VP^\"B @(\" @(\" @(#QX;7 Z36]D:69Y1&%T93XR,#(U\nM+3 S+3(X5#
+        Q.C$Q.C0W*S U.C,P/\"]X;7 Z36]D:69Y1&%T93X*(\" @(\" @\nM(\" @/'AM<#I-971A9&%T841A=&4^,C
+        R-2TP,RTR.%0P,3HQ,3HT-RLP-3HS\nM,#PO>&UP.DUE=&%D871A1&%T93X*(\" @(\" @(\"
+        @/'!D9CI0<F]D=6-E<CY4\nM;V]L:VET(&AT=' Z+R]W=W<N86-T:79E<&1F+F-O;3PO<&1F.E!R;V1U8V5R\nM/@H@(\"
+        @(\" @(\" \\9&,Z8W)E871O<CX*(\" @(\" @(\" @(\" @/')D9CI397$^\nM\"B @(\" @(\"
+        @(\" @(\" @(#QR9&8Z;&D^36EC:&%E;\"!#;VAE;CPO<F1F.FQI\nM/@H@(\" @(\" @(\" @(\"
+        \\+W)D9CI397$^\"B @(\" @(\" @(#PO9&,Z8W)E871O\nM<CX*(\" @(\" @(\" @/&1C.G1I=&QE/@H@(\"
+        @(\" @(\" @(\" \\<F1F.D%L=#X*\nM(\" @(\" @(\" @(\" @(\" @/')D9CIL:2!X;6PZ;&%N9STB>\"UD969A=6QT(CY3\nM+3,\\+W)D9CIL:3X*(\"
+        @(\" @(\" @(\" @/\"]R9&8Z06QT/@H@(\" @(\" @(\" \\\nM+V1C.G1I=&QE/@H@(\" @(\"
+        @(\" \\9&,Z9F]R;6%T/FEM86=E+V5P<V8\\+V1C\nM.F9O<FUA=#X*(\" @(\" @(\" @/'AM<$U-.DEN<W1A;F-E240^>&UP+FEI9#ID\nM.&0U869A,\"TS.&0S+6$Q-&,M.#4W8RUD-64R8C
+        P-&(R,F8\\+WAM<$U-.DEN\nM<W1A;F-E240^\"B @(\" @(\" @(#QX;7!-33I$;V-U;65N=$E$/F%D;V)E.F1O\nM8VED.G!H;W1O<VAO<#IC,#=B,&,W92UF-SDW+3DT-#8M.&1F.2TQ.31D-V0T\nM,&1C-S(\\+WAM<$U-.D1O8W5M96YT240^\"B
+        @(\" @(\" @(#QX;7!-33I/<FEG\nM:6YA;$1O8W5M96YT240^>&UP+F1I9#IF.3-F9C%E-BUC,64V+38U-#,M8C9B\nM9\"TR.#(W8S$X,C,V8C(\\+WAM<$U-.D]R:6=I;F%L1&]C=6UE;G1)1#X*(\"
+        @\nM(\" @(\" @/'AM<$U-.DAI<W1O<GD^\"B @(\" @(\" @(\" @(#QR9&8Z4V5Q/@H@\nM(\"
+        @(\" @(\" @(\" @(\" \\<F1F.FQI(')D9CIP87)S951Y<&4](E)E<V]U<F-E\nM(CX*(\" @(\"
+        @(\" @(\" @(\" @(\" @/'-T179T.F%C=&EO;CYS879E9#PO<W1%\nM=G0Z86-T:6]N/@H@(\"
+        @(\" @(\" @(\" @(\" @(\" \\<W1%=G0Z:6YS=&%N8V5)\nM1#YX;7 N:6ED.F8Y,V9F,64V+6,Q938M-C4T,RUB-F)D+3(X,C=C,3@R,S9B\nM,CPO<W1%=G0Z:6YS=&%N8V5)1#X*(\"
+        @(\" @(\" @(\" @(\" @(\" @/'-T179T\nM.G=H96X^,C R-2TP,RTR.%0P,3HQ,3HS,RLP-3HS,#PO<W1%=G0Z=VAE;CX*\nM(\"
+        @(\" @(\" @(\" @(\" @(\" @/'-T179T.G-O9G1W87)E06=E;G0^061O8F4@\nM4&AO=&]S:&]P(#(R+C
+        @*%=I;F1O=W,I/\"]S=$5V=#IS;V9T=V%R94%G96YT\nM/@H@(\" @(\" @(\" @(\" @(\" @(\"
+        \\<W1%=G0Z8VAA;F=E9#XO/\"]S=$5V=#IC\nM:&%N9V5D/@H@(\" @(\" @(\" @(\" @(\"
+        \\+W)D9CIL:3X*(\" @(\" @(\" @(\" @\nM(\" @/')D9CIL:2!R9&8Z<&%R<V54>7!E/2)297-O=7)C92(^\"B
+        @(\" @(\" @\nM(\" @(\" @(\" @(#QS=$5V=#IA8W1I;VX^<V%V960\\+W-T179T.F%C=&EO;CX*\nM(\"
+        @(\" @(\" @(\" @(\" @(\" @/'-T179T.FEN<W1A;F-E240^>&UP+FEI9#HS\nM-V-E9C-F9BUC,V(S+3
+        P-#4M.&(R,BUC-68Y-S X8C$Q9#4\\+W-T179T.FEN\nM<W1A;F-E240^\"B @(\" @(\" @(\"
+        @(\" @(\" @(#QS=$5V=#IW:&5N/C(P,C4M\nM,#,M,CA4,#$Z,3$Z-#<K,#4Z,S \\+W-T179T.G=H96X^\"B
+        @(\" @(\" @(\" @\nM(\" @(\" @(#QS=$5V=#IS;V9T=V%R94%G96YT/D%D;V)E(%!H;W1O<VAO<\"
+        R\nM,BXP(\"A7:6YD;W=S*3PO<W1%=G0Z<V]F='=A<F5!9V5N=#X*(\" @(\" @(\" @\nM(\"
+        @(\" @(\" @/'-T179T.F-H86YG960^+SPO<W1%=G0Z8VAA;F=E9#X*(\" @\nM(\" @(\" @(\"
+        @(\" @/\"]R9&8Z;&D^\"B @(\" @(\" @(\" @(\" @(#QR9&8Z;&D@\nM<F1F.G!A<G-E5'EP93TB4F5S;W5R8V4B/@H@(\"
+        @(\" @(\" @(\" @(\" @(\" \\\nM<W1%=G0Z86-T:6]N/F-O;G9E<G1E9#PO<W1%=G0Z86-T:6]N/@H@(\"
+        @(\" @\nM(\" @(\" @(\" @(\" \\<W1%=G0Z<&%R86UE=&5R<SYF<F]M(&%P<&QI8V%T:6]N\nM+W9N9\"YA9&]B92YP:&]T;W-H;W
+        @=&\\@:6UA9V4O97!S9CPO<W1%=G0Z<&%R\nM86UE=&5R<SX*(\" @(\" @(\" @(\" @(\" @/\"]R9&8Z;&D^\"B
+        @(\" @(\" @(\" @\nM(\" @(#QR9&8Z;&D@<F1F.G!A<G-E5'EP93TB4F5S;W5R8V4B/@H@(\"
+        @(\" @\nM(\" @(\" @(\" @(\" \\<W1%=G0Z86-T:6]N/F1E<FEV960\\+W-T179T.F%C=&EO\nM;CX*(\"
+        @(\" @(\" @(\" @(\" @(\" @/'-T179T.G!A<F%M971E<G,^8V]N=F5R\nM=&5D(&9R;VT@87!P;&EC871I;VXO=FYD+F%D;V)E+G!H;W1O<VAO<\"!T;R!I\nM;6%G92]E<'-F/\"]S=$5V=#IP87)A;65T97)S/@H@(\"
+        @(\" @(\" @(\" @(\" \\\nM+W)D9CIL:3X*(\" @(\" @(\" @(\" @(\" @/')D9CIL:2!R9&8Z<&%R<V54>7!E\nM/2)297-O=7)C92(^\"B
+        @(\" @(\" @(\" @(\" @(\" @(#QS=$5V=#IA8W1I;VX^\nM<V%V960\\+W-T179T.F%C=&EO;CX*(\"
+        @(\" @(\" @(\" @(\" @(\" @/'-T179T\nM.FEN<W1A;F-E240^>&UP+FEI9#ID.&0U869A,\"TS.&0S+6$Q-&,M.#4W8RUD\nM-64R8C
+        P-&(R,F8\\+W-T179T.FEN<W1A;F-E240^\"B @(\" @(\" @(\" @(\" @\nM(\" @(#QS=$5V=#IW:&5N/C(P,C4M,#,M,CA4,#$Z,3$Z-#<K,#4Z,S
+        \\+W-T\nM179T.G=H96X^\"B @(\" @(\" @(\" @(\" @(\" @(#QS=$5V=#IS;V9T=V%R94%G\nM96YT/D%D;V)E(%!H;W1O<VAO<\"
+        R,BXP(\"A7:6YD;W=S*3PO<W1%=G0Z<V]F\nM='=A<F5!9V5N=#X*(\" @(\" @(\" @(\" @(\"
+        @(\" @/'-T179T.F-H86YG960^\nM+SPO<W1%=G0Z8VAA;F=E9#X*(\" @(\" @(\" @(\" @(\"
+        @/\"]R9&8Z;&D^\"B @\nM(\" @(\" @(\" @(#PO<F1F.E-E<3X*(\" @(\" @(\" @/\"]X;7!-33I(:7-T;W)Y\nM/@H@(\"
+        @(\" @(\" \\>&UP34TZ1&5R:79E9$9R;VT@<F1F.G!A<G-E5'EP93TB\nM4F5S;W5R8V4B/@H@(\"
+        @(\" @(\" @(\" \\<W12968Z:6YS=&%N8V5)1#YX;7 N\nM:6ED.C,W8V5F,V9F+6,S8C,M,#
+        T-2TX8C(R+6,U9CDW,#AB,3%D-3PO<W12\nM968Z:6YS=&%N8V5)1#X*(\" @(\" @(\" @(\"
+        @/'-T4F5F.F1O8W5M96YT240^\nM>&UP+F1I9#IF.3-F9C%E-BUC,64V+38U-#,M8C9B9\"TR.#(W8S$X,C,V8C(\\\nM+W-T4F5F.F1O8W5M96YT240^\"B
+        @(\" @(\" @(\" @(#QS=%)E9CIO<FEG:6YA\nM;$1O8W5M96YT240^>&UP+F1I9#IF.3-F9C%E-BUC,64V+38U-#,M8C9B9\"TR\nM.#(W8S$X,C,V8C(\\+W-T4F5F.F]R:6=I;F%L1&]C=6UE;G1)1#X*(\"
+        @(\" @\nM(\" @/\"]X;7!-33I$97)I=F5D1G)O;3X*(\" @(\" @(\" @/'!H;W1O<VAO<#I#\nM;VQO<DUO9&4^-#PO<&AO=&]S:&]P.D-O;&]R36]D93X*(\"
+        @(\" @/\"]R9&8Z\nM1&5S8W)I<'1I;VX^\"B @(#PO<F1F.E)$1CX*/\"]X.GAM<&UE=&$^\"B
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" *\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @( H@\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM( H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" *\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @( H@\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\"B @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" *(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @( H@(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\"B @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" *(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @( H@(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\"B @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" *(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" *(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM( H@(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        *(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @( H@(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\" @(
+        H@(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @\"B @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" *\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @( H@(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @\"B @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" *(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @(\" @\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @(\" @(\" @(\" @(\" @(\" @( H@\nM(\" @(\" @(\" @(\" @(\" @(\" @(\"
+        @(\" @(\" @\"CP_>'!A8VME=\"!E;F0](G<B\nM/S[_VP!#  8$!08%! 8&!08'!P8(\"A *\"@D)\"A0.#PP0%Q08&!<4%A8:'24?\nM&ALC'!86(\"P@(R8G*2HI&1\\M,\"TH,\"4H*2C_VP!#
+        0<'!PH(\"A,*\"A,H&A8:\nM*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H*\"@H\nM*\"@H*\"C_P
+        \ 1\" #A 9H# 2(  A$! Q$!_\\0 '  !  $% 0$\nM  <#! 4&\" $\"_\\0 3!   0,# 00%!P@&!P<%
+        \    0 \" P0%$08'$B$Q$R)!\nM46$4,C-Q<K&R(S0U<X'!PM$5)%)T@I$V0F*3H>'Q)4-$4V.#DD545:+P_\\0\nM&@$!
+        \ (# 0                $$ P4& O_$ \"\\1  (\" 0($! 4$ P$\nM   ! @,$$1(%$R$Q,D%1\\
+        848;'A(G&1T2.!P3/_V@ , P$  A$#$0 _ .J4\nM1$ 3*)A %\\O>&-))' 9XE?,\\G11N=P.
+        2HQUCJ=[GL IF<8R//\\ \\EGQ\\>5\\\nMML2GFYM>'#?,DRGJ&S-)&.!QP.56RH?T'=GO>QG0@!U0T9SZE+[>(7K)QW1/\nM:SQP_-CFU<Q'H.40#\"*L7PB(@\"(B
+        (B( B(@\")D=X3* (B( B(@\"(B (B( B\nM(@\"(B (B\\<@/47C>U>Y'>@\")D=X1 $R.\\+
+        ZHNSK9$2V(2?).?Q=CDHM9M-G\nM/_IL7]Z?R0$X9'>$R.]0JW:/,X_1T7]Z?R6WZ/U.^ZLRZF9'F81\\'Y[N/+Q0\nM&]@Y1
+        ,(@/F1X8QSB1P&>)5.\"=LK<@MYXYK3MH%P=2LJ&\"(._5LYSZUH>FM1\nM/AJJ<>3M/RP/%WJ5^G!E;7S$:7*XS7C9\"IDO?\\$YKPN
+        YK&V.Y?I\"EZ5S&L.\nM^6X#LKYO)W8I3C.&JFJWNVLVO-3AOCV,H' CF/YIO#O\"T87!T,@'1
+        XX\\U:5\nM6H7BNZ+R9N\"!QWE86)*78IRXC7!?J)%''DBQFG)S4VF*4MW22[A]I63562VM\nMHOPDIQ4EYA$10>@2J4\\PBB>XD=5I.\"<*H]P:TDD<!GBH[UOJ#=,;&LB=O1N'\nM!ZS44NZ6U%3,RH8M;G(QVLM3&6>)K:=O&(C(DSVGP6G6N@=6SL\\YHWVMR&Y[\nM5Y;:-]=(TAKP
+        \\-ZK<J8=+V%M!%*.E>[+P[K-PM[99#\"KVQ[G'8^/=Q>[F6>\nM'W^WH4M,Z=%'&3Y0YV) [BS'=XK;
+        ,($6@LLE8]TCMJ*(41V070(B+&9@B(@\nM\"(B (B( K6ZS>3T$LH;O;N.&<=H5T>2Q]^:7VBH
+        !R=WE[00$1:JU^^WWNJI\nMA;V/$>[UC+C.6@]WBMWT!?W7>DHWFG$72,<<!^<8)\\%\"NOK=-)JBO<V.4@[G\nM)A_8:I1V1TSX;?;0]KQB-_G#':4(3)/1$0D(B(
+        B(@\"(B (B( B(@\"(B =A4\nM::ZU8ZU248%(V3I \\\\9,8QCP\\5)9Y%0AM5HY)I;;N,D.&R<FD_LH\"\\T/KA]T\nM-5FA;'T98.$N<YSX>\"F-<W;+;?+$ZOWHY1ET7-A'[2Z10+L:[JVU_I*(CI\"S\nMY)S.#<\\U%$>S4\"-[OTA+P&?0?YJ>5\\3^@D]D^Y
+        <I:HLOZ+JH&=*Z3>9O9+,\nM=JWO9\"/DF_OK?PK';67;USHN'^Y/Q%9+9!Z%O[ZW\\*$$Z(B(28F^6L5\\,V92\nMS,9;P;GO44:JL!HJG+97R!L._G<QVE3:L?=Z$5E+.PO+=^,LX#/>KF+ERHE]\nM#5<2X9#,@_7W]2&=*W@V^LIHS\"'?*[V2['W*8;37-N=!O]5A<2W
+        =GDHEU?8\nMG4%8XL,LC6Q!V2SAVJKHB\\&CJ:6%T;,=(3ESL+9Y5$<B'.K[G/\\ #<VS N^5\nMO[>T2=76W?+QTAXC]E8Z/3XZ=LG3NX=FY_FMCMU6VLIFR@M&21@'*NEIE;.'\nM0ZOY:JS]1:VZ'R>E9'G>QGCC':KI$6)O5ZEE+1:(+S\"]5*HF;$.LYHR.TX4+\nMJ&].K,#JN[>0LC#!&[?8[FY0LZ1]RJ(=YF[AP;U1GF5F=774UDM*&M8<!PZI\nMSSPLSH2Q=()7N,K=R5I\\U=#CPCB4[Y=SA\\VV?%,ODP\\*_I,V?1=@CIJ6;Y27\nMT@/$8[%N87S&S<!
+        .<KZ6CMM=LG)G98V/''K5<?((B+$9QA$)0% $1$ 1$0!\nM$1 %\\31B2,L)P\"OM$!@*W3,%54/E=/*TNQP
+        '=A9\"VVR.@9&UDCG!@(&5?H@\nM\"(B (B( B\\RO4 1$0!$1 $7F%Z@!* Y1$ 6*N-EBK2POE>W<SC
+        \"RJ(#!V[3\nMD-#O[D\\CM[',#L6<1$ 5.H^;R^R?<JBIU'S>7V3[D!SWM5^DZ/ZD_$5E=D/H\nM6_OK?PK$[5OI.C^I/Q%979!Z%O[ZW\\*
+        G1$1 $1$!B=0VYM;;ZD.>X%T9;U0\nMH7O] ;7=<L#W!C0[+AA3\\1D$+3-=6@5-)63ATF>C P&Y[5L>'Y/+EM?9FAXW\nMP_YBOF0\\2_)AM!7QSHJ.G<R(!TA&<\\>94E,<'-R\"#ZESW1.=;KS
+        TM\\QP/7X\nM*9=(W%M5;(^,8+GN& [*R<1QE%\\R/9F'@.>[8.FSO'I_&AL 7J(M4=(\"M0UE\nM<FP/IPUT1RUW-RVV0X8[CV*%-=W%YGHPT1GJNY>L*]@4\\VS0U'&<OY7'<O?=\nM&!LM*ZOER6OZCFCJ#/-3O8:(4<4S1O\\
+        6(/6\"CC9_:P!5$B7@]G9Z_!2VK'%\nM+]T]B[+\\%#X<P^53S9=W^0A( ))  YDHJ-=GR*HW1D]&[
+        ^PK4G3%\":ZT$+@\nMV6NI6$C(#IFC[U\\?IFW$\\*^C/_>;^:@[6;+FZYTW0T$[QT8R6PN/]8K
+        UM1=\nM*%KB^WR-PTOZ\\+Q_^Y(0=+P5M+./D:F\"3CCJ2 \\>[@K@A0%LPU54S34\\,[*:\nM/I*UC>T'!+1VE3XUS7C+7!P\\#E\"3T<$1.Q
+        %X @)7I( R3@(\"G-40P F::.,\nM#B2]P&%;1W.EEG$<%53R$\\@V0$G^14<;6M0RV^&X14XIWD0M(#LDG)\\\"M9V2\nMW.KN5XMDD\\#6->^0$L:0!AKN\\H\"<YJRG@C<Z>>*(-YE[PT#^:M?TU;2>%PH_\nM[]OYK3-I@JOT=<&TU.^4_)X#6%V>+>Y12([K'%TKK=4
+        #M,+\\(#HL7B@)X5U\nM(?\\ O-_-74%1#.T&*:.0'ENN!RN6Y-05U+4NB=3Q-+>Q[7 \\O6IEV87&6MH[\nM>96L;O1O)W0>\\H\"1$1$
+        1>9XK\":CO\\%JHG2LJ*3I6O#\"V20</\\4!EI:JGA'R\nMT\\4>#CK/ XK W#5=#2N</+:#@_=ZT[?S4,ZOVA7&HJ*F&&\"BD8)LM+
+        XY''N\nM<M2<*Z[N<9*27KGI?DXW<_\\ 'AQ0$_/U]2AQ JK:<''IQ^:JTVNJ.5Q#JRW#\nMAGTX_-0\"S2=2\\9\\DK^(SPB/Y+XDT[54O6%)6<3N]:(_DA!U!07RBJN592'JA\nMW5E:?O638]CQECFN'/@<KE\"DU'<[0YPCHX^
+        Z/Y2-W9]H[E+N@M>R5[I8ZY]\nMO@#(FD8=NY/VN0DE\":>*  S2LC!X O<!G^:M#>+>#QKZ3^^;^:TW:5>6QVN@\nM?2R02N=)Q
+        =G W? J&*2]5];43M92L=N'^HQQ[?6A!TL+W;?_D*+^_;^:OF3\nMPO&6RQN'@X%<T20W9H!_1M3Q_P\"@]3;9A.*=N_\"YIW&\\VD=B$F>=>K<.=PHQ\nMZYF_FO1>+>>5?2'_
+        +S?S7/53#=G2'=MM0<$\\H'K'U=UN%$6A](&;_+?C<,X\nM^U\"#IN&X4DV>BJJ=^.>[(#]ZN5
+        .SN_U-6ZLWXH1NNC\\T'MWO%3\\A*!\"ISC%\nM/+[)]RJ*G4?-Y?9/N0'/6U;Z3H_J3\\165V0>A;^^M_\"L5M6^DZ/ZD_$5E=D'\nMH6_OK?PH\"=$1$
+        1$0!4*Z(3TDL9SAPQP5=!P4IZ=2&M5H0QKJT]!<:J9O2G<\nM8T\\1PY*ZV=7$1R4<3C&/E'<S@]JV[7-\")Z*O?\\IDQ#S5%EG>ZAO]-$!P!SU^\nM?(K?T2^9QG%]U_1Q&7#Y#B$;(]I/[LG^\"02QAX((/<OM8O34PEM,3B6Y)=P!\nM\\2LHM#..V31VM<M\\5+U+&ZS]#&/-X@\\U
+        NHINGFI\\8. ?-]84U:JDW(XN7%K\nM^?V*#:=OE;@3GJD>:MWPF*2<_?F<A\\36.3C2O/\\ !,^BZ01QU7%PR6\\_M6TK\nM$:>9NLGY\\QS^U9=:>Z6Z;9U6+!0J21YP*8X$=Z87JQ%@M7T3'2->7.RU8+6-\nMCBKZ\"LF<^4.;2O:
+        S''@X]WBMG5*KCZ6DGCX]=CF\\.?$% <IT[GV/4UJA#\"&\nMNGBD)E&#Y^/#AP72>C:_R^UR2YC.)BWJ'(Y#\\U\"FU.P^17REJ6,J/D:<29<.\nM
+        PYQX\\.7!;=L:U\"9;3T#GTV9*TMP#QXM9RXH02VB(A(5C>ZCR6U5$V6C< /6\nMY<U?+2-IMZ\\BL%SA#X
+        1&TX>>/G#Q0$.[0[FZZ:K=2@1ELL;&YCXGEV*2]DE\nMA;2VB@J#TX<Q\\G!PP.9'<HITU1.ONKZ\"J+9'!S]W,(ZO
+        'UKI#3='Y!:8Z<!\nMXW2XX?SXE\"$7T].V8.#B1GN6.O=*QMEGCWG8X<?X@LMVJPO_ -$5'\\/Q!\"3F\nMK7D8CU17@$D#<^!JE79%\\PMGU;_>5%NOOZ4U_K9\\#5*6R+YA;/JW^]R$$H(B\nM^)I61,WI'-:WO<<!\"3#:JOL5GMQG;-3;XD#\"V1X&,Y\\?!<XZNO\\
+        57RZ5].R\nM&)[73N>#\"\"XG!/B>\"VC:_?WROKJ2$T\\@95#&[DNP,^*L=FFEFW*Z035+*M@E\nM@+R6#
+        R<<L@H05=#Z\"?<9(I*R&X0Q20[X>(\\#/#D2%+MET116^.-S*BI+NC#\nM,.W?#P\\%LEII6T5NIJ9F]NQ,#!O<^'>KI\"2SAM\\<36@/><#'%6U;8X*MF[))\nM*T;V]PQ^2RJ(\",M3[-Z*6-KXIZZ1SI\"XAH:<9S_94*W6SU5CJ)\"*6J#7R.8#\nM+&0#@]G
+        +K=:5KK2L-V@IP/*W%LCG$18.,CU% 054ZBFJ:6&%[(&B( <,YY8\nMX\\5G]F=.U]7<'.<1EC3_
+        (E:3>:%]NK:AKV2,:)7,!D&,X)6];,?3UOU;/>4\nM()\\-&R6*/+G# [%<-C#1@$KV+T3/4%](26S*-C
+        [#G<5\">U.F9%+;MUQ.6R<\nM_P\"%3J>14&[5O36WV9/PH#7ME8ZU?[47XETFN;=E?G5_M1?B722!=@J=1\\WE\nM]D^Y5%3J/F\\OLGW(#GK:M])T?U)^(K*[(/0M_?6_A6*VK?2=']2?B*RNR#T+\nM?WUOX4!.B(B
+        (B( F$1 6%ZA$MMJ02>+.Q0E?H_)=5-/'#6M.7>I3K7#>HY1\nM_94,:\\@$=VGE&]EK&\\^2VW\"I?J<7YG,?$E>M49KR:?\\
+        &IOVA:OI*\"E8\"PY+\nM^1\\2MP4:;,IG/@H0<<72<OXE):IYD-EK1MN%6NW%C)^B^R-<U@/DX?9?]RA:\nMP<I,_M!3=JIA?'%@'S7\\OL4&TCS2.P<-WB/.6UX9UIE%>^YS?Q\"]N57-]NOV\nM1/UD\\V;'>/O62.5B=//WV3\\0<$<OM666CL6DF=A1U@@/%$1>#*$1$!H>U\"S?\nMI\"WUTXCE<64,@RSEP#C]ZA[9U6&S7BW4DA9%OU;'XDY\\2!]RZ0O<'E%GKHL.\nM/202,PWGQ:0N:M64$MGUI;7MBD:R-D<I=(.
+        Z[N?AP0@Z9M]2VK@Z1CVO&<9\nM;R5RM0V:W2.NL!>982\\SN: P^ 6WH2?,LC8HW/>X-:T9)*@K;%=6U-RKJ&&2\nM*3I(HP&MXN/(\\/Y*8-55;*2PUTA>QKF1YZQ7.=P?->MH$&ZSI(Y
+        UN]$,\\FG\nMD@-VV+V-S*:@JWQ3-+)W\\3R4VK5]G]M%#88XRV1KA(XX?S6SGF@/5C[_ /1%\nM1_#\\060\"Q]_^B*C^'X@@.;=??TIK_6SX&J4MD7S\"V?5O][E%NOOZ4U_K9\\#5\nM*6R+YA;/JW^]R$$H+\":RJ#361\\C2T$/:./K6;6L[13C34GUC/>A)SG>)'735\nMEQA?@CI'.ZG/@I\\V=6AM';+;.&RC]5:,NY<0%
+        -MP[75?G^W]RZ?TH,:;MF/\nM_;L]R$(RJ(B$A$1 ,HO,+U <Y;6[9T1;(QDF7U3R<_:JFR\\YGK1W1L]Y6P;7\nMV,\\EI^M_Q#NWP*UW9=\\\\N'L-]Y0CS.B8O1,]07TOF+T3/4%](2#R*@W:KZ:V\nM^S)^%3D>14&[5?36WV9/PH#7]E?G5_M1?B722YMV5^=7^U%^)=)(%V\"IU'S>\nM7V3[E45.H^;R^R?<@.>MJWTG1_4GXBLKL@]\"W]];^%8K:M])T?U)^(K*[(/0\nMM_?6_A0$Z(B(
+        B(@\"(B I5?S:3U*(=H8'E55Q_W;5+E<=VDE/<%#6O9]^Z3P\nM@M.\\QO <UL^&+6PY_P\"(9)8S3]]S.;+O14'M2?B4H*,]F419#0DAPPZ3G_$I\nM,6'B'6]^_,L\\#6F'#]E]D8^\\0=-&.!.&NY*!=00>3S4_
+        C.>?K\"Z(D;O,</\nMJ$]=6V1D])N1.\\UW;XA6N%6Z3VOWW-=\\38[G1O2ZK^T21HVK9+'59>W@6\\OM\nM6S*)=G]W.*H22,&7LQP]:EK@53S:G5:TS;<*REDXZDO?5A$15#9!$1
+        >/:'-\nM<T\\B,*(-L5E+IIZR&*5W0T60X<@07GBI@6\"UE;8ZZP7+>:YTAIGL !QG@4!$\nMFQF\\R1QTE',Z-CI*L]4CB<@*>
+        0>2YAMLDNGM:6R#'0M$C)\"'\\>9/Y+H&T7?\nMRJPU-:96'HRX;P' 8 /WH0C4-KEX-+;[C2,?'ONIP0TCB<E:/LGM3J^YVVOG\nMCDQTKP7-X-X
+        A4MH]U?==7-I6O9(V:%C,-&\">:DS9398Z/3M,]T;V2,E>>+O\nM% ;S3PLIX]R/.[G/%5$1\"0L??_HBH_A^(+(+'W_Z(J/X?B\"
+        YMU]_2FO_@^!\nMJE+9%\\PMGU;_ 'N46Z^_I37_ ,'P-4I;(OF%L^K?[W(02@M?UU\"ZHT^]C&EQ\nM,C3@>M;
+        K>NIVU-.8G@D9!X%\"3E*5KK?K*X22CHVASFY=]BZ-T+<V55EML+9\nM(W'R9IP.?(*$MJEFEH:^X54,#PUU3@.)R..5L&R75$45=1TU;4Q1LCIBT@MX\nM@@!\"\"=45.FFCJ((YH7!\\;QO-<.T*HA(1$0!$6!U/?X;1#\"]U1''ON+>L,\\D!\nM#FV\"Y!T<3&2,);4O!
+        [.:MMEX_6*X]\\;/>5J>J[D;K6U <]KVB=[QNC',E;=\nMLQ&)ZP?]-GO*$'0T7HF>H+Z7S%Z)GJ\"^LA\"0>14&[5?36WV9/PJ<CR*@W:KZ\nM:V^S)^%
+        :_LK\\ZO]J+\\2Z27-NROSKA[47XETD@78*G4?-Y?9/N514ZCYO+[)\nM]R YZVK?2=']2?B*RNR#T+?WUOX5BMJWTG1_4GXBLKL@]\"W]];^%
+        3HB(@\"(\nMB (B80%E>)6QVVI)< 0SM4(ZB?Y5JD $.#FM'5]2D[6]Q%-0UT8D:'\"+D0HJ\nMM3);AJ\"FEW=\\$XRWAR!6[X97LA*Q^AR'Q!<K;*\\>/?5?=HD_0='T5#2OW7##\nMG\\_65N:Q.F:806J%I:0X%W
+        ^LK++57SWV-G2X=7*IC'Z(+3=9VELTE.8V/=A\nMKLX/J6Y*A54T<X^4!) (&\"HIL=<MR/630KZW!G/]CJ9+=+@X9OO:>L.Y3K9;\nM@*Z.5P>QVZ0.JH=U79I:*6E,<+FY#B<G/+\"SNA=0OC;,R:=C=^1HQN\\UNLVI\nM9%:MAW.1X/D/
+        O>+;V\\OXU_Z2NB^(I62@F-V\\ OM: [9/4(B( J55$)J:6)V\nM</:6G\"JH@( VHV;R+53*R*.0-A@8[><<@8+EE=,:HCBT)<H9*F!LSG2;K2.)\nMZH6X[2K&*^VU]2V%[Y!3[H(=CEE<]U0N-%<([=''NQS8):0\"3DXY_8@[&TV&\nMA=>]9VZJ<QTC2\\,+F<!PRNAK)1MH:!L#6N:
+        2<./'BHTV3:?>VCIJR>G>V2.\nMH<=[>X#EV*6#E >H>2#EQ3* \\&>U6%_^B*C^'X@L@L??P3:*C=Y]7X@@.;-?\nM?TIK_P\"#X&J4]D7S\"V?5O]Y45:_BJ3JJO+6$C+.[]AJE39
+        R5MOMG2-Q\\F_/\nM\\RA!**(B$FD[1=+Q7:TOZ**:69\\S7EK'>M<_55-7Z=O54]D#HVQ/=$#(,]O^\nM2ZV>T/&'<EH.N=\"T=RHIY*:EFEJY9@]P$F._*$&!T'M#C?3TM)<*ZEC;'!Q&\nMZ001A2;0WBAJXHW0U4;]Y@=U>Y<SWC2UTLE5/(RADCC#S&\"YP/W^\"J6W6-_M\nMI$;'Q,;&SHQF-IX#_1
+        =0\"HB/)X7RZJ@;YTC0H\"I]I%W#6])50 [O'Y$<U9U\nMVT6_/!$-1 >M_P D<D))MO6K+7;XVEUPIV.W]T[V5!6M=8UM[>(H)()F12N(\nMW&=G(+\"U5=>KVYS96\"3#C)U6@<3_
+        *K<]#[/)YI9WW.WSM8Z-KF$2 9)]10@\nMCI]%,SY66)S=_CD]ZWS9D?UBN'<QGO*N=I%HI+5;Z/R5KFOZ4L=O.)Y!66S!\nMWZW<./\\
+        4;[RA)T3%Z)GJ\"^L+YB]$SU!?2 'D5!NU7TUM]F3\\*G(\\BH,VKQS\nMF6V]&W/5DS_]4!@-E?G7#VHOQ+I)<U;*XZAKKAOLQUHN[^TNE4\"/
+        >]?%1\\W\nME]D^Y5,!4ZCYO+[)]R YZVK?2=']2?B*RNR#T+?WUOX5B-J\\=0ZYT6XS(Z$_\nM$5E=C\\<S81TC<?KK?PH03LB%&\\D)\"(@\\4
+        5&MF%/2R2D@!HSDJJ7!K22< +3\nMM;WT4M)5T\\<[ [HP0TMSVK+34[9J**^5D1QZG.7D:;KN[FIKZJ%DC'!\\;1@#\nMB>\"J[/+69):.62-^.D=DYX=JUFFCFNMXA>YO2\"1P:2WAE3%H^U1T=LBWHW,D\nM:]QP796ZRIK&H52[G(\\-KGQ#,>1/LNW\\ZF?IXFPQ!C,X'>JB!%H#M4M.@1$0\nMDUK5%C971L<R
+        O+&._KXQ_BH<W*JTU$6^WHMYP=QP[D5T.X;S7 \\B,*.M9Z9\nM;(8WP4SW;D;B3O\\ +_%;7A^5M_QS[,YOC?#7:E?3XE^/H9#2.I8:B\"43U0+S\nM(
+        /DR.SU+=@<\\ESU0U=5;)6-!$8+@XY *E_3&I*>OBEZ:J:Y^^&MPPCG]B\\Y\nMV&ZWOAV/?!^+*^/*MZ27OS9LR)Q[$'BM8=\"$1$!2JZ>.JII()V[T4@W7#.,A\nM:K5;/=/U%QBJY*)YECQAW3O&,'NRMO1
+        6EKMU-;*7R>C861;Q=@N)XGUJ[1$\nM 3\"(@\"IU$+)X71RC+'<QG\"J(@-5N.A+%7U<E14T;WROQO$3.&<
+        #O\\%EK-8J\nM&TQ1,HH3&V,$-R\\NQGUE91$ 1$0!$1 8FZZ>MMT:YM;\"YX+M\\X>X<?L*TV[;\nM-;4_>=26]Y<9,^G=RX]Y4D(@(7EV9.WG;EL?C/#Y<<O_
+        \"5U0[,HM[]9MKP-\nMW_G]OV.4O(@-.M>S^QTH#O(GM>6 .^6<?O6UTU-%3,#86X  :..> 59?$DK(\nMP\"]V
+        4!!VV&0\"G@WC_Q+_<5B-E\\+W55?NMSU&=OB59[6[OY2X102M>8ZJ3(W\nM<8YA;EL?M.])6.DB=UH8SYWK0@F.+T3/4%](T8:!W(A(6!NVEK7=#$:RG<\\Q\nMY#<2.&,\\^1\\%GD0&LVC15EM?2>1TKV;Y!=F5QSC..9\\5LR(@\"\\<
+        YI:>1&%Z\nMB UN[Z-L]UE9)64KY',;N@B5PX?856LNE;7:&XHJ=T8WQ)QD<[CP[SX+/(@\"\nM(B
+        +P\\UZL?>+G!04TSI)A'(V,O&03W_DIC%R>B/,YQ@MTGT+;45V@M]%4A\\P\nMCF$>\\!ND_<H=OMSGN]Q+8Y!*)&AO!H;E7^J]03W*L<R&9LD;XPS@S&>:J:.T\nM_)55--/+3N<WI\"\"X/Q]ZWV-3'%KYEG<XOB&79Q*]8]'A\\_?4S>A=..$5)4ST\nMQ!;(27;_
+        (^M25#&V)FXP8:K>UT;*.D;$QI: 2<$Y5VM1D7NZ;DSJ<'#AB5*\nM$0B(JY=\"(B *A54[*B)[9&[V6D<\\*NB)M$-)K1D6:JTJ]DK'4M(=T1DD]+V\\\nM>\\K4;=7U=JGCW9.B87A[NJ'<BIZJ:6*H8X2,WCND<R%&VJ]*%I::2E:
+        (R3\\\nMIV_:5NL3-4UR[3E.*<)E7+GXW1_3\\(V;36J*>X1D25>_(9 QOR1'/'@MJ!SR\nM41:&M%PA<QTD8
+        %0TGK#EP4MQ!P:=[GE4<RJ%=FD'T-QPG(NR*%*Y:/_ '_T\nM^D1%3-H$1$ 1$0!$1 $1$ 1$0
+        KP9[5ZB ^7NW!EQP%IETUW:[?65$-1<>C=\nM$\\L<.@><$'EP:MS>T.;@C*A#:9I\"Z;U?74U,T,EJ=YK^E;Q!)[\"4!+UDO5%=\nM:>%])4=*9(]\\'<<W([^(\"R:YGTSJVZV\"KZ\"KKC#%#&8@T1M=@Y'#@/!2M9-I\nM%GJ((FSU[W3B(%_R#AQX9[$!(2+
+        1:NL[V-(J7'(!]$[\\E:U^M[+31@NJWMZ\nMV/0N/W(#:'.#1Q*CO:'K:CMU/3\"CK]R3I'-?\\BX\\AXM6!U3M.@,36VBYO;()\nM#O?J_9Q[VJ+I6WG4L\\H+A4!CC(,[K,9//L0@IT=-6:DN=;O,\\H:'.E'$,YNY\nM]BZ5T=966JG#FP=$7Q,!Z^]G
+        ]:U;9UH2*W!T]?0-;TL#.(F)R>![\"I+8T,:\nM&M&&@8 0(]1$0D(B( B(@\"(B (B( B(>10&)OEXI[=!-TD_1R-C+QU\"?N\\%%\nMFI]2S7*HW:>J$D;XNC/R>[DY/#B/%;IKR@JZJ.H=
+        P.'D^/. X\\5HVG--5<T\nM\\)J:=KF], ?E!RX=Q6YP84PAS9/J<IQB[+MN6/6GM?GU/G3-AGKZF\"1]/OQ]\nM)NN.^!]ZEJQ6F&WTK6-AZ-S7$@;Q/WKRQV:GM\\
+        :V ,<'EPPXG[UEU3R\\MW/\nM1=C:<,X9##AJ_%[^@1$5(VX1$0!$1 $\"(@\"I3TT4X^58'<,<551$].Q#2?1E\nMK36^EIAB\"%K..>!/-72(I;;[B,5%:)!$102$1$
+        1$.4 1!XH@\"90\\EX!Q0'J\nM(B (>2(@/.*H5M'3UT'0U<8ECR#NG/,*X3\" B[6&SN*K;*^U6J,SOFWL]+C+\nM>/>?4H[J=%:AMLTCVT8B9O%@Q,P_9S\\%TJK6IMU+5#$\\(>,[W,\\T!S;T6HX>\nMKO.;N]7&\\Q>?HW4-=U2TR?UL%[!]ZZ$?I>S/)+J%I).3UW?FON'3=IA.8Z-K\nM3C'G._-
+        03:=G%\\J9'.J+:Q[7-W@3.SM_B4MZ9T5;;>S,MMCCD=&T.(>3D]O\nM:ML@IXH !$S= &.?8JJ
+        \\C8V-C6,&&M  '<%ZB ( B(@\"9\")@( B)Q0!$1 $\nM1$ 1$0%*>GBG:YLK X.&\"#W*C3VVDIR##
+        UI!R,$\\U=HI4FNFIY<(MZM=3P9\nM7J(H/01$0!$1 $1$ 1$0!$1 $1$ 1$0!$1 #P\"^!*W>W>.5]GDM.U-<9J*XR\nM%LSV1M:TX:LE5;LEM1AON5$-\\NQN*+
+        Z8NS*VA9ORODD<\\C+@L\\O,X.#VL]5\nM6QMBIQ[,MYJN*%Q:\\G([@JL,K9F![,X/>M1U-4RQ5U0&2.:!NXQZ@LYI>1TM\nMF@>]Q<XEW$^T5EG3MK4S#7D;[77Z?V956=37PTY<)\"[+>>
+        KQ:'J\">=UXJ88\nMY'  C SPY!137S):,G*OY$-R-H-XI\\9WGX]E7%)715#@&%QR,\\0L-06Z6:V0\nMN+&EY;G)/BLE;J*2G>TO:T
+        \ C@5,XP2>AYJG;)IM=#)JE45#(&;\\F<9QP\"JA\nM8+54CX[8XL<6GI!Q'VK'7'=)(S6SY<'+T,M3U<4[L1DYQGB%76KZ6FDDJ&A[\nMR[Y,\\_L6T*;8;):$46\\V&XLW7&G;(YA+MYI(/!7;'![&N;R<,A:!65,PN=6!\nM(X
+        2/ &?[16\\6TDVZE).28F$G[%[MJY:3,6/D<Z3CZ%9[PP9*L);M3,)!<_(\nM./-7W=9#'\"P@D9=V+3+:*BKK*EI<7AI)
+        )Y<5-52DG)D9&1*N2A%=6;G!<H)\nM20TNX#N5\\#D9\"TVZTM9201/B=N%QQEKN?!9?3E<:ITK'2.>6-'-1.E*.Z/85\nM9#<^7-=3-E!XHL?=[A%0-B,KW-WR0,#/)88Q<GHBU*2@MS*M57P4N[TI=ULX\nMP,K$'4M)_P
+        R7_P6L4HNMW<_H9G2\"(\\=Y^,9_P!%L;-/GCO4\\7\\U<=-=72;Z\nMFM63=?UJ6B^IE:.[4]3O=&YYW<<VK(J.;E0W:A=$8I.C#LEVZ\\<<86S:<O#*\nMQDV]*]Y:0!O#UKQ;CI1WP>J,F/F.4^7:M&;
+        B(%5-@$1$ 1$0!$1 $1$ 1$0\nM!$1 $1$ 1$0!$1 $1$ 1$0!$1 %I.J(VS7A\\3VAP<UO ^I;LM+U&<7X^RWW*\nMQB^/_11S]'4D_4^K?1R4=N,\\&['&PD]4\\0LU9;FR:..*1[W3.)XD>M>V.-L]\nMH+'M#@YQ!!5A5T4E'7&HAW8X&
+        <&G!Y87N35C<9=SQ\",J8QE#L6.JF_KU2>S\nMJ^X+.Z4X62#UN^(K4[I<8YZR2 [YE=CB1PY96W:6&++\"/%WQ%>[TXTI/Z&+%\nME&>3*4?K]S*J/=22-I[W5ROS@.
+        X>H*0EH%_B$]_JHW .:2.!Y>:%CP_&]?0\nMR\\2UY:T[Z_V92W:AI8K9\"'.EX-[&K+6V[0UKVMB<\\EPSQ&%:VNSTS[;!O4\\)\nMRWM\"R5);X:9P,44;\"!CJA18Z^NG<R4*_2.YK3H7HY+
+        :M^BW?6#[UGQR6 U>\nMTBTN/_4;]ZQT>-&7*_\\ &7[%GI/YRWZH_<MK6I:1E:ZK#!G>$1]X6V/<&C)7\nMK(\\9CPFN41Y6C_:E7]:_XBM[MGT;2?5,]RT\"JE$EVK&MSD2O^);_
+        &SZ-I/J\nMF>Y9LGPQ*W#VG.>A1O#=Z%GM+2[170TE;5&7>XG P,]JW2[G=A9[2C]]!/5S\nMRBF+&N#B3DX[5.,DXM2['G/<HV1E!:LV\"^7FFJ:6!D)DWFGCEN.Q7>DJ62&6\nMH?)C#VC&#ZUJMF:*>IG%Q
+        F:!AH\\[!RI(I8XV1-,3 T%HY!+TJH[%YDX;ED3\nMYT^Z\\BLM#U55/GZ$;[CNN=S6^+1-64KH!
+        3NC><[E]BQXFF_J9N(Z\\EZ&S6.\nMWQTC92V)C=\\-SCMY_FLJL18+A'6-F#-_J!N=X=^?R676\"S=N>[N6J-NQ;.Q;\nMU=+#.P]+&UY:#C/8HZM\\KZ&9C&.+!(\\9#>WBI%K:EE.SK[W6!Q@*.;;\"ZNF:\nM]A&(WMSO>M6\\7PRW=C7\\0TWPV^+K_P
+        ).1$5$VP1$0!$1 $1$ 1$0!$1 $1$\nM 1$0!$1 $1$ 1$0!$1 $1$ 6D:F8\\W]Q:>&ZWM\\%NZMYJ*GFEZ26\"-[_
+        -IS\nM<E9:;.7+5E?)I=T-J]2RTR\"+6T'GO%9&:%LK\"US6NSWA>PQ,A9N1,:QO<T87\nMVO$I:R<D9:X;8*+-#OEDG-YFJ(1$V+JX
+        .#YH\"VC3<;H;3#'(<O!=R]961?#\nM&\\DOC:XGGD+UD;(VAK&AH'8 LME[G!1?D5Z<2-5CLCYGTH]U)O0WNKF)(;O#\nMD>/(*0E:55NI:@N=+3PO<[F7-!RHHL5<M63ET.^&V+T:-?MU\\@BMD(>Z7(;Q\nMP/'UK+VVYQ5;VAAD.03U@OO]$4H;NBF@#>[=\"KTU%#
+        X&.*-N!CJC\"]3E6TV\nMEU/-4+HM*36A=9X95E=J4UE(8FM:3O X=R5ZBP)[7JBU**DM&1R8ZFSW.>>2\nM4MAR6
+        1N/#)[OL5Q7:B%12LCIYZELK2\"XYQD8/;E;I54%-4M/2T\\3R3D[S05\nM:QV.A:\\DT=-Q_L!75D5RT<UU-7\\E;#6-<NC-6TY9ZF2O?43]'(R6,N&\\<G)(\nM.2MZ@9T<,;,
+        ;K0,#P7D,$4( BC:S P-T8X*HJ]UKL>K+N+C1QXZ(Q]Z!,$>\nM/VON6M:99BNK.EPX=G;VK<Y(V2##VAP'>%1BHJ>)SG1P1M+N9#<94PM48N)%\nMN.YV*>O8U;5=K>::!U$V.)[GDN+>J2,>\"OM*U4LCIF32R/W&M&''.%L$D,<K\nM0V1C7
+        <@1E4Z>D@IW.,4,;\"[GNMQE2[MU>QGA8NV[FQ?0KJPNE\"VL;&#'&_=\nM)\\X*_18(MQ>J+<HJ:T9&\\=/<+0YW25#F\"4\\.CD/9_JLP-54H\\Y]1_+_-;1/1\nM4T^.E@B?CEO-!PK
+        V*B/_!TW_@/R5SGUV=;%U-;'$NIZ4RZ?4U\"NJ:RZNC\\C\nMJ90(\\A^\\\\C.>7N*VK3]H%$R83Q0Y<01NC/)7]-;*2#>W::%N<>:T*]
+        PL=M^\nMY;(]$9<?#V3YECU80Y1%6+X'BB(@\"(B (B( B(@\"(B (B( B(@\"(B (B( B(\nM@\"(B
+        (B( B(@\"(B (B( B(@\"(B (B( B(@\"(B (B( B(@\"(B (B( B(@\"(B\n3(B( B(@\"(B
+        (B( B(@\"(B __V0$!\n\nend\n</TEXT>\n</DOCUMENT>\n</SEC-DOCUMENT>\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 16 Jul 2026 15:56:59 GMT
+      ETag:
+      - '"c8c52d15722526853e5d8e34292fafcc-gzip"'
+      Last-Modified:
+      - Mon, 31 Mar 2025 11:46:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '254606'
+      x-amz-id-2:
+      - jWZ5Jjthg2cwup/fuTUvc9/Ouz0lpA6JFBmXB6vE2ESzG9WkqYQjhtn0gdO4YesKfCSoEwfxvjM=
+      x-amz-meta-mode:
+      - '33188'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - 715ZTWSKJ6VVNC1G
+      x-amz-server-side-encryption:
+      - AES256
+      x-amz-version-id:
+      - KuJ.JFtGs8lTCL6VREPuYfyqhjHnZNVy
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/regression/test_issue_877_s3_sections.py
+++ b/tests/issues/regression/test_issue_877_s3_sections.py
@@ -1,0 +1,76 @@
+"""
+Regression test for Issue #877: Expose .sections on S-3 registration statements.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/877
+
+Bug (FIXED): RegistrationS3 lacked the ``.sections`` accessor that
+RegistrationS1 and Prospectus424B already expose, so S-3 shelf registrations
+could not be section-scoped (Risk Factors, Use of Proceeds, Plan of
+Distribution, ...) for RAG/NLP workflows. The root cause was two-fold:
+  1. S-3 had no title-based FormSchema, so the parser did not route S-3 filings
+     through the title-based section engine used for S-1 / 424B.
+  2. RegistrationS3 did not extend ProspectusSectionsMixin and exposed no
+     ``_document`` for the mixin to read.
+
+Fix: Registered a title-based ``S3_SCHEMA`` (reusing the shared prospectus
+section vocabulary) for S-3 / S-3/A / S-3ASR in ``edgar.documents.form_schema``,
+and made ``RegistrationS3`` extend ``ProspectusSectionsMixin`` with a
+``_document`` property, mirroring ``RegistrationS1`` exactly.
+"""
+import pytest
+
+from edgar._filings import Filing
+from edgar.documents.form_schema import get_form_schema
+from edgar.offerings.prospectus._sections import ProspectusSectionsMixin
+from edgar.offerings.prospectus.registration_s3 import RegistrationS3
+
+
+class TestS3FormSchema:
+    """Network-free checks that S-3 routes through the title-based engine."""
+
+    def test_s3_variants_are_title_based(self):
+        for form in ("S-3", "S-3/A", "S-3ASR"):
+            assert get_form_schema(form).title_based is True, form
+
+    def test_item_based_forms_unchanged(self):
+        # No regression: item-based forms stay item-based.
+        assert get_form_schema("8-K").title_based is False
+        assert get_form_schema("10-K").title_based is False
+
+    def test_registration_s3_exposes_sections_api(self):
+        assert issubclass(RegistrationS3, ProspectusSectionsMixin)
+        assert hasattr(RegistrationS3, "sections")
+        assert hasattr(RegistrationS3, "section")
+
+
+class TestS3SectionsGroundTruth:
+    """Ground truth: a real S-3 resolves labelled Reg S-K sections.
+
+    Vigil Neuroscience, Inc. S-3 filed 2025-03-31 (accession
+    0001193125-25-067858). Verified by hand against the SEC EDGAR filing.
+    """
+
+    @pytest.mark.vcr
+    def test_s3_sections_ground_truth(self):
+        # Construct the Filing directly (not find()) to keep the cassette small.
+        filing = Filing(
+            form="S-3",
+            company="Vigil Neuroscience, Inc.",
+            cik=1827087,
+            filing_date="2025-03-31",
+            accession_no="0001193125-25-067858",
+        )
+        s3 = RegistrationS3.from_filing(filing)
+        keys = set(s3.sections.keys())
+
+        # Labelled prospectus sections resolved, not the single 'full' fallback.
+        assert "full" not in keys
+        assert {"risk_factors", "use_of_proceeds", "plan_of_distribution"} <= keys
+
+        # Section text is real, non-trivial content.
+        risk_factors = s3.section("risk_factors")
+        assert risk_factors is not None
+        assert len(risk_factors.text()) > 500
+
+        # Silence check: an absent section returns None, not a crash.
+        assert s3.section("this_section_does_not_exist") is None


### PR DESCRIPTION
### What this does

`RegistrationS3` now exposes `.sections` and `.section()`, the same section-scoped access `RegistrationS1` and `Prospectus424B` already provide. S-3 shelf registrations carry the same Reg S-K narrative sections (risk factors, use of proceeds, plan of distribution, and so on), and until now they could not be section-scoped, which blocked RAG/NLP workflows over S-3 filings.

```python
from edgar import Filing

s3 = Filing(form="S-3", company="Vigil Neuroscience, Inc.", cik=1827087,
            filing_date="2025-03-31", accession_no="0001193125-25-067858").obj()

list(s3.sections.keys())
# ['about_this_prospectus', 'forward_looking_statements', 'summary', 'risk_factors',
#  'use_of_proceeds', 'dividend_policy', 'selling_stockholders', 'description_of_securities',
#  'plan_of_distribution', 'legal_matters', 'experts', 'where_you_can_find_more_information']

s3.section("risk_factors").text()
```

### How

Two changes, both mirroring how S-1 already works:

1. `form_schema.py`: registered a title-based `S3_SCHEMA` for `S-3`, `S-3/A`, and `S-3ASR`. It reuses the shared prospectus section vocabulary (`_S1_SECTION_PATTERNS`), since an S-3 uses the same Reg S-K titles as an S-1. Without this, `get_form_schema("S-3")` fell back to the non-title-based default and the parser never routed S-3 through the title engine.
2. `registration_s3.py`: `RegistrationS3` now extends `ProspectusSectionsMixin` and provides the `_document` property the mixin reads (`filing.parse()`), identical to `RegistrationS1`.

Item-based forms (8-K, 10-K, and so on) are untouched.

### Verification

- Ground-truth regression test against a real S-3 (Vigil Neuroscience, `0001193125-25-067858`), backed by a VCR cassette. It asserts labelled sections resolve (`risk_factors`, `use_of_proceeds`, `plan_of_distribution`), that section text is real content, and that an unknown section returns `None` rather than erroring.
- Network-free checks that the S-3 variants are title-based, that item forms are unchanged, and that the `.sections` / `.section()` API is present.
- While developing I spot-checked five more Q1-2025 S-3s: Whitehawk, Forte Biosciences, Lipella, and Longeveron all resolve 10 to 13 labelled sections, and a short S-3/A correctly falls back to the single `full` section (no content lost).

`ruff check` is clean on both changed source files.

### Note

Marking this a draft. I noticed you flagged #877 as a quick win for v5.41.0, so if you already have it in progress locally I do not want to collide. Happy to adjust the approach if you would rather wire it differently.

Closes #877
