### PR TITLE
perf(sections): resolve navigation patterns once per document, not once per section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **A filing was md5'd once per section to rebuild a cache key that could not have changed** — the sections stage drops a further 31% on the benchmark corpus, 4.3s to 3.0s, with every section's text byte-identical.
+
+  Navigation-link filtering resolves its patterns through a cache keyed by an md5 of the entire filing, so each lookup encodes and hashes every byte. Section extraction filters once per section, and `Document.text()` filters again, so extracting all 22 sections of Morgan Stanley's 9.8MB 10-K hashed the filing **44 times — 430.7MB hashed to answer a question about 9.8MB**, and the answer was the same every time. The patterns are now resolved once per document and cached on it: 44 hashes become 1.
+
+  The memo lives on the `Document` rather than inside the pattern cache because the HTML is a plain `str`, which supports neither weak references nor attributes, so there is nowhere on the key itself to hang one. The document owns the HTML and dies with it, which is the same lifetime and invalidation story as the anchor index. `filter_with_cached_patterns` keeps its behaviour for callers that filter a single string, and now composes the two halves — `resolve_navigation_patterns` and `filter_navigation_lines` — that a repeat caller should use directly.
+
+  Per-filing sections stage: Regions 790ms to 427, Morgan Stanley 749 to 404, Ambac 462 to 192, Foot Locker 279 to 176, Tesla 239 to 130, Meta 132 to 54. Citigroup is unmoved (947 to 987, within run-to-run noise) because it resolves items through the cross-reference index.
+
 - **Section extraction is 4.4x faster on the benchmark corpus** — 20.8s to 4.7s across ten filings, with no change to any extracted section. Two costs dominated the stage, and both were doing the same work repeatedly.
 
   Anchor resolution ran a full-document XPath per lookup, from eleven call sites. On Morgan Stanley's 9.8MB 10-K that was 92 lookups resolving 30 distinct ids against one tree — 3,854ms, 60% of the whole stage — with 67% of calls re-resolving an id already looked up on the same tree. One indexing pass now serves every lookup, costing ~31ms on that document. The index is cached weakly on the document root so it dies with the tree, and it is built from the document root rather than whichever element was passed, because `//*` is an absolute path: an index built by walking a subtree would have resolved fewer anchors than the XPath it replaces.

--- a/edgar/documents/document.py
+++ b/edgar/documents/document.py
@@ -782,6 +782,31 @@ class Document:
     _text_cache: Optional[str] = field(default=None, init=False, repr=False)
     _config: Optional[Any] = field(default=None, init=False, repr=False)  # ParserConfig reference
     _section_extractor: Optional[Any] = field(default=None, init=False, repr=False)  # cached SECSectionExtractor
+    _nav_patterns: Optional[frozenset] = field(default=None, init=False, repr=False)  # cached navigation patterns
+
+    def _get_navigation_patterns(self) -> frozenset:
+        """Navigation link texts to filter out of extracted text, resolved once.
+
+        Resolution is keyed by an md5 of the entire filing, so it costs an
+        encode plus a hash of every byte — 340ms per call on a 9.8MB 10-K. The
+        section extractor filters once per section, which re-derived that key
+        ~25 times per document to prove it had not changed; against a sections
+        stage that is now ~1.1s on the same filing, that was its single largest
+        remaining item (edgartools-llmp.9).
+
+        Cached on the document rather than inside the pattern cache because the
+        HTML is a plain ``str``, which supports neither weak references nor
+        attributes, so there is nowhere on the key itself to hang a memo. The
+        document owns the HTML and dies with it, which is the same lifetime and
+        the same invalidation story as the anchor index.
+        """
+        if self._nav_patterns is None:
+            from edgar.documents.utils.anchor_cache import resolve_navigation_patterns
+            html = getattr(self.metadata, 'original_html', None)
+            # frozenset() is falsy but not None, so a document that genuinely
+            # has no repeated navigation links is cached, not re-resolved.
+            self._nav_patterns = frozenset(resolve_navigation_patterns(html))
+        return self._nav_patterns
 
     def __getstate__(self) -> Dict[str, Any]:
         """Materialize lazy metadata before serializing a stable document state."""
@@ -913,10 +938,9 @@ class Document:
         if clean:
             # Use cached/integrated navigation filtering (optimized approach)
             try:
-                from edgar.documents.utils.anchor_cache import filter_with_cached_patterns
+                from edgar.documents.utils.anchor_cache import filter_navigation_lines
                 # Use minimal cached approach (no memory overhead)
-                original_html = getattr(self.metadata, 'original_html', None)
-                text = filter_with_cached_patterns(text, html_content=original_html)
+                text = filter_navigation_lines(text, self._get_navigation_patterns())
             except Exception:
                 # Fallback to pattern-based filtering
                 from edgar.documents.utils.toc_filter import filter_toc_links

--- a/edgar/documents/extractors/toc_section_extractor.py
+++ b/edgar/documents/extractors/toc_section_extractor.py
@@ -901,15 +901,19 @@ class SECSectionExtractor:
     def _clean_section_text(self, text: str) -> str:
         """Clean extracted section text."""
         # Apply the same cleaning as the main document
-        from edgar.documents.utils.anchor_cache import filter_with_cached_patterns
+        from edgar.documents.utils.anchor_cache import filter_navigation_lines
 
         # Remove excessive whitespace
         text = re.sub(r'\n\s*\n\s*\n', '\n\n', text)
 
-        # Filter navigation links
+        # Filter navigation links. The patterns are resolved once per document
+        # and cached there: deriving them costs an md5 of the whole filing, and
+        # this runs once per section (edgartools-llmp.9). The guard stays — a
+        # document with no original HTML filters nothing here, where
+        # Document.text() falls back to the generic SEC pattern set.
         html_content = getattr(self.document.metadata, 'original_html', None)
         if html_content:
-            text = filter_with_cached_patterns(text, html_content)
+            text = filter_navigation_lines(text, self.document._get_navigation_patterns())
 
         return text.strip()
 

--- a/edgar/documents/utils/anchor_cache.py
+++ b/edgar/documents/utils/anchor_cache.py
@@ -147,35 +147,39 @@ def _analyze_navigation_minimal(html_content: str, min_frequency: int = 5) -> Se
     return patterns
 
 
-def filter_with_cached_patterns(text: str, html_content: Optional[str] = None) -> str:
+# Used when a document carries no original HTML to analyse: the navigation links
+# that appear on nearly every SEC filing.
+FALLBACK_PATTERNS = frozenset({
+    'Table of Contents',
+    'Index to Financial Statements',
+    'Index to Exhibits',
+})
+
+
+def resolve_navigation_patterns(html_content: Optional[str] = None) -> Set[str]:
     """
-    Filter text using cached navigation patterns.
+    Resolve the navigation patterns for a document's HTML.
+
+    Split out from ``filter_with_cached_patterns`` because resolving is
+    per-document while filtering is per-string. Keying the cache requires an md5
+    of the whole filing, so a caller that filters many strings from one document
+    — section extraction filters once per section — should resolve once and pass
+    the result to ``filter_navigation_lines`` rather than re-deriving a key that
+    cannot have changed (edgartools-llmp.9).
+    """
+    if html_content:
+        return get_cached_navigation_patterns(html_content)
+    return FALLBACK_PATTERNS
+
+
+def filter_navigation_lines(text: str, patterns: Set[str]) -> str:
+    """
+    Drop repeated navigation lines from ``text``, given already-resolved patterns.
 
     Preserves first occurrences of patterns (document structure headers)
     while filtering out repeated navigation links.
-
-    Args:
-        text: Text to filter
-        html_content: HTML for pattern analysis (optional)
-
-    Returns:
-        Filtered text
     """
-    if not text:
-        return text
-
-    # Get patterns (cached or analyze)
-    if html_content:
-        patterns = get_cached_navigation_patterns(html_content)
-    else:
-        # Fallback to common SEC patterns
-        patterns = {
-            'Table of Contents',
-            'Index to Financial Statements',
-            'Index to Exhibits'
-        }
-
-    if not patterns:
+    if not text or not patterns:
         return text
 
     # Smart filtering: preserve first few occurrences, filter out repetitions
@@ -203,3 +207,17 @@ def filter_with_cached_patterns(text: str, html_content: Optional[str] = None) -
             filtered_lines.append(line)
 
     return '\n'.join(filtered_lines)
+
+
+def filter_with_cached_patterns(text: str, html_content: Optional[str] = None) -> str:
+    """
+    Filter text using cached navigation patterns.
+
+    Resolves the patterns and filters in one call. Callers filtering repeatedly
+    against the same document should instead resolve once with
+    ``resolve_navigation_patterns`` and call ``filter_navigation_lines``, so the
+    filing is not re-hashed per call.
+    """
+    if not text:
+        return text
+    return filter_navigation_lines(text, resolve_navigation_patterns(html_content))

--- a/tests/test_navigation_pattern_cache.py
+++ b/tests/test_navigation_pattern_cache.py
@@ -1,0 +1,138 @@
+"""Navigation-pattern resolution is per document, not per section (edgartools-llmp.9).
+
+The pattern cache is keyed by an md5 of the entire filing, so resolving costs an
+encode plus a hash of every byte — ~340ms on a 9.8MB 10-K. Section extraction
+filtered once per section, which re-derived that key roughly 25 times per
+document to prove it had not changed.
+
+These tests assert the *behaviour* rather than the timing: the key is derived a
+bounded number of times per document however many sections are extracted, and
+the text that comes out is unchanged.
+"""
+import pytest
+
+from edgar.documents import parse_html
+from edgar.documents.config import ParserConfig
+from edgar.documents.utils import anchor_cache
+from edgar.documents.utils.anchor_cache import (
+    FALLBACK_PATTERNS,
+    filter_navigation_lines,
+    filter_with_cached_patterns,
+    resolve_navigation_patterns,
+)
+
+# Offline: every test parses an inline HTML string. Marked explicitly rather than
+# by filename so the collection gate in conftest can place the file in a CI job.
+pytestmark = pytest.mark.fast
+
+# Six items, plus a "Table of Contents" backlink repeated often enough to clear
+# _analyze_navigation_minimal's min_frequency of 5.
+NAV_LINK = '<div><a href="#toc">Table of Contents</a></div>'
+ITEMS = [
+    ("i1", "Item 1. Business", "BUSINESS_BODY"),
+    ("i1a", "Item 1A. Risk Factors", "RISK_BODY"),
+    ("i2", "Item 2. Properties", "PROPERTIES_BODY"),
+    ("i3", "Item 3. Legal Proceedings", "LEGAL_BODY"),
+    ("i5", "Item 5. Market for Registrant's Common Equity", "MARKET_BODY"),
+    ("i7", "Item 7. Management's Discussion and Analysis", "MDA_BODY"),
+]
+FILING_HTML = (
+    "<html><body><div id='toc'>"
+    + "".join(f'<a href="#{anchor}">{title}</a>' for anchor, title, _ in ITEMS)
+    + "</div>"
+    + "".join(f"{NAV_LINK}<div id='{anchor}'><p>{title}</p><p>{body}</p></div>"
+             for anchor, title, body in ITEMS)
+    + "</body></html>"
+)
+
+
+@pytest.fixture
+def count_hashes(monkeypatch):
+    """Count every md5-of-the-filing the pattern cache performs."""
+    calls = []
+    original = anchor_cache.AnchorCache._get_html_hash
+
+    def counting(self, html_content):
+        calls.append(len(html_content))
+        return original(self, html_content)
+
+    monkeypatch.setattr(anchor_cache.AnchorCache, "_get_html_hash", counting)
+    return calls
+
+
+def test_filing_is_hashed_a_bounded_number_of_times_regardless_of_section_count(count_hashes):
+    doc = parse_html(FILING_HTML, ParserConfig(form="10-K"))
+    extracted = [s for s in (doc.sections or {}).values() if s.text()]
+
+    assert len(extracted) >= 4, "need several sections for this to mean anything"
+    # A cold document hashes twice — once to look the key up, once to store it.
+    # What must not happen is scaling with the number of sections.
+    assert len(count_hashes) <= 2, (
+        f"hashed the filing {len(count_hashes)} times for {len(extracted)} sections")
+
+
+def test_document_text_does_not_rehash_after_sections(count_hashes):
+    doc = parse_html(FILING_HTML, ParserConfig(form="10-K"))
+    for section in (doc.sections or {}).values():
+        section.text()
+    before = len(count_hashes)
+    doc.text()
+    assert len(count_hashes) == before, "Document.text() re-derived the cache key"
+
+
+def test_patterns_are_resolved_once_and_reused():
+    doc = parse_html(FILING_HTML, ParserConfig(form="10-K"))
+    first = doc._get_navigation_patterns()
+    assert first is doc._get_navigation_patterns()
+    assert "Table of Contents" in first
+
+
+def test_empty_pattern_set_is_cached_not_reresolved(count_hashes):
+    """An empty result is a real answer, so it must not be mistaken for 'unset'."""
+    doc = parse_html("<html><body><p>Item 1. Business</p><p>BODY</p></body></html>",
+                     ParserConfig(form="10-K"))
+    patterns = doc._get_navigation_patterns()
+    assert patterns == frozenset()
+    hashes = len(count_hashes)
+    doc._get_navigation_patterns()
+    assert len(count_hashes) == hashes
+
+
+class TestResolveAndFilterSplit:
+    """The two halves must compose back into the original single-call behaviour."""
+
+    def test_missing_html_falls_back_to_the_generic_sec_patterns(self):
+        assert resolve_navigation_patterns(None) == FALLBACK_PATTERNS
+        assert resolve_navigation_patterns("") == FALLBACK_PATTERNS
+
+    def test_filter_keeps_first_two_occurrences_and_drops_the_rest(self):
+        text = "\n".join(["Table of Contents", "a", "Table of Contents", "b",
+                          "Table of Contents", "c", "Table of Contents"])
+        filtered = filter_navigation_lines(text, {"Table of Contents"})
+        assert filtered.split("\n").count("Table of Contents") == 2
+        assert filtered.split("\n") == ["Table of Contents", "a", "Table of Contents",
+                                        "b", "c"]
+
+    def test_empty_patterns_leave_text_untouched(self):
+        text = "Table of Contents\nbody"
+        assert filter_navigation_lines(text, set()) == text
+        assert filter_navigation_lines("", {"Table of Contents"}) == ""
+
+    @pytest.mark.parametrize("html", [None, FILING_HTML])
+    def test_wrapper_matches_resolve_plus_filter(self, html):
+        text = "\n".join(["Table of Contents", "body", "Table of Contents",
+                          "more", "Table of Contents"])
+        assert filter_with_cached_patterns(text, html) == filter_navigation_lines(
+            text, resolve_navigation_patterns(html))
+
+    def test_wrapper_short_circuits_empty_text(self):
+        assert filter_with_cached_patterns("", FILING_HTML) == ""
+
+
+def test_section_text_is_unchanged_by_the_split():
+    """Equivalence: filtering through the cached patterns matches the old path."""
+    doc = parse_html(FILING_HTML, ParserConfig(form="10-K"))
+    for name, section in (doc.sections or {}).items():
+        text = section.text() or ""
+        expected = filter_with_cached_patterns(text, FILING_HTML)
+        assert text == expected, f"{name} differs from the single-call path"


### PR DESCRIPTION
Closes `edgartools-llmp.9`.

Navigation-link filtering resolves its patterns through a cache keyed by an **md5 of the entire filing**, so every lookup encodes and hashes every byte. Section extraction filters once per section and `Document.text()` filters again, so extracting all 22 sections of Morgan Stanley's 9.8MB 10-K hashed the filing **44 times — 430.7MB hashed to answer a question about 9.8MB** — and the answer was the same every time.

```
                     before      after
filing hashed        44 times    1 time
bytes hashed         430.7 MB    9.8 MB
```

The patterns are now resolved once per document and cached on it. The sections stage drops **31% corpus-wide, 4,297ms → 2,955ms**, with every section's text byte-identical.

| document | before | after |
|---|---:|---:|
| regions | 790 | **427** |
| morganstanley | 749 | **404** |
| ambac | 462 | **192** |
| footlocker_2024 | 279 | **176** |
| tesla | 239 | **130** |
| meta | 132 | **54** |
| odp | 447 | 404 |
| jackhenry | 53 | 24 |
| citigroup | 947 | 987 |

Citigroup is unmoved (within run-to-run noise) because it resolves its items through the cross-reference index rather than per-section filtering.

## Design

The memo lives on the `Document` rather than inside the pattern cache because the HTML is a plain `str`, which supports neither weak references nor attributes — there is nowhere on the key itself to hang one. The document owns the HTML and dies with it, which is the same lifetime and invalidation story as the anchor index from #952.

`filter_with_cached_patterns` keeps its behaviour for callers filtering a single string, and now composes the two halves it used to do at once: `resolve_navigation_patterns` (per document) and `filter_navigation_lines` (per string). The disk cache is untouched — a cold document still reads and writes it exactly once.

Two details that would be easy to get wrong:

- `frozenset()` is falsy but not `None`, so a document with genuinely no repeated navigation links is cached rather than re-resolved on every section.
- `_clean_section_text` keeps its "no original HTML means no filtering" guard, which deliberately differs from `Document.text()`'s fallback to the generic SEC pattern set. Collapsing the two would have changed output on documents with no `original_html`.

## Verification

- New `tests/test_navigation_pattern_cache.py` (11 tests, offline) asserts the **behaviour** rather than the timing: the filing is hashed a bounded number of times however many sections are extracted, `Document.text()` does not re-derive the key after section extraction, an empty pattern set is cached rather than re-resolved, and the wrapper still equals `resolve` + `filter` for both the HTML and no-HTML paths.
- Corpus section dump diffed before/after across all 11 documents: **0 changed entries**.
- `test-fast` 3,526 passed; full regression suite 1,769 passed; paired before/after benchmark on the same machine for the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)