### PR TITLE
fix(documents): compare nodes by identity, not field by field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Comparing a document node with a deep copy of itself raised `RecursionError` instead of returning an answer.** `Node` and its subclasses were plain dataclasses, so Python generated a field-by-field `__eq__` that recursed through `parent` and `children`. Normally the `id` uuid is compared first and decides the result immediately, but `copy.deepcopy` preserves `id`, so the comparison fell through to `parent` and `children` and walked back on itself:
+
+  ```python
+  a = ParagraphNode(); a.add_child(TextNode(content='x'))
+  a == copy.deepcopy(a)     # RecursionError: maximum recursion depth exceeded
+  ```
+
+  Nodes now compare by identity, as plain objects do. Nothing observable changes for existing callers: because `id` is a per-instance uuid compared first, two distinct nodes were already unequal and a node was already equal to itself, so identity was the only answer equality could give that was not a crash. Section text is byte-identical across the eleven-document benchmark corpus.
+
+  Two things get better as a consequence. Every `==`, `in`, `.index()` and `.remove()` on a node stops buying a deep structural walk of the tree where the caller meant identity — the same cost that put 10.5s of Citigroup's 18s sections stage inside `ParagraphNode.__eq__` before two call sites were rewritten to compare `id()` by hand. And nodes are hashable again: `eq=True` sets `__hash__` to `None`, so sets and dicts of nodes previously had to be keyed on `id()`.
+
 ### Performance
 
 - **A filing was md5'd once per section to rebuild a cache key that could not have changed** — the sections stage drops a further 31% on the benchmark corpus, 4.3s to 3.0s, with every section's text byte-identical.

--- a/edgar/documents/nodes.py
+++ b/edgar/documents/nodes.py
@@ -91,7 +91,27 @@ def _ends_with_tail_whitespace(node) -> bool:
     return False
 
 
-@dataclass
+# eq=False on Node and every subclass: nodes compare by identity, as plain
+# objects do.
+#
+# The generated __eq__ compared field by field and recursed through `parent` and
+# `children`, so every `==`, `in`, `.index()` and `.remove()` on a node bought a
+# deep structural walk of the tree where the caller meant identity. It cost real
+# time — `n.parent not in nodes_in_range` was 10.5s of Citigroup's 18s sections
+# stage (edgartools-llmp.6.10) — and on one input it did not return at all:
+#
+#     a = ParagraphNode(); a.add_child(TextNode(content='x'))
+#     a == copy.deepcopy(a)     # RecursionError: parent -> children -> parent
+#
+# deepcopy preserves `id`, so the uuid that normally decides the comparison on
+# its first field stops short-circuiting and the walk turns back on itself.
+#
+# Nothing observable changes. `id` is a uuid compared first, so two distinct
+# nodes were already unequal and a node was already equal to itself; identity
+# was the only answer equality could give that was not a crash. Nodes also
+# become hashable again — eq=True sets __hash__ to None, so sets and dicts of
+# nodes had to be keyed on id() (edgartools-llmp.10).
+@dataclass(eq=False)
 class Node(ABC):
     """
     Base node class for document tree.
@@ -219,7 +239,7 @@ class Node(ABC):
         return key in self.metadata
 
 
-@dataclass
+@dataclass(eq=False)
 class DocumentNode(Node, CacheableMixin):
     """Root document node."""
     type: NodeType = field(default=NodeType.DOCUMENT, init=False)
@@ -251,7 +271,7 @@ class DocumentNode(Node, CacheableMixin):
 </html>"""
 
 
-@dataclass
+@dataclass(eq=False)
 class TextNode(Node):
     """Plain text content node."""
     type: NodeType = field(default=NodeType.TEXT, init=False)
@@ -271,7 +291,7 @@ class TextNode(Node):
         return text
 
 
-@dataclass
+@dataclass(eq=False)
 class ParagraphNode(Node, CacheableMixin):
     """Paragraph node."""
     type: NodeType = field(default=NodeType.PARAGRAPH, init=False)
@@ -381,7 +401,7 @@ class ParagraphNode(Node, CacheableMixin):
         return ''
 
 
-@dataclass
+@dataclass(eq=False)
 class HeadingNode(Node):
     """Heading node with level."""
     type: NodeType = field(default=NodeType.HEADING, init=False)
@@ -418,7 +438,7 @@ class HeadingNode(Node):
         return ''
 
 
-@dataclass
+@dataclass(eq=False)
 class ContainerNode(Node, CacheableMixin):
     """Generic container node (div, section, etc.)."""
     type: NodeType = field(default=NodeType.CONTAINER, init=False)
@@ -461,7 +481,7 @@ class ContainerNode(Node, CacheableMixin):
         return ''
 
 
-@dataclass
+@dataclass(eq=False)
 class SectionNode(ContainerNode):
     """Document section node."""
     type: NodeType = field(default=NodeType.SECTION, init=False)
@@ -473,7 +493,7 @@ class SectionNode(ContainerNode):
             self.set_metadata('section_name', self.section_name)
 
 
-@dataclass
+@dataclass(eq=False)
 class ListNode(Node):
     """List node (ordered or unordered)."""
     type: NodeType = field(default=NodeType.LIST, init=False)
@@ -499,7 +519,7 @@ class ListNode(Node):
         return f'<{tag}>\n{items}\n</{tag}>'
 
 
-@dataclass
+@dataclass(eq=False)
 class ListItemNode(Node):
     """List item node."""
     type: NodeType = field(default=NodeType.LIST_ITEM, init=False)
@@ -519,7 +539,7 @@ class ListItemNode(Node):
         return f'<li>{content}</li>'
 
 
-@dataclass
+@dataclass(eq=False)
 class LinkNode(Node):
     """Hyperlink node."""
     type: NodeType = field(default=NodeType.LINK, init=False)
@@ -546,7 +566,7 @@ class LinkNode(Node):
         return f'<a{href_attr}{title_attr}>{content}</a>'
 
 
-@dataclass
+@dataclass(eq=False)
 class ImageNode(Node):
     """Image node."""
     type: NodeType = field(default=NodeType.IMAGE, init=False)

--- a/edgar/documents/table_nodes.py
+++ b/edgar/documents/table_nodes.py
@@ -137,7 +137,7 @@ class Row:
         return False
 
 
-@dataclass
+@dataclass(eq=False)
 class TableNode(Node, CacheableMixin):
     """
     Table node with structured data.

--- a/tests/test_node_identity_semantics.py
+++ b/tests/test_node_identity_semantics.py
@@ -1,0 +1,137 @@
+"""Document nodes compare by identity (edgartools-llmp.10).
+
+`Node` and its subclasses were plain `@dataclass`, so Python generated a
+field-by-field `__eq__` that recursed through `parent` and `children`. Every
+`==`, `in`, `.index()` and `.remove()` on a node therefore bought a deep
+structural walk of the tree where the caller meant identity — 10.5s of
+Citigroup's 18s sections stage went to `ParagraphNode.__eq__` alone
+(edgartools-llmp.6.10) — and on a deep-copied subtree it did not return at all.
+
+Nothing observable changed when `eq=False` landed: `id` is a uuid compared
+first, so distinct nodes were already unequal and a node was already equal to
+itself. Identity was the only answer equality could give that was not a crash.
+These tests lock that in, including for subclasses added later.
+"""
+import copy
+
+import pytest
+
+from edgar.documents.nodes import (
+    ContainerNode,
+    HeadingNode,
+    ImageNode,
+    LinkNode,
+    ListItemNode,
+    ListNode,
+    Node,
+    ParagraphNode,
+    SectionNode,
+    TextNode,
+)
+from edgar.documents.table_nodes import TableNode
+
+# Offline: constructs nodes directly, no parsing, filesystem or network.
+pytestmark = pytest.mark.fast
+
+
+def _all_node_classes():
+    """Every concrete Node subclass, however deeply nested."""
+    seen = {}
+
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            if sub.__name__ not in seen:
+                seen[sub.__name__] = sub
+                walk(sub)
+
+    walk(Node)
+    return seen
+
+
+def _paragraph_with_child():
+    node = ParagraphNode()
+    node.add_child(TextNode(content="x"))
+    return node
+
+
+class TestNoGeneratedEquality:
+
+    def test_no_node_class_generates_eq(self):
+        """A new subclass declared with a bare @dataclass would reintroduce this."""
+        offenders = [name for name, cls in _all_node_classes().items()
+                     if "__eq__" in cls.__dict__]
+        assert not offenders, (
+            f"these Node subclasses generate __eq__; declare them "
+            f"@dataclass(eq=False): {offenders}")
+
+    def test_base_node_does_not_generate_eq(self):
+        assert "__eq__" not in Node.__dict__
+
+    @pytest.mark.parametrize("cls", [
+        TextNode, ParagraphNode, HeadingNode, ContainerNode, SectionNode,
+        ListNode, ListItemNode, LinkNode, ImageNode, TableNode,
+    ])
+    def test_subclasses_are_hashable(self, cls):
+        """eq=True sets __hash__ to None, so nodes were unhashable."""
+        node = cls()
+        assert hash(node) == hash(node)
+        assert len({node, cls()}) == 2
+
+
+class TestIdentitySemantics:
+
+    def test_node_equals_itself(self):
+        node = _paragraph_with_child()
+        assert node == node
+
+    def test_structurally_identical_nodes_are_not_equal(self):
+        assert _paragraph_with_child() != _paragraph_with_child()
+
+    def test_deep_copy_does_not_recurse_forever(self):
+        """deepcopy preserves `id`, so the uuid stopped short-circuiting and the
+        walk turned back on itself: parent -> children -> parent."""
+        node = _paragraph_with_child()
+        clone = copy.deepcopy(node)
+        assert clone.id == node.id, "precondition: deepcopy preserves the uuid"
+        assert node != clone  # previously RecursionError
+
+    def test_membership_is_identity(self):
+        first, second = _paragraph_with_child(), _paragraph_with_child()
+        assert first in [second, first]
+        assert first not in [second]
+
+    def test_index_finds_the_object_not_a_lookalike(self):
+        first, second = TextNode(content="x"), TextNode(content="x")
+        assert [first, second].index(second) == 1
+
+
+class TestChildListOperations:
+
+    def test_remove_child_removes_the_right_one(self):
+        parent = ContainerNode()
+        first, second = TextNode(content="x"), TextNode(content="x")
+        parent.add_child(first)
+        parent.add_child(second)
+
+        parent.remove_child(second)
+
+        assert len(parent.children) == 1
+        assert parent.children[0] is first
+        assert second.parent is None
+        assert first.parent is parent
+
+    def test_remove_child_ignores_a_lookalike_from_another_tree(self):
+        parent = ContainerNode()
+        child = TextNode(content="x")
+        parent.add_child(child)
+
+        parent.remove_child(TextNode(content="x"))
+
+        assert parent.children == [child]
+
+    def test_a_node_can_be_added_to_a_set_of_visited_nodes(self):
+        """The pattern llmp.6.10 had to write as `{id(n) for n in ...}`."""
+        nodes = [_paragraph_with_child() for _ in range(3)]
+        visited = set(nodes)
+        assert len(visited) == 3
+        assert all(node in visited for node in nodes)


### PR DESCRIPTION
Closes `edgartools-llmp.10`.

`Node` and its subclasses were plain dataclasses, so Python generated a field-by-field `__eq__` that recursed through `parent` and `children`. Normally the `id` uuid is compared first and decides immediately — but `copy.deepcopy` preserves `id`, so the comparison falls through to `parent` and `children` and walks back on itself:

```python
a = ParagraphNode(); a.add_child(TextNode(content='x'))
a == copy.deepcopy(a)     # RecursionError: maximum recursion depth exceeded
```

Nodes now compare by identity, as plain objects do.

## Nothing observable changes

Because `id` is a per-instance uuid compared first, two distinct nodes were already unequal and a node was already equal to itself. **Identity was the only answer equality could give that was not a crash.** Section text is byte-identical across the eleven-document corpus (0 changed entries), and the sections stage is unmoved — 3,036ms vs 2,955ms, run-to-run noise.

That last number is worth stating plainly: this is **preventive, not a speedup**. The two hot comparison sites were already rewritten to compare `id()` by hand under `llmp.6.10`, which is where the 10.5s of Citigroup's 18s sections stage inside `ParagraphNode.__eq__` went. What is left is the class of bug rather than a measured cost.

Two things get better as a consequence:

- Every `==`, `in`, `.index()` and `.remove()` on a node stops buying a deep structural walk of the tree where the caller meant identity. `remove_child`'s `if child in self.children` needed no change — it now means what it says.
- Nodes are **hashable again**. `eq=True` sets `__hash__` to `None`, so sets and dicts of nodes had to be keyed on `id()`.

## Scope

Applied to all eleven `Node` dataclasses in `nodes.py` plus `TableNode`. `Cell` and `Row` in `table_nodes.py` are not `Node`s and keep their generated equality.

Callers were checked for reliance on structural equality — `search.py:146`/`599` (`n in section_nodes`) and `search.py:654` (`cached_nodes == nodes`) all mean identity and are unaffected for the reason above.

## Verification

- New `tests/test_node_identity_semantics.py`, 20 tests, offline. **14 fail without the change**; the 6 that pass are exactly the cases where identity already coincided, which is the argument for safety made executable.
- One test walks `Node.__subclasses__()` and asserts no subclass generates `__eq__`, so a new node class declared with a bare `@dataclass` fails rather than quietly reintroducing this.
- `test-fast` 3,526 passed; regression suite 1,769 passed; corpus section dump 0 changed entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)