### PR TITLE
fix(documents): preserve text following inline-XBRL facts

### DIFF
--- a/edgar/documents/strategies/document_builder.py
+++ b/edgar/documents/strategies/document_builder.py
@@ -558,36 +558,46 @@ class DocumentBuilder:
 
     def _get_element_text(self, element: HtmlElement) -> str:
         """Get text content from element."""
+        inline = element.tag.lower() in self.INLINE_ELEMENTS
         text_parts = []
 
         # Get element's direct text
         if element.text:
             # For inline elements, preserve leading/trailing whitespace
-            if element.tag.lower() in self.INLINE_ELEMENTS:
+            if inline:
                 text_parts.append(element.text)
             else:
                 text_parts.append(element.text.strip())
 
         # For simple elements, get all text content
-        if element.tag.lower() in self.INLINE_ELEMENTS or \
-           element.tag.lower() in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+        if inline or element.tag.lower() in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
             # Get all text including from child elements
             for child in element:
                 if child.tag.lower() not in self.SKIP_ELEMENTS:
                     child_text = child.text_content()
                     if child_text:
                         # For inline elements, preserve whitespace in child content too
-                        if element.tag.lower() in self.INLINE_ELEMENTS:
+                        if inline:
                             text_parts.append(child_text)
                         else:
                             text_parts.append(child_text.strip())
+                # Text following a child's closing tag lives on child.tail (lxml),
+                # not on the parent. Without capturing it, the unit word and the
+                # rest of the sentence after an inline fact (e.g. ix:nonfraction)
+                # are silently dropped. Read it even for skipped children, since
+                # their trailing text is still part of the document. (gh-898)
+                if child.tail:
+                    if inline:
+                        text_parts.append(child.tail)
+                    elif child.tail.strip():
+                        text_parts.append(child.tail.strip())
 
-        # For inline elements with preserved whitespace, concatenate directly
-        # For others, join with spaces
-        if element.tag.lower() in self.INLINE_ELEMENTS and len(text_parts) == 1:
-            return text_parts[0] if text_parts else ''
-        else:
-            return ' '.join(text_parts)
+        # A single preserved inline part is returned as-is; otherwise space-join
+        # so word boundaries survive (the preprocessor strips whitespace adjacent
+        # to tags, and this re-separates the parts).
+        if inline and len(text_parts) == 1:
+            return text_parts[0]
+        return ' '.join(text_parts)
 
     def _is_text_only_container(self, element: HtmlElement) -> bool:
         """Check if element contains only text and inline elements."""

--- a/tests/issues/regression/test_issue_898_ixbrl_tail_text.py
+++ b/tests/issues/regression/test_issue_898_ixbrl_tail_text.py
@@ -1,0 +1,74 @@
+"""
+Regression test for Issue #898: text after inline-XBRL facts is silently dropped.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/898
+
+Bug (FIXED): the document parser's ``_get_element_text()`` collected each child's
+``text_content()`` but never its ``.tail``. For inline containers this dropped the
+text between an inline fact's closing tag and the next element - the unit word and
+the rest of the sentence. So "$95.2 billion, of which ... paid" rendered as
+"$ 95.2": the scale word "billion" and the trailing clause vanished, leaving a bare
+number that reads as 95.2 rather than 95.2 billion. Multi-fact sentences collapsed
+into number runs.
+
+Fix: read ``child.tail`` in ``_get_element_text``
+(``edgar/documents/strategies/document_builder.py``) so trailing text is preserved.
+
+Note: inter-token spacing (e.g. "$ 95.2" vs "$95.2") is governed by a separate,
+pre-existing whitespace-normalization step and is out of scope here. These tests
+assert that the previously-dropped text is present, not exact spacing. All are
+network-free.
+"""
+from edgar.documents import HTMLParser, ParserConfig
+from edgar.richtools import rich_to_text
+
+IX = "http://www.xbrl.org/2013/inlineXBRL"
+
+
+def _render(html: str) -> str:
+    doc = HTMLParser(ParserConfig(form="10-K")).parse(html)
+    return rich_to_text(doc, width=500)
+
+
+def test_text_after_inline_fact_is_preserved():
+    html = (
+        f'<html xmlns:ix="{IX}"><body><div><span>'
+        'commitments were $<ix:nonfraction name="us-gaap:OtherCommitment" '
+        'contextref="c-1" scale="9">95.2</ix:nonfraction>'
+        " billion, of which substantially all will be paid."
+        "</span></div></body></html>"
+    )
+    text = _render(html)
+    # The tagged value survives ...
+    assert "95.2" in text
+    # ... and so do the scale word and trailing clause that used to vanish.
+    assert "billion" in text
+    assert "of which substantially all will be paid" in text
+
+
+def test_multiple_inline_facts_do_not_collapse_to_a_number_run():
+    html = (
+        f'<html xmlns:ix="{IX}"><body><div><span>'
+        'total was $<ix:nonfraction name="a" contextref="c" scale="9">27</ix:nonfraction>'
+        ' billion, of which $<ix:nonfraction name="b" contextref="c" scale="9">7</ix:nonfraction>'
+        " billion will be paid."
+        "</span></div></body></html>"
+    )
+    text = _render(html)
+    # Both scale words survive instead of collapsing into "$ 27 7".
+    assert text.count("billion") == 2
+    assert "will be paid" in text
+
+
+def test_text_after_a_skipped_child_is_preserved():
+    # Text following an ix:exclude (a skipped child) is still document text and
+    # must survive, while the excluded content itself is dropped.
+    html = (
+        f'<html xmlns:ix="{IX}"><body><div><span>'
+        "keep this<ix:exclude>drop this</ix:exclude> and keep this too."
+        "</span></div></body></html>"
+    )
+    text = _render(html)
+    assert "keep this" in text
+    assert "and keep this too" in text
+    assert "drop this" not in text


### PR DESCRIPTION
### The bug

`filing.text()` (the `edgar.documents` parser) silently drops the text that follows an inline-XBRL fact inside an inline container. The tagged value survives, but the text after the closing tag, usually the unit word and the rest of the sentence, disappears. So a commitments note that reads "$95.2 billion, of which substantially all will be paid" comes out as "$ 95.2", and the reader sees a bare 95.2 with "billion" gone. On NVIDIA's FY2026 10-K the reporter measured 86 of 118 scale-word-adjacent facts losing their unit. Full credit to whoever wrote #898, that diagnosis is excellent and made this easy.

### Root cause and fix

In `_get_element_text` (`edgar/documents/strategies/document_builder.py`) the child loop collected each child's `text_content()` but never its `.tail`. In lxml, the text after an element's closing tag lives on that element's `.tail`, so for inline elements (which include `ix:nonfraction`) everything between the fact's close and the next element was dropped. The fix reads `child.tail` in that loop, including for skipped children, whose trailing text is still part of the document.

### Tests

Added `tests/issues/regression/test_issue_898_ixbrl_tail_text.py`, three network-free cases:

- text after an inline fact is preserved (the unit word and trailing clause come back)
- multiple facts in one sentence no longer collapse into a number run
- text after a skipped `ix:exclude` child is kept while the excluded content is dropped

I also ran the existing parser suite (`test_html_parser*.py`): 66 passed, 6 skipped, no regressions.

### One honest note on scope

This restores the dropped text. The exact inter-token spacing ("$ 95.2 billion" vs "$95.2 billion") is a separate, pre-existing thing: `preprocessor._normalize_whitespace` strips whitespace adjacent to tags (`spaces_after_tags`), which on the unmodified parser also merges normal inline words (e.g. "the quick brown fox" already renders as "The quick brownfox"). That is a broader string-level change with a wider blast radius, so I kept it out of this PR to stay focused on the data loss. Happy to tackle it separately if you want it.

The issue also flagged two small adjacent items (dead `INLINE_IXBRL_TAGS` in `html_documents.py`, and a mixed-case `ix:nonNumeric` in `skip_header_detection_tags` that can never match). I confirmed both. Glad to fold them into this PR or a follow-up, whichever you prefer.

Closes #898
