### PR TITLE
ci: document that required checks are pinned to job names

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -12,6 +12,25 @@
 # request forever. Since these checks are meant to become required, every PR has
 # to produce them — the few CI minutes a markdown-only run costs are cheaper than
 # a merge queue that deadlocks on documentation.
+#
+# REQUIRED CHECKS ARE PINNED TO JOB NAMES. `main` requires exactly two contexts:
+#
+#     Cassette safety gate
+#     test-fast (3.13)
+#
+# The second name is generated from the matrix below, which is event-dependent —
+# a pull request builds only 3.13, so the context is literally "test-fast (3.13)".
+# Renaming a job, or changing the pull-request leg of that matrix, retires the
+# context that branch protection is waiting for; it never reports, and every pull
+# request blocks forever with enforce_admins on. If you touch either, update the
+# protection contexts in the same commit:
+#
+#     gh api repos/dgunning/edgartools/branches/main/protection \
+#        --jq .required_status_checks.contexts
+#
+# test-network, test-slow and Combine Coverage are deliberately NOT required:
+# they carry `if: github.event_name != 'pull_request'` and so report as skipped
+# on every pull request. They run on push to main, which is the integration gate.
 
 name: Build and Test Edgartools
 


### PR DESCRIPTION
Branch protection on `main` was just corrected — approvals 1→0, `enforce_admins` false→true, and two required status checks added where there were none.

This PR records the trap that creates, next to the code that can spring it, and doubles as the end-to-end verification that the new configuration actually permits merging.

## The coupling

`main` now requires exactly two contexts:

```
Cassette safety gate
test-fast (3.13)
```

The second is generated from the matrix in this file, which is event-dependent:

```yaml
python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.13"]') || fromJSON('["3.10", "3.13"]') }}
```

Rename the job, or change the pull-request leg of that matrix, and the context branch protection waits for is retired. It never reports, every PR blocks, and with `enforce_admins: true` there is no `--admin` escape. This is the same failure the file already warns about for `paths-ignore`, one level up: the deadlock moves from "no checks at all" to "a check that can never arrive".

The durable fix is a fixed-name aggregator job (`needs: [test-fast]`) whose name never changes, and requiring that instead. Worth doing before 6.0 adds Python versions — not done here to keep this change comment-only.

## Why those two and not the others

`test-network`, `test-slow` and `Combine Coverage` all carry `if: github.event_name != 'pull_request'`, so they report skipped on every PR. Requiring a check that does not run is how you deadlock a branch, and they add no PR signal anyway — they run on push to `main`, which is the integration gate.

## This PR is also the test

Every merge today used `--admin` because the old configuration required an approval no one could give. This PR should merge with **no** `--admin`, once both required checks report green. If it can't, the configuration is wrong and gets rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)