### PR TITLE
fix: quarterize negative cash flow totals

### DIFF
--- a/edgar/ttm/calculator.py
+++ b/edgar/ttm/calculator.py
@@ -532,6 +532,7 @@ class TTMCalculator:
             'income', 'loss', 'expense', 'cost', 'liability',
             'deficit', 'impairment', 'depreciation', 'amortization',
             'interest', 'tax', 'earnings', 'profit',  # Can be loss
+            'providedbyusedin',  # Cash-flow totals commonly represent net outflows
         ]
 
         # Check for negative-OK keywords first (more specific)

--- a/tests/issues/regression/test_issue_907.py
+++ b/tests/issues/regression/test_issue_907.py
@@ -1,0 +1,48 @@
+"""Regression test for GOOGL cash-flow quarterization (GH #907)."""
+
+from datetime import date
+
+import pytest
+
+from edgar.entity.models import FinancialFact
+from edgar.ttm.calculator import TTMCalculator
+
+
+def _fact(start: str, end: str, value: int, period: str) -> FinancialFact:
+    return FinancialFact(
+        concept="us-gaap:NetCashProvidedByUsedInInvestingActivities",
+        taxonomy="us-gaap",
+        label="Net Cash Provided by (Used in) Investing Activities",
+        value=value,
+        numeric_value=value,
+        unit="USD",
+        period_start=date.fromisoformat(start),
+        period_end=date.fromisoformat(end),
+        period_type="duration",
+        fiscal_year=2025,
+        fiscal_period=period,
+        filing_date=date(2026, 2, 5),
+        form_type="10-K" if period == "FY" else "10-Q",
+        accession=f"2025-{period}",
+        statement_type="CashFlowStatement",
+    )
+
+
+@pytest.mark.fast
+def test_negative_cash_flow_quarters_are_derived():
+    """Net cash outflows are valid and must not be rejected as negative cash."""
+    facts = [
+        _fact("2025-01-01", "2025-03-31", -16_194_000_000, "Q1"),
+        _fact("2025-01-01", "2025-06-30", -40_738_000_000, "Q2"),
+        _fact("2025-01-01", "2025-09-30", -68_515_000_000, "Q3"),
+        _fact("2025-01-01", "2025-12-31", -120_291_000_000, "FY"),
+    ]
+
+    quarters = TTMCalculator(facts).quarterize()
+
+    assert [(fact.fiscal_period, fact.numeric_value) for fact in quarters] == [
+        ("Q1", -16_194_000_000),
+        ("Q2", -24_544_000_000),
+        ("Q3", -27_777_000_000),
+        ("Q4", -51_776_000_000),
+    ]


### PR DESCRIPTION
Closes #907

`NetCashProvidedByUsedInInvestingActivities` can legitimately be negative, but the generic `cash` positivity check discarded every derived quarter. This treats net provided-by/used-in cash-flow totals as sign-variable and adds a regression using the reported GOOGL values.

Validation: the regression fails with only Q1 before the fix and passes with Q1-Q4 after it; related TTM regressions pass.
