### PR TITLE
fix(sections): stop pattern-path sections at their boundary, not at their container's end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sections detected by heading patterns ran past their own end and into the next item.** Section content was collected by walk position: every node whose position fell in `[start, end)` was gathered, and the top-level ones were attached to the section. A section's `end` is the position of the *next* item's header, but filers normally wrap that header in a container which itself begins before it — so the container was in range, was attached whole, and brought everything it held.
+
+  The boundary was honoured as an index and ignored as a content limit. On Wells Fargo's FY2024 10-K (`0000072971-25-000094`), whose computed boundaries are provably correct, **20 of 23 sections carried a foreign item heading**. Item 8 is a 261-character incorporation-by-reference pointer and came back as 3,329 characters running through Items 9, 9A, 9B and 9C, because a single container spanning positions 489-517 was attached to a section whose range ended at 492. Item 6 — `[RESERVED]` — carried the whole of Item 7's heading.
+
+  A node whose subtree fits inside the range is still attached as it is. One that straddles the boundary is now replaced by a shallow stand-in holding only the children that fall inside, so the nesting the text extractor sees is unchanged. Nothing is dropped: the remainder belongs to the next section, whose range begins where this one ends. Wells Fargo now carries zero foreign headings, Item 8 is 374 characters and Item 6 is 46. Sections detected from a table of contents are unaffected — every section across the eleven-document benchmark corpus is byte-identical.
+
+  Two related defects went with it. The document was re-walked once per section, and the "is my parent also in range?" test read `node.parent` *after* earlier sections had already reassigned it — sections are created in dict order rather than document order, so the result could depend on iteration order. Both now work from one walk and one snapshot taken before any node is attached.
+
+  This is the pattern-path half of the end-boundary overflow cluster. The other half — sections whose *boundaries* are themselves wrong because the TOC pass missed an item anchor (GH #924) — is unchanged.
+
 - **Comparing a document node with a deep copy of itself raised `RecursionError` instead of returning an answer.** `Node` and its subclasses were plain dataclasses, so Python generated a field-by-field `__eq__` that recursed through `parent` and `children`. Normally the `id` uuid is compared first and decides the result immediately, but `copy.deepcopy` preserves `id`, so the comparison fell through to `parent` and `children` and walked back on itself:
 
   ```python

--- a/edgar/documents/extractors/pattern_section_extractor.py
+++ b/edgar/documents/extractors/pattern_section_extractor.py
@@ -2,6 +2,7 @@
 Section extraction from documents.
 """
 
+import copy
 import logging
 import re
 from typing import Dict, List, Optional, Set, Tuple
@@ -965,6 +966,71 @@ class SectionExtractor:
 
         sections = {}
 
+        # Walk the document once, and record each node's position, its original
+        # parent, and how far its subtree reaches.
+        #
+        # The walk was previously redone per section, which is also why the
+        # parent test below has to work from a snapshot: add_child() reassigns
+        # child.parent, so by the time a later section asked "is my parent in my
+        # range?" the answer could already have been rewritten by an earlier one.
+        # Sections are created in dict order, not document order, so that made
+        # the result depend on iteration order. The snapshot is taken before any
+        # node is attached, so every section sees the document as parsed.
+        walk = list(document.root.walk())
+        positions = {id(n): i for i, n in enumerate(walk)}
+        original_parent = {id(n): id(n.parent) if n.parent is not None else None
+                           for n in walk}
+        # reach[node] is one past the last index its subtree occupies.
+        reach = {}
+        for n in reversed(walk):
+            end = positions[id(n)] + 1
+            for child in getattr(n, 'children', None) or []:
+                child_end = reach.get(id(child))
+                if child_end is not None and child_end > end:
+                    end = child_end
+            reach[id(n)] = end
+
+        def attach_bounded(target: Node, source: Node, limit: int) -> None:
+            """Attach ``source`` to ``target``, dropping any subtree past ``limit``.
+
+            A section's boundary is the position of the *next* item's header, but
+            that header is usually nested inside a container which itself starts
+            before the boundary. Attaching that container whole handed the
+            section everything the container held — Wells Fargo's Item 8 is a
+            261-character incorporation-by-reference pointer and came back as
+            3,329 characters running through Items 9, 9A, 9B and 9C, because one
+            container spanning positions 489-517 was attached to a section whose
+            range ended at 492 (edgartools-llmp.6.1).
+
+            A node whose subtree fits inside the range is attached as it is. One
+            that straddles the boundary is replaced by a shallow stand-in holding
+            only the children that fall inside, so the nesting the text extractor
+            sees is unchanged while the out-of-range content is not carried. The
+            remainder is not lost: it belongs to the next section, whose own
+            range starts at this limit.
+            """
+            if reach[id(source)] <= limit:
+                target.add_child(source)
+                return
+
+            stand_in = copy.copy(source)
+            stand_in.children = []
+            stand_in.parent = None
+            stand_in.metadata = dict(source.metadata) if source.metadata else {}
+            # copy.copy carries the source's memoised text, which described the
+            # untrimmed subtree.
+            if hasattr(stand_in, 'clear_text_cache'):
+                stand_in._text_cache = None
+
+            for child in getattr(source, 'children', None) or []:
+                child_pos = positions.get(id(child))
+                if child_pos is None or child_pos >= limit:
+                    break
+                attach_bounded(stand_in, child, limit)
+
+            if stand_in.children:
+                target.add_child(stand_in)
+
         for section_name, (node, title, start_pos, end_pos) in matched_sections.items():
             # Check if this is an HTML-extracted section (marked by start_pos == -1)
             html_extracted_text = node.get_metadata('html_extracted_text') if hasattr(node, 'get_metadata') else None
@@ -983,31 +1049,26 @@ class SectionExtractor:
 
                 # Find all nodes in position range - only add top-level nodes
                 # (nodes whose parent is outside the range)
-                # First collect all nodes in range
-                nodes_in_range = []
-                position = 0
-                for n in document.root.walk():
-                    if start_pos <= position < end_pos:
-                        nodes_in_range.append(n)
-                    position += 1
+                nodes_in_range = walk[start_pos:end_pos]
 
                 # Now add only top-level nodes (nodes whose parent is not in the range)
                 # This prevents adding both a parent and its children as direct section children
                 #
                 # Membership here means identity — "is this same node object also in
-                # the range". It must not go through `in` on the list: Node is a
-                # @dataclass, so `==` compares field-by-field and recurses through
-                # `children`, which is both quadratic (10.5s of Citigroup's 18s
-                # sections stage) and wrong. Two distinct paragraphs with identical
-                # text and styling compare equal, so a node whose parent merely
-                # resembled an in-range node was treated as nested and silently
-                # dropped — boilerplate-heavy filings are exactly where identical
-                # nodes are common. Snapshot the ids first: add_child() reassigns
-                # child.parent as we go.
+                # the range". It must not go through `in` on the list: Node used to
+                # be a plain @dataclass, so `==` compared field-by-field and recursed
+                # through `children`, which was both quadratic (10.5s of Citigroup's
+                # 18s sections stage) and wrong. Two distinct paragraphs with
+                # identical text and styling compared equal, so a node whose parent
+                # merely resembled an in-range node was treated as nested and
+                # silently dropped — boilerplate-heavy filings are exactly where
+                # identical nodes are common. Nodes compare by identity now
+                # (edgartools-llmp.10), but the id() test stays: it is what this
+                # means, and it reads as deliberate rather than incidental.
                 ids_in_range = {id(n) for n in nodes_in_range}
                 for n in nodes_in_range:
-                    if id(n.parent) not in ids_in_range:
-                        section_node.add_child(n)
+                    if original_parent[id(n)] not in ids_in_range:
+                        attach_bounded(section_node, n, end_pos)
 
                 # Clear text cache to ensure fresh text generation
                 # (nodes may have stale cached text from earlier processing)

--- a/tests/issues/regression/test_issue_llmp_6_1_boundary_overflow.py
+++ b/tests/issues/regression/test_issue_llmp_6_1_boundary_overflow.py
@@ -1,0 +1,158 @@
+"""Regression tests for edgartools-llmp.6.1 — pattern-path sections overshot their end.
+
+`_create_sections` collected the nodes whose position fell in `[start, end)` and
+attached the top-level ones to the section. A section's `end` is the position of
+the *next* item's header, but that header is normally nested inside a container
+which itself starts before it — so the container was in range, was attached
+whole, and brought everything it held with it. The boundary was honoured as an
+index and ignored as a content limit.
+
+Wells Fargo's FY2024 10-K is the case that isolates this. Its computed
+boundaries are provably correct — every section starts on its own item header
+and ends on the next one, with no overlaps and no gaps — so anything extra is
+attributable to node collection alone. Every item is a short
+incorporation-by-reference pointer with a known correct length, and Item 8's
+boundary span of 483-492 yielded 3,329 characters running through Items 9, 9A,
+9B and 9C, because one container spanning 489-517 was attached to it.
+
+20 of the filing's 23 sections carried a foreign item heading. The synthetic
+tests show the same mechanism in four lines of HTML, where each section swallowed
+the whole of the next.
+
+Offline: Wells Fargo is a tracked fixture; the rest is inline HTML.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from edgar.documents import parse_html
+from edgar.documents.config import ParserConfig
+
+pytestmark = pytest.mark.fast
+
+WFC = Path(__file__).parents[2] / "fixtures" / "html" / "wfc" / "10k" / "wfc-10-k-2025-02-25.html"
+
+ITEM_HEADING = re.compile(r"ITEM\s+(\d+[A-C]?)\.", re.IGNORECASE)
+
+
+def _normalise(text):
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+@pytest.fixture(scope="module")
+def wfc_sections():
+    if not WFC.exists():
+        pytest.skip("Wells Fargo 10-K fixture not available")
+    doc = parse_html(WFC.read_bytes().decode("utf-8", "replace"), ParserConfig(form="10-K"))
+    sections = {name: _normalise(section.text()) for name, section in doc.sections.items()}
+    items = {name: section.item for name, section in doc.sections.items()}
+    yield sections, items
+    del doc
+
+
+class TestWellsFargoDoesNotOvershoot:
+
+    def test_no_section_carries_another_items_heading(self, wfc_sections):
+        """The headline invariant: 20 of 23 sections failed this before."""
+        sections, items = wfc_sections
+        offenders = {}
+        for name, text in sections.items():
+            own = (items.get(name) or "").upper()
+            foreign = sorted({h.upper() for h in ITEM_HEADING.findall(text)} - {own})
+            if own and foreign:
+                offenders[name] = foreign
+        assert not offenders, f"sections carrying a foreign item heading: {offenders}"
+
+    def test_item_8_is_the_by_reference_pointer_it_claims_to_be(self, wfc_sections):
+        """3,329 chars before — Items 9, 9A, 9B and 9C rode in on one container."""
+        sections, _ = wfc_sections
+        text = sections["financial_statements"]
+        assert "incorporated into this item by reference" in text
+        assert len(text) < 1000, f"Item 8 over-captured: {len(text)} chars"
+        for foreign in ("CONTROLS AND PROCEDURES", "Not applicable"):
+            assert foreign not in text
+
+    def test_reserved_item_6_is_just_its_heading(self, wfc_sections):
+        sections, _ = wfc_sections
+        assert sections["part_ii_item_6"].startswith("ITEM 6.")
+        assert "RESERVED" in sections["part_ii_item_6"]
+        assert "MANAGEMENT" not in sections["part_ii_item_6"]
+
+    def test_every_section_opens_on_its_own_heading(self, wfc_sections):
+        sections, items = wfc_sections
+        for name, text in sections.items():
+            item = items.get(name)
+            if not item:
+                continue
+            assert text.upper().startswith(f"ITEM {item.upper()}."), (
+                f"{name} does not open on its own heading: {text[:60]!r}")
+
+    def test_no_content_is_lost_to_the_trim(self, wfc_sections):
+        """Trimming must move text to the next section, never drop it."""
+        sections, _ = wfc_sections
+        for marker in ("MINE SAFETY DISCLOSURES", "CONTROLS AND PROCEDURES",
+                       "OTHER INFORMATION", "FORM 10-K SUMMARY",
+                       "MANAGEMENT’S DISCUSSION AND ANALYSIS"):
+            assert any(marker in text for text in sections.values()), (
+                f"{marker!r} is in no section at all")
+
+
+# Each item's heading is wrapped in its own container, which is what puts the
+# container's position inside the *previous* item's range.
+WRAPPED_HEADINGS = """
+<html><body>
+<div><p><b>ITEM 1. BUSINESS</b></p><p>BUSINESS_BODY</p></div>
+<div><p><b>ITEM 1A. RISK FACTORS</b></p><p>RISK_BODY</p></div>
+<div><p><b>ITEM 2. PROPERTIES</b></p><p>PROPERTIES_BODY</p></div>
+<div><p><b>ITEM 3. LEGAL PROCEEDINGS</b></p><p>LEGAL_BODY</p></div>
+</body></html>
+"""
+
+BODIES = {
+    "business": "BUSINESS_BODY",
+    "risk_factors": "RISK_BODY",
+    "properties": "PROPERTIES_BODY",
+    "legal_proceedings": "LEGAL_BODY",
+}
+
+
+class TestWrappedHeadingsSynthetic:
+
+    @pytest.fixture(scope="class")
+    def sections(self):
+        doc = parse_html(WRAPPED_HEADINGS, ParserConfig(form="10-K"))
+        return {name: _normalise(section.text()) for name, section in doc.sections.items()}
+
+    def test_all_four_items_are_detected_by_the_pattern_path(self, sections):
+        assert set(sections) == set(BODIES)
+
+    @pytest.mark.parametrize("name, body", sorted(BODIES.items()))
+    def test_section_holds_its_own_body_and_no_other(self, sections, name, body):
+        text = sections[name]
+        assert body in text
+        for other_name, other_body in BODIES.items():
+            if other_name != name:
+                assert other_body not in text, (
+                    f"{name} swallowed {other_name}")
+
+    def test_every_body_survives_somewhere(self, sections):
+        """The trimmed remainder belongs to the next section, not to nobody."""
+        for body in BODIES.values():
+            assert sum(body in text for text in sections.values()) == 1
+
+
+def test_a_container_wholly_inside_the_range_is_not_rebuilt():
+    """Only a straddling container is replaced; the common case is untouched."""
+    html = """
+    <html><body>
+    <div><p><b>ITEM 1. BUSINESS</b></p>
+      <div><p>NESTED_ONE</p><p>NESTED_TWO</p></div>
+    </div>
+    <div><p><b>ITEM 2. PROPERTIES</b></p><p>PROPERTIES_BODY</p></div>
+    </body></html>
+    """
+    doc = parse_html(html, ParserConfig(form="10-K"))
+    business = _normalise(doc.sections["business"].text())
+    assert "NESTED_ONE" in business and "NESTED_TWO" in business
+    assert "PROPERTIES_BODY" not in business


### PR DESCRIPTION
Refs `edgartools-llmp.6.1` — **partial fix, the issue stays open** (see Scope below).

Section content was collected by walk position: every node whose position fell in `[start, end)` was gathered and the top-level ones attached to the section. A section's `end` is the position of the **next** item's header — but filers normally wrap that header in a container which itself begins *before* it. So the container was in range, was attached whole, and brought everything it held. The boundary was honoured as an index and ignored as a content limit.

## Wells Fargo isolates it

Its computed boundaries are provably correct — every section starts on its own item header and ends on the next, no overlaps, no gaps — so anything extra is attributable to node collection alone.

**20 of 23 sections carried a foreign item heading. Now 0.**

| | before | after |
|---|---:|---:|
| `financial_statements` (Item 8) | 3,329 | **374** |
| `part_ii_item_6` (`[RESERVED]`) | 243 | **46** |
| `part_i_item_4` (Mine Safety) | 1,380 | **88** |
| `mda` (Item 7) | 1,128 | **378** |

Item 8 is a 261-character incorporation-by-reference pointer that came back running through Items 9, 9A, 9B and 9C, because one container spanning positions 489-517 was attached to a section whose range ended at 492.

Four lines of HTML show the same mechanism — before the fix each section swallowed the whole of the next:

```
business           'ITEM 1. BUSINESS BUSINESS_BODY ITEM 1A. RISK FACTORS RISK_BODY'
risk_factors       'ITEM 1A. RISK FACTORS RISK_BODY ITEM 2. PROPERTIES PROPERTIES_BODY'
```

## The fix

A node whose subtree fits inside the range is still attached as it is. One that **straddles** the boundary is replaced by a shallow stand-in holding only the children that fall inside, so the nesting the text extractor sees is unchanged rather than flattened. Nothing is dropped — the remainder belongs to the next section, whose range begins where this one ends, and a test asserts every body survives in exactly one section.

Two related defects went with it:

- The document was re-walked **once per section**; it is now walked once.
- The "is my parent also in range?" test read `node.parent` *after* earlier sections had already reassigned it via `add_child`. Sections are created in dict order rather than document order, so the answer could depend on iteration order. It now works from a snapshot taken before any node is attached.

## Scope — what this does *not* fix

`llmp.6.1` is a 40-finding cluster with two mechanisms folded together. This fixes the one where **boundaries are correct and collection overshoots**. The other half — sections whose *boundaries are themselves wrong* because the TOC pass missed an item anchor (GH #924, Tesla legal proceedings, TAP business description) — is untouched and still blocked on `6e4n` / PR #916. The issue stays open with a note recording the split.

## Verification

- New `tests/issues/regression/test_issue_llmp_6_1_boundary_overflow.py`, 12 tests, offline. **8 fail without the change.**
- Corpus section dump: **0 changed entries** across all 11 documents — TOC-detected sections are unaffected.
- `test-fast` 3,546 passed; regression suite 1,781 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)