### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # EdgarTools — Python Library for SEC EDGAR Filings
 
+[![MCP Toplist](https://mcptoplist.com/badge/tools.edgar%2Fsec-intelligence.svg)](https://mcptoplist.com/server/tools.edgar%2Fsec-intelligence)
+
 <br clear="left">
 
 <p>


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **edgar.tools SEC Intelligence** is currently ranked **#39**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/tools.edgar%2Fsec-intelligence.svg)](https://mcptoplist.com/server/tools.edgar%2Fsec-intelligence)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building edgar.tools SEC Intelligence!
