### PR TITLE
feat(perf): wire the three unwired schema surfaces into the baseline

### DIFF
--- a/engineering/analysis/perf-baseline/README.md
+++ b/engineering/analysis/perf-baseline/README.md
@@ -150,6 +150,30 @@ them.
 For the record, since #929 asked: `decimals` currently carries **`pd.NA`**, not
 `None` and not `NaN`.
 
+### The EntityFacts surfaces — the same defect, a different code path
+
+Wiring these in was meant to close a gap in coverage. It found the same bug
+again. Tesla's company facts (CIK 1318605), one `EntityFacts` object, two
+queries through `edgar/entity/query.py:641`:
+
+| column | `.query()` | `.query().by_concept("Revenues")` |
+|---|---|---|
+| *(column count)* | 19 | 19 |
+| `value` | float64 | **int64** |
+| `period_start` | nulls=`None` | no nulls |
+| `statement_type` | nulls=`pd.NA` | no nulls |
+
+The column *count* holds, unlike the XBRL side — but `value`, the column an
+EntityFacts consumer actually reads, changes dtype family when the query narrows
+to a concept whose values all happen to be integral. That moves its null
+sentinel from `NaN` to none-present and changes division semantics for anyone
+not explicitly coercing.
+
+This is the parallel implementation of the same idea as `edgar/xbrl/facts.py`,
+so it inherited the same design: build a DataFrame from a list of dicts and let
+pandas infer. Tracked at P1, to be fixed by applying the same declared-schema
+decision rather than inventing a second contract.
+
 ### `Document.to_dataframe()` — informational, and currently broken
 
 Not gated: its columns are the columns of whatever tables the document happens
@@ -172,20 +196,28 @@ methods in the library:
 |---|---|
 | `FactsQuery.to_dataframe()` — `edgar/xbrl/facts.py:859` | captured |
 | `Filings.to_pandas()` — `edgar/_filings.py:548` | captured |
-| `EntityFacts.to_dataframe()` — `edgar/entity/entity_facts.py:246` | **not yet wired** — needs a cached company-facts payload |
-| `edgar/entity/query.py:641` | **not yet wired** |
-| `edgar/xbrl/stitching/query.py:545` | **not yet wired** |
+| `EntityFacts.to_dataframe()` — `edgar/entity/entity_facts.py:246` | captured, 2 variants |
+| `edgar/entity/query.py:641` | captured, 2 variants |
+| `edgar/xbrl/stitching/query.py:545` | captured |
 
-The three unwired surfaces are a known gap, recorded here rather than left
-silent — an absent key in `schemas.json` would read as "no change" on the next
-diff.
+All five are now wired. The last three needed a cached company-facts payload,
+which comes from a different endpoint than the filing bundles; `build_corpus.py`
+caches the raw JSON for two companies already in the filing corpus and the bench
+re-parses it each run, so a change to `EntityFactsParser` shows up rather than
+being frozen into a stored object.
+
+Worth recording, since this file previously claimed otherwise: those three were
+not being written as `unavailable` — they were **absent from the capture
+entirely**, which is exactly the silence the `unavailable` convention exists to
+prevent. The convention was real (`Document.to_dataframe()` is recorded that
+way) but had never been applied to the surfaces that had no builder at all.
 
 ---
 
 ## Reproducing
 
 ```bash
-python scripts/perf_baseline/build_corpus.py       # network, ~86 MB, once
+python scripts/perf_baseline/build_corpus.py       # network, ~94 MB, once
 python scripts/perf_baseline/bench.py --reps 3 --out /tmp/after
 
 python scripts/perf_baseline/schema_snapshot.py \

--- a/engineering/analysis/perf-baseline/schemas.json
+++ b/engineering/analysis/perf-baseline/schemas.json
@@ -428,6 +428,692 @@
     "xbrl_entry": "footlocker_10k_fy2024",
     "accession": "0001437749-25-009620"
   },
+  "EntityFacts.to_dataframe()": {
+    "column_order": [
+      "concept",
+      "label",
+      "value",
+      "numeric_value",
+      "unit",
+      "period_type",
+      "period_start",
+      "period_end",
+      "fiscal_year",
+      "fiscal_period"
+    ],
+    "columns": {
+      "concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "numeric_value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "unit": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_start": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": false
+      },
+      "period_end": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_year": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_period": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      }
+    },
+    "row_count": 24131,
+    "index_dtype_family": "integer",
+    "label": "EntityFacts.to_dataframe()"
+  },
+  "EntityFacts.to_dataframe() [include_metadata]": {
+    "column_order": [
+      "concept",
+      "label",
+      "value",
+      "numeric_value",
+      "unit",
+      "period_type",
+      "period_start",
+      "period_end",
+      "fiscal_year",
+      "fiscal_period",
+      "accession",
+      "filing_date",
+      "form_type",
+      "statement_type",
+      "taxonomy",
+      "scale",
+      "data_quality",
+      "is_audited",
+      "confidence_score"
+    ],
+    "columns": {
+      "concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "numeric_value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "unit": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_start": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": false
+      },
+      "period_end": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_year": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_period": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "accession": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "filing_date": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "form_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "statement_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [
+          "pd.NA"
+        ],
+        "all_null": false
+      },
+      "taxonomy": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "scale": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": true
+      },
+      "data_quality": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_audited": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "confidence_score": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      }
+    },
+    "row_count": 24131,
+    "index_dtype_family": "integer",
+    "label": "EntityFacts.to_dataframe() [include_metadata]"
+  },
+  "entity.FactQuery.to_dataframe()": {
+    "column_order": [
+      "concept",
+      "label",
+      "value",
+      "numeric_value",
+      "unit",
+      "scale",
+      "period_start",
+      "period_end",
+      "period_type",
+      "fiscal_year",
+      "fiscal_period",
+      "filing_date",
+      "form_type",
+      "accession",
+      "data_quality",
+      "confidence_score",
+      "is_audited",
+      "is_estimated",
+      "statement_type"
+    ],
+    "columns": {
+      "concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "numeric_value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "unit": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "scale": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": true
+      },
+      "period_start": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": false
+      },
+      "period_end": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_year": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_period": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "filing_date": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "form_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "accession": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "data_quality": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "confidence_score": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_audited": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_estimated": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "statement_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [
+          "pd.NA"
+        ],
+        "all_null": false
+      }
+    },
+    "row_count": 24131,
+    "index_dtype_family": "integer",
+    "label": "entity.FactQuery.to_dataframe()"
+  },
+  "entity.FactQuery.to_dataframe() [Revenues]": {
+    "column_order": [
+      "concept",
+      "label",
+      "value",
+      "numeric_value",
+      "unit",
+      "scale",
+      "period_start",
+      "period_end",
+      "period_type",
+      "fiscal_year",
+      "fiscal_period",
+      "filing_date",
+      "form_type",
+      "accession",
+      "data_quality",
+      "confidence_score",
+      "is_audited",
+      "is_estimated",
+      "statement_type"
+    ],
+    "columns": {
+      "concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "value": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "numeric_value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "unit": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "scale": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [
+          "None"
+        ],
+        "all_null": true
+      },
+      "period_start": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_end": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_year": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_period": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "filing_date": {
+        "dtype_family": "object",
+        "dtype_exact": "object",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "form_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "accession": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "data_quality": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "confidence_score": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_audited": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_estimated": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "statement_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      }
+    },
+    "row_count": 333,
+    "index_dtype_family": "integer",
+    "label": "entity.FactQuery.to_dataframe() [Revenues]"
+  },
+  "_entity_source": {
+    "key": "tesla",
+    "cik": 1318605
+  },
+  "StitchedFactQuery.to_dataframe()": {
+    "column_order": [
+      "concept",
+      "label",
+      "original_label",
+      "value",
+      "numeric_value",
+      "period_start",
+      "period_end",
+      "decimals",
+      "statement_type",
+      "fiscal_period",
+      "standard_concept",
+      "period_type",
+      "period_instant",
+      "period_label",
+      "level",
+      "is_abstract",
+      "is_total",
+      "filing_count",
+      "standardized",
+      "fiscal_year"
+    ],
+    "columns": {
+      "concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "original_label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "value": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "numeric_value": {
+        "dtype_family": "float",
+        "dtype_exact": "float64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_start": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [
+          "pd.NA"
+        ],
+        "all_null": false
+      },
+      "period_end": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "decimals": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "statement_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_period": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "standard_concept": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [
+          "pd.NA"
+        ],
+        "all_null": false
+      },
+      "period_type": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "period_instant": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [
+          "pd.NA"
+        ],
+        "all_null": false
+      },
+      "period_label": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "level": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_abstract": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "is_total": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "filing_count": {
+        "dtype_family": "integer",
+        "dtype_exact": "int64",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "standardized": {
+        "dtype_family": "bool",
+        "dtype_exact": "bool",
+        "null_tokens": [],
+        "all_null": false
+      },
+      "fiscal_year": {
+        "dtype_family": "string",
+        "dtype_exact": "str",
+        "null_tokens": [],
+        "all_null": false
+      }
+    },
+    "row_count": 207,
+    "index_dtype_family": "integer",
+    "label": "StitchedFactQuery.to_dataframe()"
+  },
+  "_stitch_source": {
+    "keys": [
+      "footlocker_10k_fy2013",
+      "footlocker_10k_fy2024"
+    ]
+  },
   "Document.to_dataframe()": {
     "unavailable": "TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'"
   }

--- a/scripts/perf_baseline/README.md
+++ b/scripts/perf_baseline/README.md
@@ -36,7 +36,7 @@ legitimately between corpus files) while the **null token** is asserted exactly
 ## Usage
 
 ```bash
-# once: download and cache the corpus (network; ~86 MB)
+# once: download and cache the corpus (network; ~94 MB)
 python scripts/perf_baseline/build_corpus.py
 
 # measure
@@ -95,11 +95,16 @@ and what 6.0 work will touch:
 
 - `FactsQuery.to_dataframe()` — `edgar/xbrl/facts.py:859`
 - `Filings.to_pandas()` — `edgar/_filings.py:548`
-- `EntityFacts.to_dataframe()` — `edgar/entity/entity_facts.py:246` *(not yet
-  wired: needs a cached company-facts payload in the corpus)*
-- `edgar/entity/query.py:641` and `edgar/xbrl/stitching/query.py:545` *(not yet
-  wired)*
+- `EntityFacts.to_dataframe()` — `edgar/entity/entity_facts.py:246`
+- `edgar/entity/query.py:641`
+- `edgar/xbrl/stitching/query.py:545`
+
+Several are captured under more than one query, because narrowing a query is
+what moved the schema in the first place — a single capture per surface would
+have missed it.
 
 Surfaces that cannot be built from the cached corpus are recorded as
-`unavailable` rather than omitted — an absent key would read as "no change" on
-the next diff.
+`unavailable` rather than omitted, since an absent key reads as "no change" on
+the next diff. That convention only helps where a builder exists to fail: the
+last three surfaces above had none, so they were silently missing from the
+capture until the company-facts payload was added to the corpus.

--- a/scripts/perf_baseline/bench.py
+++ b/scripts/perf_baseline/bench.py
@@ -205,6 +205,57 @@ def capture_schemas(manifest: dict, reps: int) -> dict:
     else:
         schemas["FactsQuery.to_dataframe()"] = {"unavailable": "no XBRL in corpus"}
 
+    # EntityFacts surfaces. Company facts come from a different endpoint than the
+    # filing bundles, so these need their own cached payload; without it they were
+    # not merely unavailable but absent from the capture entirely, which is the
+    # silence this file exists to avoid.
+    entity_specs = manifest.get("entity_facts") or []
+    entity_names = ["EntityFacts.to_dataframe()",
+                    "EntityFacts.to_dataframe() [include_metadata]",
+                    "entity.FactQuery.to_dataframe()",
+                    "entity.FactQuery.to_dataframe() [Revenues]"]
+    if entity_specs:
+        from edgar.entity.parser import EntityFactsParser
+
+        # Pinned to the first spec: the gate compares one company run over run, so
+        # a second company would be a different measurement, not a better one.
+        spec = entity_specs[0]
+        payload = json.loads((HERE / spec["path"]).read_text())
+        entity_facts = EntityFactsParser.parse_company_facts(payload)
+        if entity_facts is None:
+            for name in entity_names:
+                schemas[name] = {"unavailable": f"parse returned None for CIK {spec['cik']}"}
+        else:
+            record("EntityFacts.to_dataframe()", lambda: entity_facts.to_dataframe())
+            record("EntityFacts.to_dataframe() [include_metadata]",
+                   lambda: entity_facts.to_dataframe(include_metadata=True))
+            record("entity.FactQuery.to_dataframe()",
+                   lambda: entity_facts.query().to_dataframe())
+            # A narrowing query, because narrowing is what moved the schema on the
+            # XBRL side of the house (edgartools-rsyt).
+            record("entity.FactQuery.to_dataframe() [Revenues]",
+                   lambda: entity_facts.query().by_concept("Revenues").to_dataframe())
+            schemas["_entity_source"] = {"key": spec["key"], "cik": spec["cik"]}
+    else:
+        for name in entity_names:
+            schemas[name] = {"unavailable": "no cached company facts in corpus"}
+
+    # StitchedFactQuery — two filings from ONE company, so the stitcher has
+    # something coherent to align across periods.
+    stitch_keys = sorted(e["key"] for e in manifest["entries"]
+                         if e.get("xbrl_roles") and e["key"].startswith("footlocker"))
+    if len(stitch_keys) >= 2:
+        from edgar.xbrl.stitching import XBRLS
+
+        def stitched_df():
+            xbrls = XBRLS([_xbrl_from_dir(CORPUS / key / "xbrl") for key in stitch_keys])
+            return xbrls.facts.query().to_dataframe()
+        record("StitchedFactQuery.to_dataframe()", stitched_df)
+        schemas["_stitch_source"] = {"keys": stitch_keys}
+    else:
+        schemas["StitchedFactQuery.to_dataframe()"] = {
+            "unavailable": f"needs 2 same-company XBRL entries, found {len(stitch_keys)}"}
+
     # Document.to_dataframe() — INFORMATIONAL, not gated. Its columns are the
     # columns of whatever tables the document happens to contain, so two
     # different filings produce unrelated schemas and a diff across them means

--- a/scripts/perf_baseline/build_corpus.py
+++ b/scripts/perf_baseline/build_corpus.py
@@ -157,6 +157,50 @@ def fetch_entry(entry: dict, refresh: bool) -> dict | None:
     return record
 
 
+# Companies whose SEC company-facts payload is cached, so the EntityFacts
+# surfaces named in the GH #929 commitment can be snapshotted without network.
+# Both are already in the filing corpus, which keeps the manifest coherent — and
+# they are deliberately unalike: one reports in a single currency with a short
+# history, the other has a decade of restatements behind it.
+ENTITY_FACTS_SPEC = [
+    dict(key="tesla", cik=1318605, note="matches tesla_10k_fy2023"),
+    dict(key="footlocker", cik=850209, note="matches the two footlocker entries"),
+]
+
+
+def fetch_entity_facts(refresh: bool) -> list[dict]:
+    """Cache each company's raw company-facts JSON. Network.
+
+    The raw payload rather than a parsed object: EntityFactsParser is exactly
+    what a 6.0 change might alter, so the baseline has to re-parse it on every
+    run rather than snapshot a pickle of last year's parse.
+    """
+    from edgar.entity.entity_facts import download_company_facts_from_sec
+
+    out = CORPUS / "_entity_facts"
+    records = []
+    for spec in ENTITY_FACTS_SPEC:
+        path = out / f"CIK{spec['cik']:010}.json"
+        if not path.exists() or refresh:
+            out.mkdir(parents=True, exist_ok=True)
+            try:
+                payload = download_company_facts_from_sec(spec["cik"])
+            except Exception as exc:
+                print(f"  ! entity facts {spec['key']}: {type(exc).__name__}: {exc}",
+                      file=sys.stderr)
+                continue
+            if not payload:
+                print(f"  ! entity facts {spec['key']}: empty payload", file=sys.stderr)
+                continue
+            path.write_text(json.dumps(payload))
+        record = dict(spec)
+        record["path"] = str(path.relative_to(HERE))
+        record["bytes"] = path.stat().st_size
+        records.append(record)
+        print(f"{'facts ' + spec['key']:<28} {record['bytes']/1e6:>7.2f} MB  CIK {spec['cik']}")
+    return records
+
+
 INDEX_QUARTER = (2025, 1)  # pinned; a moving quarter would make the snapshot drift
 
 
@@ -228,8 +272,10 @@ def main() -> int:
               f"xbrl:{len(record.get('xbrl_roles', []))}/6  {record['accession']}")
 
     index = fetch_index(args.refresh)
+    entity_facts = fetch_entity_facts(args.refresh)
 
-    MANIFEST.write_text(json.dumps({"entries": manifest, "index": index}, indent=2) + "\n")
+    MANIFEST.write_text(json.dumps(
+        {"entries": manifest, "index": index, "entity_facts": entity_facts}, indent=2) + "\n")
     total = sum(e["html_bytes"] for e in manifest)
     with_xbrl = sum(1 for e in manifest if e.get("xbrl_roles"))
     print(f"\nCorpus: {len(manifest)} filings, {total/1e6:.1f} MB HTML, {with_xbrl} with XBRL")

--- a/scripts/perf_baseline/corpus_manifest.json
+++ b/scripts/perf_baseline/corpus_manifest.json
@@ -172,5 +172,21 @@
     "rows": 340032,
     "year": 2025,
     "quarter": 1
-  }
+  },
+  "entity_facts": [
+    {
+      "key": "tesla",
+      "cik": 1318605,
+      "note": "matches tesla_10k_fy2023",
+      "path": "corpus/_entity_facts/CIK0001318605.json",
+      "bytes": 4030874
+    },
+    {
+      "key": "footlocker",
+      "cik": 850209,
+      "note": "matches the two footlocker entries",
+      "path": "corpus/_entity_facts/CIK0000850209.json",
+      "bytes": 3738100
+    }
+  ]
 }


### PR DESCRIPTION
Closes the coverage gap in `edgartools-07lk.1`. Harness and baseline data only — no library code changes.

## What was missing

`EntityFacts.to_dataframe()`, `edgar/entity/query.py:641` and `edgar/xbrl/stitching/query.py:545` are named in the [#929](https://github.com/dgunning/edgartools/issues/929) commitment but were not being captured.

The first two need company facts, which come from a different endpoint than the filing bundles, so `build_corpus.py` now caches the raw payload for two companies already in the filing corpus (Tesla, Foot Locker — ~7.8 MB). The bench **re-parses that JSON every run** rather than storing a parsed object, so a change to `EntityFactsParser` shows up in the diff instead of being frozen out of it.

The stitched surface needed no new data: `footlocker_10k_fy2013` and `footlocker_10k_fy2024` are the same company in two periods, which gives the stitcher something coherent to align.

## A correction to what this harness claimed about itself

The README said surfaces that can't be built are *"recorded as `unavailable` rather than omitted — an absent key would read as no change on the next diff."*

Those three were not recorded as `unavailable`. They were **absent from the capture entirely**. The convention is real and works where a builder exists to fail (`Document.to_dataframe()` is recorded that way), but it had never been applied to surfaces with no builder at all — so the exact silence it exists to prevent was sitting in the file documenting it. Both READMEs now say what the code does.

## Wiring them found the same bug again

One `EntityFacts` object (Tesla, CIK 1318605), two queries through `edgar/entity/query.py:641`:

| column | `.query()` | `.query().by_concept("Revenues")` |
|---|---|---|
| *(column count)* | 19 | 19 |
| `value` | float64 | **int64** |
| `period_start` | nulls=`None` | no nulls |
| `statement_type` | nulls=`pd.NA` | no nulls |

The column count holds — unlike the XBRL side — but `value`, the column an EntityFacts consumer actually reads, changes dtype family when the query narrows to a concept whose values happen to be integral. Same root cause as `edgartools-rsyt`: build a DataFrame from a list of dicts and let pandas infer, in the parallel implementation of the same idea.

Filed at P1, to be fixed by applying the [rsyt declared-schema decision](https://github.com/dgunning/edgartools/pull/941) rather than inventing a second contract.

## Verification

Five new captures, several under more than one query — narrowing is what moved the schema in the first place, so a single capture per surface would have missed it:

```
EntityFacts.to_dataframe():                     10 columns, 24,131 rows
EntityFacts.to_dataframe() [include_metadata]:  19 columns, 24,131 rows
entity.FactQuery.to_dataframe():                19 columns, 24,131 rows
entity.FactQuery.to_dataframe() [Revenues]:     19 columns,    333 rows
StitchedFactQuery.to_dataframe():               20 columns,    207 rows
```

The baseline update is **purely additive** — 686 lines added, 0 removed. Every pre-existing surface diffs clean against the committed 5.45.1 capture (`0 breaking schema change(s)`), and `timings.json` is untouched, so the 5.45.1 numbers still describe 5.45.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)