### PR TITLE
fix(xbrl): declare the FactQuery.to_dataframe() column set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`FactQuery.to_dataframe()` now declares its columns instead of inferring them from the rows a query returned.** The column set follows the query's *configuration* — the `include_*` flags and any names passed to `to_dataframe()` — and no longer varies with which facts happened to match. Three things change for callers: a column no matching row populated comes back null rather than disappearing (`.limit(5)` on Foot Locker's FY2024 10-K returned five fewer columns than the same query unlimited, having dropped `balance`, `currency`, `decimals`, `unit_ref` and `weight` because those five rows were null); narrowing to instant facts no longer removes `period_start`/`period_end`; and an empty result now carries the full column set with zero rows, so `df['decimals']` yields an empty column instead of raising `KeyError`. Requesting a column by name in `to_dataframe('concept', 'period_instant')` likewise returns it null rather than silently omitting it.
+
+  Dtypes are unchanged for populated columns. A column containing no data at all now takes its declared dtype, because inference had nothing to work with there and landed arbitrarily — an all-null `decimals` inferred as `object`/`None` rather than string/`pd.NA`. `preferred_sign` and `fiscal_year` still change dtype family between queries; they move to nullable `Int64` in 6.0, which is a sentinel change and so waits for the breaking window.
+
+  With `include_dimensions=True` and a result containing no dimensioned facts, the five fixed dimension columns (`dimension`, `member`, `dimension_label`, `dimension_member_label`, `full_dimension_label`) are now present and null rather than absent. The per-axis `dim_<axis>` columns remain data-driven, since their names depend on which axes the filer used.
+
+  Found while capturing the 6.0 performance baseline's schema snapshot, and it is the failure mode reported in GH #929 occurring *within* a single version: a consumer's filter could break by filtering differently, with no upgrade involved. Full reasoning in `engineering/decisions/facts-dataframe-schema.md`.
+
 ## [5.45.1] - 2026-08-03
 
 Three section-extraction fixes, all reported against 5.44.x with reproductions. Each returned wrong content at full confidence with no warning, so a caller had no signal anything was off.

--- a/edgar/xbrl/facts.py
+++ b/edgar/xbrl/facts.py
@@ -993,9 +993,7 @@ class FactQuery:
                             or col == 'is_dimensioned']]
 
         if not self._include_contexts:
-            context_cols = ['context_ref', 'entity_identifier', 'entity_scheme',
-                            'period_type']
-            df = df.loc[:, [col for col in df.columns if col not in context_cols]]
+            df = df.loc[:, [col for col in df.columns if col not in _CONTEXT_COLUMNS]]
 
         if not self._include_element_info:
             element_cols = ['element_id', 'element_name', 'element_type', 'element_period_type',
@@ -1064,8 +1062,11 @@ class FactQuery:
 
         display_columns = [col for col in ['concept','label', 'value', 'period_start', 'period_end']
                            if col in columns]
-        # What is the maximum width of the concept column?
-        max_width = df.concept.apply(len).max() if 'concept' in df.columns else 20
+        # What is the maximum width of the concept column? An empty result carries
+        # the declared columns, so `concept` is present with no rows to measure and
+        # .max() returns NaN — which rich accepts as a width and then fails to
+        # render ("can't multiply sequence by non-int of type 'float'").
+        max_width = df.concept.apply(len).max() if 'concept' in df.columns and not df.empty else 20
         rich_columns = [Column('concept', width=max_width)] + display_columns[1:]
         df = df[display_columns]
         table = Table(*rich_columns, show_header=True, header_style="bold", box=box.SIMPLE)

--- a/edgar/xbrl/facts.py
+++ b/edgar/xbrl/facts.py
@@ -27,6 +27,78 @@ from edgar.xbrl.core import STANDARD_LABEL, parse_date
 from edgar.xbrl.models import select_display_label
 
 
+# The pandas default dtype for strings changed in 3.0 (object -> str), and the
+# supported floor is still 2.0. Probing it keeps a column that had to be
+# materialized identical to the same column when rows populated it, on either
+# major — and avoids astype('str'), which turns nulls into the string "nan".
+_STR_DTYPE = pd.Series([""]).dtype
+
+# Columns FactQuery.to_dataframe() declares, in the order it emits them.
+#
+# The rule (see engineering/decisions/facts-dataframe-schema.md, edgartools-rsyt):
+# the column set is a function of the query's *configuration*, never of the rows
+# that came back. Narrowing a query chooses fewer rows, not a different table
+# shape, so a column no returned row happened to populate is materialized as null
+# rather than silently vanishing.
+#
+# Dtypes here are applied ONLY to columns that had to be materialized. Pinning the
+# dtype of a populated column moves a null sentinel, which is a breaking change
+# held for the 6.0 window (edgartools-rsyt.2) — until then `preferred_sign` and
+# `fiscal_year` keep the float64 they take today whenever a null is present.
+_CORE_COLUMNS: Dict[str, Any] = {
+    'concept': _STR_DTYPE,
+    'label': _STR_DTYPE,
+    'balance': _STR_DTYPE,
+    'preferred_sign': 'float64',
+    'weight': 'float64',
+    'value': _STR_DTYPE,
+    'numeric_value': 'float64',
+    'period_key': _STR_DTYPE,  # emitted for time series analysis (Issue #464)
+    'period_start': _STR_DTYPE,
+    'period_end': _STR_DTYPE,
+    'period_instant': _STR_DTYPE,
+    # Nullable, though _build_facts always populates it: an empty *numpy* bool
+    # column materializes as True, and fabricating "this fact is dimensioned"
+    # is exactly the kind of silent wrong answer this schema exists to prevent.
+    'is_dimensioned': 'boolean',
+    'decimals': _STR_DTYPE,
+    'statement_type': _STR_DTYPE,
+    'statement_name': _STR_DTYPE,
+    'fact_id': _STR_DTYPE,
+    'context_ref': _STR_DTYPE,
+    'unit_ref': _STR_DTYPE,
+    'currency': _STR_DTYPE,
+    'period_type': _STR_DTYPE,
+    'entity_identifier': _STR_DTYPE,
+    'entity_scheme': _STR_DTYPE,
+    'fiscal_period': _STR_DTYPE,
+    'fiscal_year': 'float64',
+}
+
+# Dropped by include_contexts=False.
+_CONTEXT_COLUMNS = frozenset(
+    {'context_ref', 'entity_identifier', 'entity_scheme', 'period_type'})
+
+# Added by include_dimensions=True. The per-axis `dim_<axis>` columns are NOT
+# declared: their names depend on which axes the filer used, so two filings
+# legitimately differ and a diff across them carries no information.
+_DIMENSION_COLUMNS: Dict[str, Any] = {
+    'dimension': _STR_DTYPE,
+    'member': _STR_DTYPE,
+    'dimension_label': _STR_DTYPE,
+    'dimension_member_label': _STR_DTYPE,
+    'full_dimension_label': _STR_DTYPE,
+}
+
+# Never emitted, whatever the configuration.
+_SKIP_COLUMNS = frozenset({'fact_key', 'original_label'})
+
+
+def _null_column(dtype, index: pd.Index) -> pd.Series:
+    """An all-null column of `dtype`, for a declared column no row populated."""
+    return pd.Series(index=index, dtype=dtype)
+
+
 def _deduplicate_facts(df: pd.DataFrame) -> pd.DataFrame:
     """
     Remove true duplicate facts from a DataFrame.
@@ -856,6 +928,18 @@ class FactQuery:
 
         return results
 
+    def _declared_columns(self) -> Dict[str, Any]:
+        """The column -> dtype mapping this query's *configuration* declares.
+
+        A function of the include_* flags only, so two queries configured the
+        same way describe the same table however few rows either returns.
+        """
+        declared = {name: dtype for name, dtype in _CORE_COLUMNS.items()
+                    if self._include_contexts or name not in _CONTEXT_COLUMNS}
+        if self._include_dimensions:
+            declared.update(_DIMENSION_COLUMNS)
+        return declared
+
     def to_dataframe(self, *columns) -> pd.DataFrame:
         """
         Execute the query and return results as a DataFrame.
@@ -863,6 +947,18 @@ class FactQuery:
 
         Returns:
             pandas DataFrame with query results
+
+        The column set is determined by this query's configuration — the
+        ``include_*`` flags and any ``columns`` given here — and never by which
+        rows the query matched. Narrowing a query returns fewer rows, not a
+        different set of columns: a column no matching row populated comes back
+        null rather than disappearing, and an empty result still carries the
+        full set of columns so ``df['decimals']`` works on it.
+
+        The exception is the per-axis ``dim_<axis>`` columns added by
+        ``include_dimensions``, whose names depend on which axes the filer used.
+
+        See engineering/decisions/facts-dataframe-schema.md.
         """
         cache_key = columns
         cache = getattr(self, '_df_cache', {})
@@ -871,7 +967,13 @@ class FactQuery:
         results = self.execute()
 
         if not results:
-            return pd.DataFrame()
+            # Zero rows, but the declared columns and their dtypes. A bare
+            # DataFrame() has no columns at all, so df['decimals'] raised
+            # KeyError on an empty result instead of yielding an empty column.
+            declared = self._declared_columns()
+            names = [c for c in columns if c in declared] if columns else list(declared)
+            return pd.DataFrame({name: _null_column(declared[name], pd.RangeIndex(0))
+                                 for name in names})
 
         df = pd.DataFrame(results)
         df = _deduplicate_facts(df)
@@ -900,17 +1002,6 @@ class FactQuery:
                             'element_balance', 'element_label']
             df = df.loc[:, [col for col in df.columns if col not in element_cols]]
 
-        # Drop empty columns
-        df = df.dropna(axis=1, how='all')
-
-        # Filter columns if specified
-        if columns:
-            columns = [col for col in columns if col in df.columns]
-            df = df[list(columns)]
-        # skip these columns
-        # Note: period_key is now included for time series analysis (Issue #464)
-        skip_columns = ['fact_key', 'original_label']
-
         if 'statement_role' in df.columns:
             # Change the statement_role to statement name
             df['statement_name'] = df.statement_role.fillna('').apply(lambda s: s.split('/')[-1] if s else None)
@@ -918,17 +1009,33 @@ class FactQuery:
             if 'statement_role' in df.columns:
                 df = df.drop(columns=['statement_role'])
 
-        # order columns
-        first_columns = [col for col in
-                         ['concept', 'label', 'balance', 'preferred_sign', 'weight', 'value', 'numeric_value',
-                          'period_key', 'period_start', 'period_end', 'period_instant',
-                          'is_dimensioned', 'decimals', 'statement_type', 'statement_name']
-                         if col in df.columns]
-        columns = first_columns + [col for col in df.columns
-                                   if col not in first_columns
-                                   and col not in skip_columns]
+        declared = self._declared_columns()
 
-        result = df[columns]
+        # Whatever is present but undeclared is the per-axis dim_<axis> tail.
+        # Sorted, because its order otherwise follows whichever returned row
+        # first introduced each axis.
+        extra = sorted(col for col in df.columns
+                       if col not in declared and col not in _SKIP_COLUMNS)
+        ordered = list(declared) + extra
+        if columns:
+            # A caller projection keeps the caller's order, and may name a
+            # declared column no row populated; unknown names are dropped as before.
+            ordered = [col for col in columns if col in declared or col in df.columns]
+
+        # reindex materializes the declared columns this query's rows left empty,
+        # so the shape stops depending on which rows happened to match.
+        result = df.reindex(columns=ordered)
+
+        # A declared column with no data in it gets its declared dtype. Inference
+        # has nothing to work with there and lands somewhere arbitrary — an
+        # all-None `decimals` infers as object/None rather than string/pd.NA — and
+        # before this change dropna() hid that by deleting the column outright.
+        # Populated columns keep their inferred dtype until edgartools-rsyt.2
+        # pins them, since changing those moves a sentinel callers may rely on.
+        for col in ordered:
+            if col in declared and result[col].isna().all():
+                result[col] = _null_column(declared[col], result.index)
+
         cache[cache_key] = result
         self._df_cache = cache
         return result

--- a/tests/test_xbrl_facts.py
+++ b/tests/test_xbrl_facts.py
@@ -297,8 +297,19 @@ def test_query_by_dimension_none(aapl_xbrl):
              .by_text("Revenue")
              .by_dimension(None)
              )
-    print(facts.to_dataframe().columns.tolist())
-    assert not any('dim' in col for col in facts.to_dataframe().columns if col != 'is_dimensioned')
+    df = facts.to_dataframe()
+    # No per-axis dim_<axis> column: those exist only for facts that carry that
+    # axis, and this query filtered every dimensioned fact out.
+    assert not any(col.startswith('dim_') for col in df.columns)
+    # The five fixed dimension columns ARE present, and entirely null. The caller
+    # asked for dimension columns via include_dimensions=True, so they get them;
+    # the column set follows the query's configuration, not the rows that matched
+    # (edgartools-rsyt). This assertion previously read "absent", which held only
+    # because dropna(axis=1) deleted any column the result left empty.
+    for col in ['dimension', 'member', 'dimension_label',
+                'dimension_member_label', 'full_dimension_label']:
+        assert col in df.columns
+        assert df[col].isna().all()
 
 
 def test_flexible_dimension_matching(aapl_xbrl):

--- a/tests/test_xbrl_facts_schema.py
+++ b/tests/test_xbrl_facts_schema.py
@@ -1,0 +1,222 @@
+"""The output schema of ``FactQuery.to_dataframe()`` is declared, not inferred.
+
+The contract (engineering/decisions/facts-dataframe-schema.md, edgartools-rsyt):
+the column set is a function of the query's *configuration*, never of the rows
+that came back. Narrowing a query returns fewer rows, not a different table.
+
+This is the check that was missing when the drift went unnoticed: every test
+here compares several queries against **one** XBRL instance, so a failure means
+the code changed the shape, never that the data differed.
+
+Runs offline against the committed Tesla 10-Q fixture.
+"""
+import pandas as pd
+import pytest
+from pandas.api import types as pdt
+
+from edgar.xbrl import XBRL
+from edgar.xbrl.facts import _CONTEXT_COLUMNS, _CORE_COLUMNS, _DIMENSION_COLUMNS
+
+FIXTURE = "tests/fixtures/xbrl/tsla"
+
+# Ground truth: the exact columns and order a default query emits, verified by
+# hand against the fixture. Pinned as a list so an accidental reorder is caught.
+EXPECTED_COLUMNS = [
+    'concept', 'label', 'balance', 'preferred_sign', 'weight', 'value',
+    'numeric_value', 'period_key', 'period_start', 'period_end',
+    'period_instant', 'is_dimensioned', 'decimals', 'statement_type',
+    'statement_name', 'fact_id', 'context_ref', 'unit_ref', 'currency',
+    'period_type', 'entity_identifier', 'entity_scheme', 'fiscal_period',
+    'fiscal_year',
+]
+
+
+@pytest.fixture(scope='module')
+def xbrl():
+    return XBRL.from_directory(FIXTURE)
+
+
+def _queries(xbrl):
+    """Queries that return very different row sets from the same instance.
+
+    Each one previously produced a different column set: narrowing to instant
+    facts removed period_start/period_end, .limit() removed whichever columns
+    those few rows left null, and a no-match query returned no columns at all.
+    """
+    return {
+        'bare': xbrl.facts.query(),
+        'income_statement': xbrl.facts.query().by_statement_type('IncomeStatement'),
+        'balance_sheet': xbrl.facts.query().by_statement_type('BalanceSheet'),
+        'instant_only': xbrl.facts.query().by_period_type('instant'),
+        'duration_only': xbrl.facts.query().by_period_type('duration'),
+        'limit_5': xbrl.facts.query().limit(5),
+        'no_match': xbrl.facts.query().by_concept('ZzzNoSuchConceptExists'),
+    }
+
+
+def test_declared_columns_ground_truth(xbrl):
+    """A default query emits exactly these 24 columns, in this order."""
+    df = xbrl.facts.query().to_dataframe()
+    assert list(df.columns) == EXPECTED_COLUMNS
+    assert len(df) == 1059
+
+
+def test_column_set_is_identical_across_queries(xbrl):
+    """The invariant. One instance, seven row sets, one table shape."""
+    shapes = {name: list(q.to_dataframe().columns)
+              for name, q in _queries(xbrl).items()}
+
+    for name, columns in shapes.items():
+        assert columns == EXPECTED_COLUMNS, (
+            f"{name} produced a different column set: "
+            f"missing {sorted(set(EXPECTED_COLUMNS) - set(columns))}, "
+            f"extra {sorted(set(columns) - set(EXPECTED_COLUMNS))}"
+        )
+
+
+def test_narrowing_a_query_does_not_drop_inapplicable_columns(xbrl):
+    """Instant facts have no start/end date, so those columns are null — present."""
+    df = xbrl.facts.query().by_period_type('instant').to_dataframe()
+
+    assert 'period_start' in df.columns
+    assert 'period_end' in df.columns
+    assert df['period_start'].isna().all()
+    assert df['period_instant'].notna().any()
+
+
+def test_all_null_declared_columns_keep_their_declared_dtype(xbrl):
+    """A column with no data still has a usable type.
+
+    Inference has nothing to work with on an all-null column and lands somewhere
+    arbitrary — an all-None ``decimals`` infers as object/None rather than
+    string/pd.NA. This previously went unseen because ``dropna(axis=1)`` deleted
+    such columns outright, which is how ``.limit(5)`` came to return 5 fewer
+    columns than the same query unlimited.
+    """
+    for name, query in _queries(xbrl).items():
+        df = query.to_dataframe()
+        for column in df.columns:
+            if column not in _CORE_COLUMNS or not df[column].isna().all():
+                continue
+            expected = _CORE_COLUMNS[column]
+            assert df[column].dtype == expected, (
+                f"{name}: all-null column {column!r} has inferred dtype "
+                f"{df[column].dtype}, expected the declared {expected}"
+            )
+
+
+def test_string_columns_never_hold_the_literal_string_nan(xbrl):
+    """astype('str') on a null yields the string "nan"; the declared dtype must not.
+
+    Guards the pandas 2/3 split — the default string dtype changed from object to
+    str, and the naive cast silently turns missing data into the text "nan".
+    """
+    df = xbrl.facts.query().limit(5).to_dataframe()
+
+    for column in df.columns:
+        if pdt.is_string_dtype(df[column].dtype) or df[column].dtype == object:
+            assert not (df[column] == 'nan').any(), f"{column} holds the string 'nan'"
+
+
+class TestEmptyResults:
+    """An empty result is zero rows, not zero columns."""
+
+    def test_empty_result_has_the_full_column_set(self, xbrl):
+        df = xbrl.facts.query().by_concept('ZzzNoSuchConceptExists').to_dataframe()
+
+        assert len(df) == 0
+        assert list(df.columns) == EXPECTED_COLUMNS
+
+    def test_a_column_of_an_empty_result_is_addressable(self, xbrl):
+        """Previously KeyError: a bare DataFrame() has no columns to address."""
+        df = xbrl.facts.query().by_concept('ZzzNoSuchConceptExists').to_dataframe()
+
+        assert len(df['decimals']) == 0          # not KeyError
+        assert df['decimals'].isna().all()       # vacuously true, and not a crash
+        assert len(df[df['concept'] == 'Revenue']) == 0
+
+    def test_empty_result_of_a_projection_keeps_the_projection(self, xbrl):
+        df = (xbrl.facts.query()
+              .by_concept('ZzzNoSuchConceptExists')
+              .to_dataframe('concept', 'value'))
+
+        assert list(df.columns) == ['concept', 'value']
+
+
+class TestConfigurationDrivenColumns:
+    """What the flags change, they change deterministically."""
+
+    def test_exclude_contexts_drops_exactly_the_context_block(self, xbrl):
+        df = xbrl.facts.query().exclude_contexts().to_dataframe()
+
+        assert set(EXPECTED_COLUMNS) - set(df.columns) == set(_CONTEXT_COLUMNS)
+        assert list(df.columns) == [c for c in EXPECTED_COLUMNS
+                                    if c not in _CONTEXT_COLUMNS]
+
+    def test_exclude_contexts_is_stable_across_row_sets(self, xbrl):
+        """The flag decides the shape; the rows do not get a vote."""
+        wide = xbrl.facts.query().exclude_contexts().to_dataframe()
+        narrow = (xbrl.facts.query().exclude_contexts()
+                  .by_period_type('instant').limit(3).to_dataframe())
+
+        assert list(narrow.columns) == list(wide.columns)
+
+    def test_dimension_columns_are_declared_when_dimensions_included(self, xbrl):
+        """Including dimensions adds the five fixed columns whether or not any
+        returned fact is dimensioned — the case that previously varied."""
+        everything = xbrl.facts.query().with_dimensions().to_dataframe()
+        undimensioned = (xbrl.facts.query().with_dimensions()
+                         .by_dimension(None)
+                         .to_dataframe())
+
+        assert len(undimensioned) > 0, "fixture has no undimensioned facts"
+
+        for column in _DIMENSION_COLUMNS:
+            assert column in everything.columns
+            assert column in undimensioned.columns
+
+
+class TestProjection:
+    """`to_dataframe('a', 'b')` names columns, and gets them."""
+
+    def test_projection_returns_the_requested_columns_in_order(self, xbrl):
+        df = xbrl.facts.query().to_dataframe('value', 'concept')
+
+        assert list(df.columns) == ['value', 'concept']
+
+    def test_projection_can_name_a_column_no_row_populated(self, xbrl):
+        """Asking for period_instant on duration-only facts yields a null column.
+
+        It previously yielded nothing at all: the projection intersected with
+        whichever columns had survived inference.
+        """
+        df = (xbrl.facts.query().by_period_type('duration')
+              .to_dataframe('concept', 'period_instant'))
+
+        assert list(df.columns) == ['concept', 'period_instant']
+        assert df['period_instant'].isna().all()
+
+    def test_unknown_column_names_are_dropped(self, xbrl):
+        df = xbrl.facts.query().to_dataframe('concept', 'not_a_real_column')
+
+        assert list(df.columns) == ['concept']
+
+
+def test_repeated_calls_return_the_same_shape(xbrl):
+    """The per-query DataFrame cache must not hand back a different table."""
+    query = xbrl.facts.query().by_statement_type('IncomeStatement')
+
+    assert list(query.to_dataframe().columns) == list(query.to_dataframe().columns)
+
+
+def test_declared_schema_covers_the_documented_column_list():
+    """The spec and the ground-truth list are the same 24 columns."""
+    assert list(_CORE_COLUMNS) == EXPECTED_COLUMNS
+    assert _CONTEXT_COLUMNS <= set(_CORE_COLUMNS)
+    assert not set(_DIMENSION_COLUMNS) & set(_CORE_COLUMNS)
+
+
+def test_dtypes_are_valid_pandas_dtypes():
+    """A typo in the spec must fail here, not at the first empty query."""
+    for column, dtype in {**_CORE_COLUMNS, **_DIMENSION_COLUMNS}.items():
+        assert len(pd.Series(index=pd.RangeIndex(0), dtype=dtype)) == 0, column

--- a/tests/test_xbrl_facts_schema.py
+++ b/tests/test_xbrl_facts_schema.py
@@ -135,6 +135,18 @@ class TestEmptyResults:
         assert df['decimals'].isna().all()       # vacuously true, and not a crash
         assert len(df[df['concept'] == 'Revenue']) == 0
 
+    def test_an_empty_query_can_still_be_displayed(self, xbrl):
+        """Rendering must survive the empty frame having columns.
+
+        Declaring the columns gave an empty result a `concept` column with no
+        rows to measure, so the width calculation in __rich__ produced NaN and
+        rich failed to render it. A mistyped concept in a REPL is enough to hit
+        this, which is exactly the interaction the panel invites.
+        """
+        query = xbrl.facts.query().by_concept('ZzzNoSuchConceptExists')
+
+        assert repr(query)  # previously TypeError inside rich's box rendering
+
     def test_empty_result_of_a_projection_keeps_the_projection(self, xbrl):
         df = (xbrl.facts.query()
               .by_concept('ZzzNoSuchConceptExists')


### PR DESCRIPTION
Implements `edgartools-rsyt.1`, the additive half of the [schema decision](https://github.com/dgunning/edgartools/pull/941). Depends on nothing; #941 records the reasoning and can merge in either order.

## What changes for callers

The column set now follows the query's **configuration** — the `include_*` flags and any names passed to `to_dataframe()` — instead of whichever rows happened to match. Narrowing a query returns fewer rows, not a different table.

| before | after |
|---|---|
| `.limit(5)` returned **5 fewer columns** than the same query unlimited | same columns, the empty ones null |
| narrowing to instant facts removed `period_start`/`period_end` | present, null |
| empty result had **zero columns**, so `df['decimals']` raised `KeyError` | full column set, zero rows |
| `to_dataframe('concept', 'period_instant')` silently omitted an unpopulated name | returns it, null |

## Why it was happening

Four mechanisms, measured on one XBRL instance in one version — no upgrade involved, which is what makes this the [#929](https://github.com/dgunning/edgartools/issues/929) failure mode in its worst form:

- `dropna(axis=1, how='all')` deleted any column the returned rows left null. That is how `.limit(5)` on Foot Locker FY2024 lost `balance`, `currency`, `decimals`, `unit_ref` and `weight` — by luck of the draw, not because they didn't apply.
- `_build_facts` adds keys conditionally, so instant-only results had no `period_start`/`period_end` column at all.
- an empty result returned a bare `DataFrame()`.
- dtype was inferred per call from the returned rows.

The first three are fixed here. **Dtypes of populated columns are untouched** — pinning those moves a null sentinel, so it waits for the 6.0 window (`edgartools-rsyt.2`).

## Two things worth a reviewer's eye

**A column with no data does take its declared dtype.** Inference has nothing to work with there and lands arbitrarily — an all-null `decimals` infers as `object`/`None` rather than string/`pd.NA`. This was invisible while `dropna()` was deleting such columns, and simply retaining them without the declared dtype would have traded a presence bug for a dtype bug.

**Declared dtypes are probed, not literal.** The pandas default string dtype changed in 3.0 (`object` → `str`) and the supported floor is 2.0, so `astype('str')` would have turned nulls into the string `"nan"` on the floor. There's a test pinning that. `is_dimensioned` is declared nullable because an empty *numpy* bool column materializes as `True` — fabricating "this fact is dimensioned" is exactly the silent wrong answer this work exists to prevent.

## Behaviour change to be aware of

With `include_dimensions=True` and a result containing no dimensioned facts, the five fixed dimension columns are now present-and-null rather than absent. `test_query_by_dimension_none` asserted their absence, which held only because `dropna()` removed them; it now asserts the sharper thing — no per-axis `dim_<axis>` column, and the fixed five present and null.

The `dim_<axis>` columns stay undeclared (their names depend on which axes the filer used) but are now ordered deterministically instead of by whichever row introduced each axis first.

## Verification

`tests/test_xbrl_facts_schema.py` — 17 tests, offline against the committed Tesla fixture. The core one compares **seven queries against one instance**, so a failure means the code changed the shape, never that the data differed. That check is what was missing when this drift went unnoticed.

- fast suite: **2835 passed**
- core suite: **4519 passed**

Remaining drift after this change is exactly `preferred_sign` and `fiscal_year`, which `rsyt.2` owns.

## Note

`engineering/analysis/perf-baseline/schemas.json` still records 5.45.1's shape, so a schema diff against it will show this change — correctly. It gets re-taken when this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)