### PR TITLE
perf(sections): index anchors per document and walk from the anchor, not the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Section extraction is 4.4x faster on the benchmark corpus** — 20.8s to 4.7s across ten filings, with no change to any extracted section. Two costs dominated the stage, and both were doing the same work repeatedly.
+
+  Anchor resolution ran a full-document XPath per lookup, from eleven call sites. On Morgan Stanley's 9.8MB 10-K that was 92 lookups resolving 30 distinct ids against one tree — 3,854ms, 60% of the whole stage — with 67% of calls re-resolving an id already looked up on the same tree. One indexing pass now serves every lookup, costing ~31ms on that document. The index is cached weakly on the document root so it dies with the tree, and it is built from the document root rather than whichever element was passed, because `//*` is an absolute path: an index built by walking a subtree would have resolved fewer anchors than the XPath it replaces.
+
+  Section content was collected with `iterwalk`, which always begins at the document root, so every section paid for each element preceding its own start anchor and then discarded it — 3,121,117 of 3,892,226 tree events, 80% of the traversal, and worst at the end of a filing, where `part_iii_item_14` walked 190,115 events to use 9. The walk now starts at the anchor, which was already resolved. It is not a subtree walk: sections routinely span containers, and the collector relies on `end` events from ancestors whose `start` fired before the anchor, since those carry the block-level paragraph breaks and tail text.
+
+  Per-filing: Morgan Stanley 6,308ms to 1,136ms, Ambac 3,711 to 519, Regions 3,807 to 793, Tesla 1,549 to 248, Meta 1,189 to 182, Foot Locker 1,185 to 273, ODP 984 to 439. Citigroup moves least (1,048 to 919) because it resolves its items through the cross-reference index, which uses no anchors.
+
+  Guarded by equivalence rather than by expectation: the index returns the identical elements in identical document order as the XPath for all 509 anchor ids across the corpus, the walk reproduces the root walk's exact event sequence from 286 different start elements, and every section's text is byte-identical to before across all eleven documents.
+
 ### Fixed
 
 - **Wells Fargo's 10-K published its exhibit list as the financial statements, and Citigroup's items were unreachable by their canonical keys.** Two filings that every anchor-driven strategy failed on, for two unrelated structural reasons.

--- a/edgar/documents/extractors/toc_section_extractor.py
+++ b/edgar/documents/extractors/toc_section_extractor.py
@@ -17,6 +17,7 @@ from lxml import html as lxml_html
 from edgar.documents.document import Document
 from edgar.documents.nodes import Node
 from edgar.documents.utils.anchor_targets import find_anchor_targets, is_anchor_match
+from edgar.documents.utils.tree_traversal import iterwalk_from, precedes
 from edgar.documents.utils.toc_analyzer import TOCAnalyzer
 
 logger = logging.getLogger(__name__)
@@ -750,6 +751,26 @@ class SECSectionExtractor:
         if not start_elements:
             return ""
 
+        # An end boundary that sits BEFORE the start anchor means the boundary
+        # pair is inverted, and this section yields nothing.
+        #
+        # The root walk got this for free: it tested the end anchor before
+        # `in_range` was ever set, so an inverted pair broke out on the first
+        # pass and returned "". Walking from the start anchor never meets that
+        # earlier element, so the section would instead run to the end of the
+        # document — 26,330 chars for a Morgan Stanley Item 1B that is a single
+        # paragraph, ending in the signature block, at confidence 0.95 with no
+        # warning. Silence is the better answer, so the check is now explicit.
+        #
+        # It fires on 4 sections across 3 of the 11 corpus documents. The
+        # inverted boundaries themselves are a separate detection bug
+        # (edgartools-4q74); this preserves the behaviour rather than papering
+        # over it with over-captured text.
+        if boundary.end_element_id:
+            end_elements = find_anchor_targets(tree, boundary.end_element_id)
+            if end_elements and precedes(end_elements[0], start_elements[0]):
+                return ""
+
         # Use document-order traversal (iterwalk) to collect all text between anchors
         # This correctly handles multi-container sections where start and end anchors
         # are in different parent containers
@@ -760,7 +781,16 @@ class SECSectionExtractor:
         block_elements = {'p', 'div', 'table', 'tr', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
                          'blockquote', 'pre', 'section', 'article', 'header', 'footer'}
 
-        for event, el in etree.iterwalk(tree, events=('start', 'end')):
+        # Walk from the start anchor rather than the document root. iterwalk always
+        # begins at the root, so each section used to pay for every element ahead
+        # of its own anchor and discard it — 80% of the traversal on a 9.8MB 10-K,
+        # and worst for the last items in a filing (edgartools-llmp.8). The element
+        # is already resolved above, so starting there costs nothing extra.
+        #
+        # The loop body below is unchanged: iterwalk_from yields the identical
+        # event/element sequence the root walk would have produced from this point
+        # on, ancestor 'end' events included.
+        for event, el in iterwalk_from(start_elements[0]):
             # Skip non-element nodes (comments, etc.)
             if not hasattr(el, 'get'):
                 continue

--- a/edgar/documents/utils/anchor_targets.py
+++ b/edgar/documents/utils/anchor_targets.py
@@ -1,12 +1,121 @@
 """Utilities for resolving and matching SEC anchor targets."""
 
+from weakref import WeakKeyDictionary
+
+# One anchor index per document tree.
+#
+# Anchor resolution used to run a full-document XPath per lookup, and section
+# extraction calls it from eleven sites: on a 9.8MB 10-K that was 92 calls
+# resolving 30 distinct ids against one tree, 3,854ms — 60% of the whole
+# sections stage — with 67% of calls re-resolving an id already looked up on the
+# same tree (edgartools-llmp.7). One index pass costs ~31ms on that document and
+# serves every subsequent lookup.
+#
+# Keyed weakly on the document root element so the index dies with the tree.
+# lxml.html elements support weak references (lxml.etree._ElementTree does not,
+# which is why the key is normalized to the root element), and a weak key avoids
+# the id()-reuse hazard of caching on id(tree) — lxml materializes element
+# proxies on demand, so an id() is only unique while a proxy is alive.
+#
+# Safe to cache because nothing in the section-extraction path mutates a shared
+# tree: section_slicer deep-copies elements before re-parenting them precisely so
+# that re-parenting cannot mutate the source (see its ``_clone``). A caller that
+# does mutate a tree must drop the entry via ``invalidate_anchor_index``.
+_ANCHOR_INDEX_CACHE: "WeakKeyDictionary" = WeakKeyDictionary()
+
+
+def _document_root(tree):
+    """Normalize an element or ElementTree to the document root element.
+
+    ``tree.xpath('//*[...]')`` is an absolute path — it searches from the
+    document root no matter which element it is called on — so an index built by
+    walking a subtree would resolve fewer anchors than the XPath it replaces.
+    Both entry points converge here.
+
+    ``getroot()`` returns an identity-stable proxy, which is what makes it usable
+    as a cache key; ``getroottree()`` builds a fresh wrapper each call and is not.
+    """
+    getroot = getattr(tree, 'getroot', None)
+    if getroot is not None:          # an _ElementTree
+        return getroot()
+    getroottree = getattr(tree, 'getroottree', None)
+    if getroottree is not None:      # an element
+        return getroottree().getroot()
+    return tree
+
+
+def _build_anchor_index(root):
+    """Map every anchor id/name to its elements, in document order.
+
+    Mirrors ``//*[@id=$a or (self::a and @name=$a)]`` exactly:
+      * ``//*`` selects elements only, so comments and processing instructions
+        (which ``iter()`` also yields) are skipped via the ``str`` tag check.
+      * the ``or`` means an ``<a>`` carrying the same value as both ``id`` and
+        ``name`` matches once, not twice — hence the ``name != anchor_id`` guard.
+      * ``iter()`` yields document order, which is the order XPath returns.
+    """
+    index: dict = {}
+    for el in root.iter():
+        if not isinstance(el.tag, str):
+            continue
+        anchor_id = el.get('id')
+        if anchor_id:
+            index.setdefault(anchor_id, []).append(el)
+        if el.tag == 'a':
+            name = el.get('name')
+            if name and name != anchor_id:
+                index.setdefault(name, []).append(el)
+    return index
+
+
+def _anchor_index(tree):
+    """Index for ``tree``'s document, building and caching it on first use.
+
+    Returns None when the tree cannot serve as a weak key, so the caller falls
+    back to the XPath rather than failing.
+    """
+    try:
+        root = _document_root(tree)
+    except Exception:
+        return None
+
+    try:
+        index = _ANCHOR_INDEX_CACHE.get(root)
+    except TypeError:
+        return None  # unhashable or not weak-referenceable
+
+    if index is None:
+        index = _build_anchor_index(root)
+        try:
+            _ANCHOR_INDEX_CACHE[root] = index
+        except TypeError:
+            pass  # usable for this call, just not cacheable
+    return index
+
+
+def invalidate_anchor_index(tree) -> None:
+    """Drop the cached index for ``tree``'s document.
+
+    Only needed if a caller mutates a tree's ids, names or structure after
+    anchors have been resolved against it. No current code path does.
+    """
+    try:
+        _ANCHOR_INDEX_CACHE.pop(_document_root(tree), None)
+    except TypeError:
+        pass
+
 
 def find_anchor_targets(tree, anchor_id: str):
     """Find elements matching an anchor target via either id or name."""
     if not anchor_id:
         return []
 
-    return tree.xpath('//*[@id=$anchor_id or (self::a and @name=$anchor_id)]', anchor_id=anchor_id)
+    index = _anchor_index(tree)
+    if index is None:
+        return tree.xpath('//*[@id=$anchor_id or (self::a and @name=$anchor_id)]', anchor_id=anchor_id)
+
+    # Copy so a caller mutating the result cannot corrupt the cached index.
+    return list(index.get(anchor_id, ()))
 
 
 def is_anchor_match(element, anchor_id: str) -> bool:

--- a/edgar/documents/utils/tree_traversal.py
+++ b/edgar/documents/utils/tree_traversal.py
@@ -1,0 +1,74 @@
+"""Document-order tree traversal helpers."""
+
+from lxml import etree
+
+
+def document_order_path(element):
+    """Sibling-index path from the document root, comparable with ``<``.
+
+    ``[0, 3, 1]`` means "root's child 0, its child 3, its child 1". Comparing two
+    such paths lexicographically gives document order, which lxml exposes no
+    direct operator for. Costs O(depth) rather than a document walk.
+    """
+    path = []
+    node = element
+    parent = node.getparent()
+    while parent is not None:
+        path.append(parent.index(node))
+        node = parent
+        parent = node.getparent()
+    path.reverse()
+    return path
+
+
+def precedes(first, second) -> bool:
+    """True if ``first`` comes strictly before ``second`` in document order."""
+    return document_order_path(first) < document_order_path(second)
+
+
+def iterwalk_from(start_element):
+    """Yield ``(event, element)`` in document order from ``start_element`` onward.
+
+    Produces exactly the tail of
+    ``etree.iterwalk(tree, events=('start', 'end'))`` beginning at
+    ``start_element``'s ``start`` event — same events, same order, same element
+    objects — without paying for the elements that precede it.
+
+    That distinction matters because section extraction walks from the document
+    root for every section, so each one pays for the whole prefix of the filing
+    before its own start anchor and discards it. On a 9.8MB 10-K, 25 extraction
+    calls walked 3,892,226 events to use 771,109: **80% discarded**, and worst at
+    the end of the document, where ``part_iii_item_14`` walked 190,115 events to
+    use 9 (edgartools-llmp.8).
+
+    A subtree walk is *not* a substitute. Sections routinely span containers, and
+    the consumer relies on ``end`` events for elements whose ``start`` fired
+    before the anchor — those carry the block-level paragraph breaks and tail
+    text. So after the start element's own subtree this climbs the ancestor
+    chain, emitting each following sibling's subtree and then the ancestor's
+    ``end``, which is precisely what the root walk would have produced.
+
+    Verified against the root walk over 286 start elements across the 11-document
+    performance corpus: identical event sequences, zero divergence.
+
+    Comments and processing instructions are skipped, because ``iterwalk`` does
+    not yield them either — and passing one to ``iterwalk`` raises
+    ``ValueError: Input object is not an XML element``. No corpus document
+    contains a comment, so only a synthetic case exposes this.
+    """
+    if not isinstance(start_element.tag, str):
+        return
+
+    yield from etree.iterwalk(start_element, events=('start', 'end'))
+
+    node = start_element
+    parent = node.getparent()
+    while parent is not None:
+        for sibling in node.itersiblings():
+            if not isinstance(sibling.tag, str):
+                continue
+            yield from etree.iterwalk(sibling, events=('start', 'end'))
+        if isinstance(parent.tag, str):
+            yield ('end', parent)
+        node = parent
+        parent = node.getparent()

--- a/tests/test_anchor_index_and_traversal.py
+++ b/tests/test_anchor_index_and_traversal.py
@@ -1,0 +1,234 @@
+"""Anchor indexing and document-order traversal (edgartools-llmp.7 / llmp.8).
+
+Both changes are pure performance work whose whole value depends on producing
+*identical* results to what they replace, so these tests assert equivalence
+against the original implementations rather than against hand-written
+expectations:
+
+  * ``find_anchor_targets`` must return the same elements, in the same order, as
+    the full-document XPath ``//*[@id=$a or (self::a and @name=$a)]``.
+  * ``iterwalk_from`` must yield the same ``(event, element)`` sequence as
+    ``etree.iterwalk`` from the document root, from the start element onward —
+    ancestor ``end`` events included, since those carry paragraph breaks and
+    tail text.
+"""
+import pytest
+from lxml import etree
+from lxml import html as lxml_html
+
+from edgar.documents.utils.anchor_targets import (
+    find_anchor_targets,
+    invalidate_anchor_index,
+    is_anchor_match,
+)
+from edgar.documents.utils.tree_traversal import (
+    document_order_path,
+    iterwalk_from,
+    precedes,
+)
+
+# Fully offline: every test parses an inline HTML string with lxml and touches
+# no filesystem or network. Marked explicitly rather than by filename so the
+# collection gate in conftest can place the file in a CI job.
+pytestmark = pytest.mark.fast
+
+XPATH = '//*[@id=$anchor_id or (self::a and @name=$anchor_id)]'
+
+# Exercises every branch the index has to mirror: plain id, <a name>, an <a>
+# carrying id and name with the SAME value (must not be listed twice), an <a>
+# whose id and name DIFFER (must be reachable under both), a duplicate id
+# (document order matters), a non-anchor `name` (must be ignored), nesting, and
+# a comment (which `//*` excludes but `iter()` yields).
+SAMPLE = """
+<html><body>
+  <div id="top">top text
+    <a name="alpha"></a>
+    <p id="dup">first dup</p>
+    <!-- a comment -->
+    <a id="both" name="both">same value</a>
+    <a id="idx" name="namex">different values</a>
+    <input name="notananchor"/>
+    <span id="nested"><b id="deep">deep</b></span>
+  </div>
+  <div id="second">
+    <p id="dup">second dup</p>
+  </div>
+</body></html>
+"""
+
+
+def _tree():
+    return lxml_html.fromstring(SAMPLE)
+
+
+class TestAnchorIndexMatchesXPath:
+
+    def test_every_id_and_name_resolves_identically(self):
+        tree = _tree()
+        ids = ["top", "alpha", "dup", "both", "idx", "namex", "nested",
+               "deep", "second", "notananchor", "missing", ""]
+
+        for anchor_id in ids:
+            expected = tree.xpath(XPATH, anchor_id=anchor_id) if anchor_id else []
+            got = find_anchor_targets(tree, anchor_id)
+            assert len(got) == len(expected), f"{anchor_id!r}: {len(got)} vs {len(expected)}"
+            assert all(g is e for g, e in zip(got, expected, strict=True)), \
+                f"{anchor_id!r}: different elements or order"
+
+    def test_element_with_matching_id_and_name_is_returned_once(self):
+        """The XPath's `or` matches such an element once; a naive index lists it twice."""
+        tree = _tree()
+
+        assert len(find_anchor_targets(tree, "both")) == 1
+
+    def test_anchor_reachable_under_both_id_and_name_when_they_differ(self):
+        tree = _tree()
+
+        by_id = find_anchor_targets(tree, "idx")
+        by_name = find_anchor_targets(tree, "namex")
+
+        assert len(by_id) == 1 and len(by_name) == 1
+        assert by_id[0] is by_name[0]
+
+    def test_name_on_non_anchor_element_is_not_a_target(self):
+        """`self::a and @name` — only <a> elements match by name."""
+        tree = _tree()
+
+        assert find_anchor_targets(tree, "notananchor") == []
+
+    def test_duplicate_ids_come_back_in_document_order(self):
+        tree = _tree()
+
+        got = find_anchor_targets(tree, "dup")
+
+        assert [e.text for e in got] == ["first dup", "second dup"]
+
+    def test_result_is_a_copy_so_callers_cannot_corrupt_the_cache(self):
+        tree = _tree()
+
+        first = find_anchor_targets(tree, "dup")
+        first.clear()
+
+        assert len(find_anchor_targets(tree, "dup")) == 2
+
+    def test_repeated_lookups_are_stable(self):
+        """The second lookup is served from the cache; it must not differ."""
+        tree = _tree()
+
+        a = find_anchor_targets(tree, "nested")
+        b = find_anchor_targets(tree, "nested")
+
+        assert a[0] is b[0]
+
+    def test_invalidate_forces_a_rebuild(self):
+        tree = _tree()
+        find_anchor_targets(tree, "top")
+
+        invalidate_anchor_index(tree)
+
+        assert find_anchor_targets(tree, "top")[0] is tree.xpath(XPATH, anchor_id="top")[0]
+
+    def test_index_is_built_from_the_document_root_not_the_subtree(self):
+        """`//*` is absolute: called on a subtree element it still searches the
+        whole document. An index built by walking that subtree would resolve
+        fewer anchors."""
+        tree = _tree()
+        subtree = tree.xpath('//div[@id="second"]')[0]
+
+        # "top" lives outside `subtree`, but the XPath finds it from there.
+        assert len(subtree.xpath(XPATH, anchor_id="top")) == 1
+        assert len(find_anchor_targets(subtree, "top")) == 1
+
+    def test_separate_trees_do_not_share_an_index(self):
+        one, two = _tree(), lxml_html.fromstring("<html><body><p id='top'>other</p></body></html>")
+
+        assert find_anchor_targets(one, "top")[0].get("id") == "top"
+        assert find_anchor_targets(two, "top")[0].text == "other"
+        assert find_anchor_targets(two, "alpha") == []
+
+
+class TestIsAnchorMatchUnchanged:
+
+    def test_matches_by_id_and_by_anchor_name_only(self):
+        tree = _tree()
+        a_named = tree.xpath('//a[@name="alpha"]')[0]
+        not_anchor = tree.xpath('//input')[0]
+
+        assert is_anchor_match(a_named, "alpha") is True
+        assert is_anchor_match(not_anchor, "notananchor") is False
+        assert is_anchor_match(a_named, "") is False
+
+
+class TestIterwalkFromMatchesRootWalk:
+
+    def test_sequence_is_the_tail_of_the_root_walk(self):
+        tree = _tree()
+        full = list(etree.iterwalk(tree, events=('start', 'end')))
+
+        for index, (event, element) in enumerate(full):
+            if event != 'start':
+                continue
+            expected = full[index:]
+            got = list(iterwalk_from(element))
+
+            assert len(got) == len(expected), f"at {element.tag}: {len(got)} vs {len(expected)}"
+            assert all(g[0] == e[0] and g[1] is e[1] for g, e in zip(got, expected, strict=True)), \
+                f"diverged starting at {element.tag}"
+
+    def test_ancestor_end_events_are_emitted(self):
+        """The reason a subtree walk is not a substitute: content after a deep
+        start element includes its ancestors' `end` events, which carry the
+        block-level paragraph breaks and tail text."""
+        tree = _tree()
+        deep = tree.xpath('//b[@id="deep"]')[0]
+
+        events = list(iterwalk_from(deep))
+        ended = [el.get('id') for ev, el in events if ev == 'end']
+
+        # Its own end, then the ancestors it sits inside, outermost last.
+        assert 'deep' in ended
+        assert 'nested' in ended
+        assert 'top' in ended
+        assert ended.index('nested') < ended.index('top')
+
+    def test_following_siblings_are_included(self):
+        tree = _tree()
+        top = tree.xpath('//div[@id="top"]')[0]
+
+        seen = {el.get('id') for ev, el in iterwalk_from(top) if ev == 'start'}
+
+        assert 'second' in seen, "the sibling div after the start element was skipped"
+
+    def test_starting_at_the_last_element_terminates(self):
+        tree = _tree()
+        last = tree.xpath('//div[@id="second"]/p')[0]
+
+        events = list(iterwalk_from(last))
+
+        assert events[0] == ('start', last)
+        assert any(ev == 'end' and el is last for ev, el in events)
+
+
+class TestDocumentOrder:
+
+    def test_precedes_follows_document_order(self):
+        tree = _tree()
+        order = [el for el in tree.iter() if isinstance(el.tag, str)]
+
+        for earlier, later in zip(order, order[1:], strict=False):
+            assert precedes(earlier, later) is True
+            assert precedes(later, earlier) is False
+
+    def test_an_element_does_not_precede_itself(self):
+        tree = _tree()
+        el = tree.xpath('//*[@id="both"]')[0]
+
+        assert precedes(el, el) is False
+
+    def test_path_is_rooted_and_ordered(self):
+        tree = _tree()
+        top = tree.xpath('//div[@id="top"]')[0]
+        second = tree.xpath('//div[@id="second"]')[0]
+
+        assert document_order_path(top) < document_order_path(second)
+        assert document_order_path(tree) == []


### PR DESCRIPTION
Closes `edgartools-llmp.7` and `edgartools-llmp.8`. Taken together because both wanted the resolved start element — doing them separately would have resolved it twice.

**Sections stage: 20,755ms → 4,674ms across the corpus (4.4×), with no change to any extracted section.**

| entry | before | after | speedup |
|---|---:|---:|---:|
| morganstanley_10k_fy2024 | 6,308 | 1,136 | **5.6×** |
| ambac_10k_fy2022 | 3,711 | 519 | **7.2×** |
| regions_10k_fy2021 | 3,807 | 793 | 4.8× |
| tesla_10k_fy2023 | 1,549 | 248 | 6.2× |
| meta_10k_fy2024 | 1,189 | 182 | 6.5× |
| footlocker_10k_fy2024 | 1,185 | 273 | 4.3× |
| odp_10k_fy2025 | 984 | 439 | 2.2× |
| footlocker_10k_fy2013 | 794 | 135 | 5.9× |
| jackhenry_10q_fy2025 | 180 | 30 | 6.0× |
| citigroup_10k_fy2024 | 1,048 | 919 | 1.1× |

Citigroup moving least is the sanity check, not a disappointment: it resolves its items through the cross-reference index (#951), which uses no anchors, so it *should* barely benefit.

## llmp.7 — index anchors per document

`find_anchor_targets` ran `//*[@id=$a or (self::a and @name=$a)]` per lookup, from eleven call sites. On Morgan Stanley: 92 lookups resolving 30 distinct ids against one tree, **3,854ms = 60% of the stage**, 67% of them re-resolving an id already looked up on the same tree.

Two things the issue didn't anticipate:

- It warned that "lxml elements accept neither arbitrary attributes nor weak references". That's true of `lxml.etree._ElementTree` but **not** of `lxml.html.HtmlElement`, which supports both — and every tree at these call sites comes from `lxml_html.fromstring`. So a `WeakKeyDictionary` keyed on the root element works: no `id()`-reuse hazard, no lifetime leak, and **no call-site changes**, since all eleven already pass the tree.
- `//*` is an **absolute** path — called on a subtree element it still searches from the document root. An index built by walking whichever element was passed would silently resolve fewer anchors than the XPath it replaces. The index normalizes to the document root, which also settles the cache key: `getroot()` returns an identity-stable proxy, `getroottree()` builds a fresh wrapper each call.

Caching is safe because nothing mutates a shared tree — `section_slicer` deep-copies before re-parenting precisely so it cannot (its `_clone` docstring says as much). `invalidate_anchor_index` is there for a future caller that does.

## llmp.8 — walk from the anchor

`_extract_section_content` used `iterwalk`, which always begins at the document root, so every section paid for each element preceding its own anchor and discarded it: **3,121,117 of 3,892,226 events, 80% of the traversal**, worst at the end of a filing where `part_iii_item_14` walked 190,115 events to use 9.

`iterwalk_from` is deliberately **not** a subtree walk. Sections routinely span containers, and the collector relies on `end` events from ancestors whose `start` fired before the anchor — those carry the block-level paragraph breaks and tail text. It yields the start element's subtree, then each following sibling's subtree, then the ancestor's `end`, climbing to the root. The loop body it feeds is byte-for-byte unchanged.

## The finding that mattered

Starting mid-document changed output on **4 sections across 3 of 11 documents**. All four have **inverted boundaries** — the end anchor resolves *before* the start anchor:

| | start | end |
|---|---:|---:|
| morganstanley `part_i_item_1b` | 94,674 | 18,696 |
| morganstanley `part_ii_item_5` | 94,699 | 18,742 |
| ambac `part_ii_item_9b` | 53,449 | 19,223 |
| odp `part_ii_item_8` | 13,323 | 11,446 |

The root walk tested the end anchor *before* `in_range` was set, so an inverted pair broke out immediately and returned `""`. Walking from the start never meets that earlier element, so extraction ran to end-of-document instead: Morgan Stanley's Item 1B — a single paragraph — came back as **26,330 chars ending in the signature block, at confidence 0.95, with no warning**, and the size guardrail caught none of the four.

Silence is the better answer, so the check is now explicit rather than an accident of walk order. Converting silence into over-capture inside a perf change would have been the wrong trade. The inverted boundaries are a genuine data-quality bug — those four sections, **including ODP's financial statements**, are simply missing from `document.sections` today — filed as `edgartools-4q74` with the evidence and an explicit warning that the obvious fix is the one rejected here.

## Verification — equivalence, not expectation

| gate | scope | result |
|---|---|---|
| index vs XPath | 509 anchor ids / 11 docs | identical elements **and order**, 0 diff |
| `iterwalk_from` vs root walk | 286 start elements / 11 docs | identical event sequences, 0 diff |
| section text before/after | every section / 11 docs | **byte-identical**, 0 diff |
| `hatch run test-fast` | | 3,500 passed |
| offline regression | | 1,233 passed |

The 18 new unit tests assert equivalence against the original implementations rather than hand-written expectations, on a synthetic document covering every branch the index must mirror: plain `id`, `<a name>`, an `<a>` whose `id` and `name` share a value (must appear **once** — the XPath's `or`), an `<a>` whose `id` and `name` differ (reachable under both), duplicate ids (document order), `name` on a non-anchor (must not match), and a comment.

That comment earned its place: **it caught a real bug the 11-document corpus could not**. `etree.iterwalk` raises `ValueError` on an `HtmlComment`, and `iterwalk_from` was handing it sibling comments. Not one corpus document contains a single comment (measured: non-element nodes = 0 in all 11), so only the synthetic case exposed it.

## Follow-up noted

`edgartools-llmp.9` (the nav-pattern cache md5-ing the whole filing per section) was raised P2 → P1. Its ~340ms is unchanged, but it was ~6% of a 6.3s stage and is now ~30% of the ~1.1s that remains — the largest single item left in this stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
