### PR TITLE
ci: run checks on every pull request, including docs-only ones

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -5,28 +5,21 @@
 #   - Push to main:   fast (full matrix) + network + slow      (real integration gate)
 #   - Nightly (cron): full suite                               (freshness vs SEC API)
 #   - concurrency:    cancel superseded runs on the same ref
-#   - paths-ignore:   skip docs/markdown-only changes
 #   - pip cache:      avoid reinstalling deps from scratch in every job
+#
+# There is deliberately NO paths-ignore. A docs-only change would then report no
+# checks at all, and a required status check that never reports blocks the pull
+# request forever. Since these checks are meant to become required, every PR has
+# to produce them — the few CI minutes a markdown-only run costs are cheaper than
+# a merge queue that deadlocks on documentation.
 
 name: Build and Test Edgartools
 
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
   schedule:
     # Nightly full suite at 07:00 UTC
     - cron: '0 7 * * *'


### PR DESCRIPTION
Prerequisite for the branch-protection work in `edgartools-07lk.14`. One file, two lines of trigger config.

## The problem

`python-hatch-workflow.yml` had `paths-ignore` on both the `push` and `pull_request` triggers, covering `docs/**`, `**.md`, `mkdocs.yml`, `LICENSE` and `.gitignore`. A docs-only PR therefore ran **no workflow at all** and reported **no checks**.

That's a sensible saving today. It becomes a deadlock the moment those checks are required: GitHub blocks the PR waiting for a status that will never arrive, and there is nothing to re-run.

This isn't hypothetical — #941 demonstrated it. A single markdown file, and its check rollup came back empty.

## Why now

`07lk.14` sets `main`'s protection to require `cassette-gate` and `test-fast` and turns on `enforce_admins`. The current protection is configured backwards from that target:

```
required_approving_review_count: 1      <- an approval nobody can give
enforce_admins:                  false  <- so it gets bypassed
required_status_checks:          NONE SET
```

Requiring the checks while a whole class of PR cannot produce them would deadlock every future documentation change — and with `enforce_admins: true` there'd be no bypass. So `paths-ignore` has to go first.

## Cost

A fast-test run on markdown-only PRs. The workflow's cost design already keeps PRs to the cheap tier — fast tests, single Python version — while the full matrix, network and slow suites stay on push-to-main and the nightly cron. Those are unaffected; this only changes which events start the workflow.

## Sequencing after this merges

1. Open a docs-only PR and confirm `cassette-gate` and `test-fast` both report
2. Set `required_approving_review_count: 0`
3. Require `cassette-gate` + `test-fast`
4. Enable `enforce_admins: true`

Step 1 is the one that matters — enabling `enforce_admins` before the checks are known to report on every PR type would lock the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)