### PR TITLE
fix(10-K): convert Cross Reference Index items to text before returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **10-K items came back as raw HTML on filings that use a Cross Reference Index.** `TenK.__getitem__` prefers the Cross Reference Index when a filing has one, and returned `CrossReferenceIndex.extract_item_content()` straight through. That method returns HTML by contract — it slices the source document by page range — while every other branch of the same lookup returns text. Citigroup's FY2024 10-K (`0000831001-25-000029`) gave 1,685,461 characters beginning `<div style="min-height:36pt;width:100%">` for `obj['Item 1']`, now 218,550 characters of text opening on the Business overview. The item is converted before the trailing-`PART` cleanup that follows it, which was always written for text and silently did nothing to markup.
+
+  It surfaced per item rather than per filing: Citi's section map has only four non-canonical keys, so items coinciding with one of those (`Item 1A`, `Item 7`, `Item 8`) already returned text, while Item 1 had no such section, missed the canonical-Part lookup, and fell through to the Cross Reference Index. Items on any filing that reaches this branch — GE and Henry Schein among them — now return text, so a caller that was parsing the returned markup will need to stop. This is the "Citi HTML leakage" named in GH #821, which was closed on the section-map behaviour while the item API kept emitting HTML.
+
 ### Changed
 
 - **`FactQuery.to_dataframe()` now declares its columns instead of inferring them from the rows a query returned.** The column set follows the query's *configuration* — the `include_*` flags and any names passed to `to_dataframe()` — and no longer varies with which facts happened to match. Three things change for callers: a column no matching row populated comes back null rather than disappearing (`.limit(5)` on Foot Locker's FY2024 10-K returned five fewer columns than the same query unlimited, having dropped `balance`, `currency`, `decimals`, `unit_ref` and `weight` because those five rows were null); narrowing to instant facts no longer removes `period_start`/`period_end`; and an empty result now carries the full column set with zero rows, so `df['decimals']` yields an empty column instead of raising `KeyError`. Requesting a column by name in `to_dataframe('concept', 'period_instant')` likewise returns it null rather than silently omitting it.

--- a/edgar/company_reports/ten_k.py
+++ b/edgar/company_reports/ten_k.py
@@ -11,7 +11,7 @@ from rich.tree import Tree
 from edgar.company_reports._base import CompanyReport
 from edgar.company_reports._structures import FilingStructure
 from edgar.core import log
-from edgar.documents import HTMLParser, ParserConfig
+from edgar.documents import HTMLParser, ParserConfig, parse_html
 from edgar.files.htmltools import ChunkedDocument
 from edgar.display.formatting import datefmt
 
@@ -652,15 +652,26 @@ class TenK(CompanyReport):
         if self._cross_reference_index is not None:
             item_id = _CROSS_REF_ITEM_MAP.get(item_or_part)
             if item_id:
-                # Extract content using Cross Reference Index parser
-                item_text = self._cross_reference_index.extract_item_content(item_id)
-                if item_text:
-                    # Successfully extracted via Cross Reference Index
-                    item_text = item_text.rstrip()
-                    last_line = item_text.split("\n")[-1]
-                    if re.match(r'^\b(PART\s+[IVXLC]+)\b', last_line):
-                        item_text = item_text.rstrip(last_line)
-                    return item_text
+                # Extract content using Cross Reference Index parser.
+                # extract_item_content() returns HTML by contract (it slices the
+                # source document by page range), while every other branch of
+                # this method returns text. Returning it unconverted handed
+                # callers raw markup — 1.7MB of <div>/<span> for Citigroup's
+                # Item 1, the "HTML leakage" half of GH #821. Convert before the
+                # PART-stripping below, which is written for text and silently
+                # did nothing on markup.
+                item_html = self._cross_reference_index.extract_item_content(item_id)
+                if item_html:
+                    item_text = parse_html(item_html).text()
+                    # An empty conversion falls through to the legacy fallback
+                    # rather than returning the markup — a caller that asked for
+                    # text is better served by the next strategy than by HTML.
+                    if item_text and item_text.strip():
+                        item_text = item_text.rstrip()
+                        last_line = item_text.split("\n")[-1]
+                        if re.match(r'^\b(PART\s+[IVXLC]+)\b', last_line):
+                            item_text = item_text.rstrip(last_line)
+                        return item_text
 
         # Fall back to chunked document for backward compatibility
         # Log fallback usage for Phase 1 deprecation tracking

--- a/tests/issues/regression/test_issue_215_ge_cross_reference_index.py
+++ b/tests/issues/regression/test_issue_215_ge_cross_reference_index.py
@@ -211,8 +211,20 @@ class TestIssue215TenKIntegration:
 
         assert directors is not None, \
             "tenk.directors_officers_and_governance should not return None for GE"
-        assert len(directors) > 5000, \
+
+        # The old floor here was 5000, which this section cleared only because
+        # the Cross Reference Index branch returned raw HTML — markup inflated
+        # the length. Now that it returns text (GH #821 "HTML leakage"), the
+        # same section is ~4,970 characters. Assert on content instead of on a
+        # markup-inflated length, and pin the text-not-markup property that
+        # the shorter length actually reflects.
+        assert len(directors) > 1000, \
             f"Directors section should have content (got {len(directors)} chars)"
+        assert 'DIRECTORS, EXECUTIVE OFFICERS' in directors.upper(), \
+            "Directors section should carry its own heading"
+        leaked_markup = '<div' in directors or '<span' in directors
+        assert not leaked_markup, \
+            f"Directors section returned raw HTML: {directors[:120]!r}"
 
     def test_tenk_getitem_direct_access(self, ge_tenk):
         """Test direct access via tenk['Item 1A'] for GE."""

--- a/tests/issues/regression/test_issue_821_citi_html_leak.py
+++ b/tests/issues/regression/test_issue_821_citi_html_leak.py
@@ -1,0 +1,119 @@
+"""Regression test for the "Citi HTML leakage" half of GH #821 (bead edgartools-sldz,
+mechanism recorded on edgartools-llmp.6.4).
+
+Bug:
+    TenK.__getitem__ prefers the Cross Reference Index when a filing has one
+    (edgar/company_reports/ten_k.py, "prefer it over chunked_document"). That
+    branch returned CrossReferenceIndex.extract_item_content() directly, and
+    that method returns HTML by contract — it slices the source document by
+    page range. Every other branch of the same method returns text.
+
+    So callers asking for an item got raw markup. On Citigroup's 2024 10-K,
+    tenk['Item 1'] returned 1,685,461 characters beginning
+    '<div style="min-height:36pt;width:100%">...'.
+
+    It surfaced on Citi specifically because doc.sections yields only four
+    non-canonical keys there (mda, risk_factors, financial_statements,
+    controls_procedures). Items that coincide with one of those returned clean
+    text; Item 1 (Business) has no such section, missed the part_key lookup,
+    and fell through to the cross-reference branch.
+
+    The giveaway that this was a bug rather than a contract: the code
+    immediately below the return strips a trailing 'PART IV' line using
+    text.split("\\n")[-1], which is written for text and silently does nothing
+    to markup.
+
+Fix:
+    Convert with parse_html(...).text() before the PART-stripping. An empty
+    conversion falls through to the legacy fallback rather than returning the
+    markup.
+
+Offline: drives TenK against the tracked 16.7MB Citi fixture through a minimal
+filing stub, so no network is required.
+"""
+from pathlib import Path
+
+import pytest
+
+from edgar.company_reports import TenK
+
+FIXTURE = Path(__file__).parents[2] / "fixtures" / "html" / "c" / "10k" / "c-10-k-2025-02-21.html"
+
+pytestmark = pytest.mark.skipif(not FIXTURE.exists(),
+                                reason="Citigroup 10-K fixture not available")
+
+
+class _StubFiling:
+    """Minimal surface TenK needs: html(), and identifiers used in logging."""
+    accession_number = "0000831001-25-000029"
+    base_dir = ""
+    form = "10-K"
+    company = "Citigroup Inc."
+    cik = 831001
+    filing_date = "2025-02-21"
+
+    def __init__(self, html: str):
+        self._html = html
+
+    def html(self) -> str:
+        return self._html
+
+
+@pytest.fixture(scope="module")
+def citi_tenk():
+    return TenK(_StubFiling(FIXTURE.read_text(encoding="utf-8")))
+
+
+class TestCitiItemsAreTextNotHtml:
+
+    def test_cross_reference_branch_is_actually_exercised(self, citi_tenk):
+        """Guard against a vacuous pass.
+
+        If Citi ever stops being detected as a Cross Reference Index filing, or
+        Item 1 starts resolving from doc.sections, the assertions below would
+        hold for a reason unrelated to this bug.
+        """
+        assert citi_tenk._cross_reference_index is not None, \
+            "Citi is no longer detected as a Cross Reference Index filing"
+        assert 'part_i_item_1' not in (citi_tenk.sections or {}), \
+            "Item 1 now resolves from doc.sections; this test no longer covers the leak"
+
+    def test_item_1_returns_text_not_markup(self, citi_tenk):
+        item1 = citi_tenk['Item 1']
+
+        assert item1 is not None, "Item 1 (Business) should not be None"
+        # Reduce to a bool before asserting. When this fails the item is ~1.7MB
+        # of markup, and pytest's assertion introspection renders the operands —
+        # asserting on the string directly turns a failure into a multi-minute
+        # hang instead of a test report.
+        leaked_markup = '<div' in item1 or '<span' in item1
+        assert not leaked_markup, f"Item 1 returned raw HTML: {item1[:120]!r}"
+
+    def test_item_1_carries_the_business_narrative(self, citi_tenk):
+        """Ground truth, hand-checked against the filing.
+
+        Length alone would not catch the bug — the HTML was 1.68M characters,
+        far longer than the correct text — so assert on content that only the
+        Business section contains.
+        """
+        item1 = citi_tenk['Item 1']
+
+        # Bools first — see the note in test_item_1_returns_text_not_markup.
+        has_narrative = ("Citigroup's history dates back to the founding of the City B" in item1
+                         or "Citigroup’s history dates back to the founding of the City B" in item1)
+        assert has_narrative, "Item 1 does not open on Citi's Business narrative"
+
+        starts_at_overview = item1.lstrip().startswith('OVERVIEW')
+        assert starts_at_overview, \
+            f"Item 1 should begin at the Business overview, got {item1[:60]!r}"
+
+    @pytest.mark.parametrize("item", ["Item 1", "Item 1A", "Item 7", "Item 8"])
+    def test_no_item_leaks_markup(self, citi_tenk, item):
+        """The other items resolved from doc.sections and were already text.
+        They are included so a future change that routes them through the
+        cross-reference branch cannot regress them silently."""
+        value = citi_tenk[item]
+
+        assert value, f"{item} returned nothing"
+        leaked_markup = '<div' in value or '<span' in value
+        assert not leaked_markup, f"{item} returned raw HTML: {value[:120]!r}"


### PR DESCRIPTION
Fixes the "Citi HTML leakage" half of GH #821 — the bug that closed with `sldz` but stayed live in the item API. Mechanism recorded on `edgartools-llmp.6.4`.

## What was wrong

`TenK.__getitem__` prefers the Cross Reference Index when a filing has one, and returned `CrossReferenceIndex.extract_item_content()` straight through. That method returns **HTML by contract** — it slices the source document by page range — while every other branch of the same lookup returns text.

```
Item 1    1,685,461 chars   RAW HTML   '<div style="min-height:36pt;width:100%">...'
Item 1A     484,080 chars   text       'RISK FACTORS...'
Item 7      234,483 chars   text       'MANAGEMENT'S DISCUSSION AND ANALYSIS...'
Item 8    1,019,789 chars   text       'CONSOLIDATED FINANCIAL STATEMENTS...'
```

It surfaced **per item, not per filing**: Citi's section map has only four non-canonical keys, so Items 1A/7/8 coincide with one and already returned text. Item 1 has no such section, missed the canonical-Part lookup at `ten_k.py:645`, and fell through to the cross-reference branch.

The clearest sign this was a bug rather than a contract: the code immediately below the return strips a trailing `PART IV` line via `text.split("\n")[-1]` — written for text, and silently a no-op on markup.

## The fix

Convert with `parse_html(...).text()` before that PART-stripping. An empty conversion falls through to the legacy fallback rather than returning markup — a caller who asked for text is better served by the next strategy.

**Citi `Item 1`: 1,685,461 chars of HTML → 218,550 chars of text**, opening `OVERVIEW\n\nCitigroup's history dates back to the founding of the City B…`.

## Blast radius

Any filing reaching this branch — **GE and Henry Schein included** — now returns text instead of HTML. That is the intended correction, and no test asserted HTML-ness, but it is a visible change for a caller that was parsing the returned markup. Called out in the CHANGELOG.

## Testing

`tests/issues/regression/test_issue_821_citi_html_leak.py` — 7 tests, offline against the tracked 16.7MB Citi fixture, 5.6s. Confirmed it **fails without the fix** (3 failures, all Item 1) and passes with it. It asserts the cross-reference branch is actually the one exercised, so it cannot pass vacuously if detection changes underneath it.

It asserts on **booleans rather than the item strings directly**: when this regresses the value is ~1.7MB, and pytest's assertion introspection on an operand that size turns a failure into a multi-minute hang rather than a report. (Learned the hard way.)

**One existing test changed.** GE's `test_tenk_directors_officers_property` asserted `len(directors) > 5000` — a threshold the section cleared only because markup inflated its length; as text it is 4,973. Replaced with a content assertion (`DIRECTORS, EXECUTIVE OFFICERS` present), a lower floor, and an explicit no-markup check, so it pins the property the length was standing in for rather than just relaxing the number.

Runs: 62 passed across cross-reference / GE (#215) / `has_index` (#928) / GS (#821); 464 passed, 1 skipped across the broader TenK and section suites.

## What this does not fix

Citi still returns 4 non-canonical sections where comparable 10-Ks return 20–24 — tracked on `edgartools-4agg`, where I've also recorded evidence that its cross-reference index is fully parseable (22 items with page ranges, folios recoverable 328/328 monotonic), which suggests a cheaper route than the positional slicing that issue proposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)