### PR TITLE
ci: let the offline half of the regression tree gate pull requests

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -92,8 +92,16 @@ jobs:
 
     - name: Run fast tests
       run: |
-        # Parallelize fast tests - safe, no SEC API calls
-        pytest -n auto --cov --cov-report=xml -m 'fast and not regression'
+        # Parallelize fast tests - safe, no SEC API calls.
+        #
+        # No `and not regression` here, unlike the network and slow jobs. The
+        # regression tree is 1,746 tests and every one of them used to be
+        # deselected on pull requests, so a PR could break any of them and merge
+        # green (bead edgartools-07lk.21). conftest.py now classifies each as
+        # fast or network by measurement, and the 934 offline ones gate here.
+        # The network half still runs only in the Regression Tests workflow —
+        # PRs must not hammer the SEC endpoint.
+        pytest -n auto --cov --cov-report=xml -m 'fast'
 
     - name: Upload coverage data
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,13 +9,19 @@ on:
   # Run weekly on Sundays
   schedule:
     - cron: '0 8 * * 0'
-  # Also run on main branch pushes for critical changes
+  # Also run on main branch pushes that touch the library.
+  #
+  # This used to name three packages — edgar/xbrl, edgar/entity and the
+  # regression tree itself — which left every other package uncovered. A change
+  # under edgar/documents that added no regression file ran the suite in no job
+  # at all, and that is where the section-extraction defect cluster lives
+  # (bead edgartools-07lk.21). `edgar/**` closes the hole as a class instead of
+  # one package at a time; docs- and script-only merges still skip it.
   push:
     branches: [ "main" ]
     paths:
       - 'tests/issues/regression/**'
-      - 'edgar/xbrl/**'
-      - 'edgar/entity/**'
+      - 'edgar/**'
 
 # Cancel superseded regression runs on the same ref.
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,18 +205,25 @@ test-fast-parallel = "pytest -n auto -m 'fast' {args}"
 test-core-parallel = "pytest -n 2 -m 'not (slow or network or performance or batch)' --ignore=tests/perf {args}"
 test-parallel-safe = "pytest -n auto -m 'fast' {args}"
 
-# Parallel CI test strategy (skip regression tests for faster feedback)
+# Parallel CI test strategy
 #
 # SELECTIVE PARALLELIZATION STRATEGY:
-# 1. Marker-based: -m 'not regression' excludes tests marked as regression
+# 1. Marker-based: 'not regression' keeps the network/slow regression tests out
+#    of the PR jobs — they run in the Regression Tests workflow, which is the
+#    only place allowed to hammer the SEC endpoint.
 # 2. Path-based: --ignore=tests/issues/regression excludes entire folder
 # 3. Auto-marking: conftest.py automatically marks tests as fast/network based on filename
 # 4. Selective parallel: Only parallelize tests safe from SEC rate limits
 # 5. Combined coverage: CI combines coverage from fast/network/slow groups for 65% threshold
 #
+# test-ci-fast deliberately does NOT exclude regression. conftest.py classifies
+# every regression test as fast or network by measurement, and the offline ones
+# belong in the pull-request gate — before this they ran only after merge
+# (bead edgartools-07lk.21).
+#
 # Note: "core" group removed from CI - auto-marking leaves 0 tests without markers
 
-test-ci-fast = "pytest -n auto --cov --cov-report=xml -m 'fast and not regression' {args}"
+test-ci-fast = "pytest -n auto --cov --cov-report=xml -m 'fast' {args}"
 test-ci-network = "pytest --cov --cov-report=xml -m 'network and not slow and not regression' {args}"
 test-ci-slow = "pytest --cov --cov-report=xml -m 'slow and not regression' {args}"
 test-ci-all = "pytest --cov --cov-report=xml -m 'not regression' --ignore=tests/perf --ignore=tests/issues/regression {args}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,75 @@ def pytest_collection_modifyitems(items):
         'test_6k_with_financials', 'test_fix_429', 'test_multiple_companies_429',
     ]
 
+    # Regression tests used to carry no fast/network marker at all: this hook
+    # marked them `regression` and stopped. All three PR-facing CI selectors read
+    # 'fast and not regression', 'network and not slow and not regression' and
+    # 'slow and not regression', so every one of the 1,746 tests under
+    # tests/issues/regression/ was deselected on every pull request and ran only
+    # after merge, on the weekly/main-push Regression Tests workflow. A PR could
+    # break any of them and merge green (bead edgartools-07lk.21). CLAUDE.md
+    # tells every bug fix to put its regression test in that tree, so the better
+    # a contributor followed the docs, the less their test gated anything.
+    #
+    # Classifying them lets the offline half gate pull requests. Which half is
+    # which was MEASURED, not guessed (2026-08-04): the tree was run with
+    # outbound TCP and DNS blocked, and everything that failed was re-run with
+    # the network to separate "needs SEC" from "already broken" — all 159
+    # passed, so none was broken. Re-measure the same way rather than editing
+    # this by eye; the filename heuristic was wrong for five files the last time
+    # a classification was done here.
+    #
+    # "Offline" means offline *alone*: the measurement clears every functools
+    # cache in the edgar package before each test, so no test is credited with a
+    # fetch an earlier one had already cached. That is stricter than CI, where
+    # xdist workers share warm caches, and deliberately so. Four of the files
+    # below (test_424b_parser, test_fee_table, test_issue_2h4c,
+    # test_issue_868_869_offerings) are cassette-backed and mostly offline, but
+    # 59 of their 170 tests also fetch the quarterly form index, which no
+    # cassette records. Under the lax standard which of them fail depends on the
+    # worker count — stable on one machine, different on a 4-core runner,
+    # different again the next time a test is added. No gate can be built on
+    # that. They go to `network` whole rather than by node id, because a node-id
+    # list lets a renamed test back into the gate silently; bead
+    # edgartools-zuuu tracks decoupling the index fetch, which returns all 170
+    # at once.
+    REGRESSION_NETWORK_FILES = {
+        'test_424b_parser.py',
+        'test_fee_table.py',
+        'test_issue_2h4c.py',
+        'test_issue_868_869_offerings.py',
+        'test_entityfacts_no_duplicate_quarterly_periods.py',
+        'test_issue_282_xbrl_api_regression.py',
+        'test_issue_408_cashflow_empty_periods.py',
+        'test_issue_416_segment_member_values.py',
+        'test_issue_420_multi_year_income_statements.py',
+        'test_issue_427_xbrl_data_cap.py',
+        'test_issue_429_statement_period_regression.py',
+        'test_issue_439_order_parsing.py',
+        'test_issue_441_current_filings_pagination.py',
+        'test_issue_443_corrupted_cache.py',
+        'test_issue_446_20f_ifrs_statements.py',
+        'test_issue_451_expense_sign_regression.py',
+        'test_issue_464_period_key.py',
+        'test_issue_513_data_accuracy.py',
+        'test_issue_518_income_statement_fallback.py',
+        'test_issue_633_earnings_data_accuracy.py',
+        'test_issue_637_ifrs_concept_discovery.py',
+        'test_issue_706_missing_statements.py',
+        'test_issue_712_xbrl_weight_sign.py',
+        'test_issue_880.py',
+        'test_issue_ugc2_discovery.py',
+        'test_issue_xvxp_footnoted_shares.py',
+    }
+
+    # Files whose tests split: everything else in them runs offline.
+    REGRESSION_NETWORK_TESTS = {
+        'tests/issues/regression/test_issue_863_10b5_plan_detection.py::test_aff10b5_one_checkbox_flows_through_xml_parsing_end_to_end',
+        'tests/issues/regression/test_issue_i5wx_api_consistency.py::test_form4_tables_and_remarks_always_present_when_xml_omits_them',
+        'tests/issues/regression/test_issue_t043_footnote_attribution.py::test_footnote_ids_are_deduped_within_a_transaction',
+        'tests/issues/regression/test_issue_t043_footnote_attribution.py::test_transaction_footnote_ids_are_populated_from_whole_transaction',
+    }
+
     unclassified = []
 
     for item in items:
@@ -314,8 +383,21 @@ def pytest_collection_modifyitems(items):
         is_regression = "/regression/" in test_path or "\\regression\\" in test_path
         if is_regression:
             item.add_marker(pytest.mark.regression)
+            existing_markers = {m.name for m in item.iter_markers()}
+            if not existing_markers & {'fast', 'network', 'slow'}:
+                # Unlisted means fast, deliberately. A new regression test that
+                # needs SEC and says so gets `network` from its own marker; one
+                # that needs SEC and forgets fails the pull-request gate on its
+                # first run, which is loud and one marker from fixed. Defaulting
+                # the other way would file it back into the post-merge-only tree
+                # silently — the defect this classification exists to close.
+                needs_network = (
+                    Path(test_path).name in REGRESSION_NETWORK_FILES
+                    or item.nodeid in REGRESSION_NETWORK_TESTS
+                )
+                item.add_marker(pytest.mark.network if needs_network
+                                else pytest.mark.fast)
             logger.debug(f"Auto-marked regression test: {item.nodeid}")
-            # Don't auto-mark regression tests with fast/network - they need explicit markers
             continue
 
         # Skip if test already has fast/network/slow marker

--- a/tests/issues/regression/test_entityfacts_no_duplicate_quarterly_periods.py
+++ b/tests/issues/regression/test_entityfacts_no_duplicate_quarterly_periods.py
@@ -4,6 +4,13 @@ Regression test for duplicate quarterly periods bug.
 Issue: Company.balance_sheet(annual=False) shows duplicate fiscal periods
 Root Cause: SEC Facts API includes comparative data with same fiscal_period
 Fix: Validate period_end matches expected month for fiscal_period
+
+Everything here that calls ``Company(...)`` is marked ``network``: it reads the
+SEC Facts API live. Four of them carried ``fast`` instead, which cost nothing
+while the whole regression tree was excluded from the pull-request gate and
+would have broken it the moment the tree was let in (bead edgartools-07lk.21).
+Only ``test_validate_quarterly_period_end`` is genuinely offline — it calls the
+validation function directly.
 """
 
 import pytest
@@ -12,7 +19,7 @@ from datetime import date
 from edgar import Company
 
 
-@pytest.mark.fast
+@pytest.mark.network
 def test_no_duplicate_quarterly_periods_apple():
     """Apple Q3 2025 should appear only once, not twice"""
     c = Company("AAPL")
@@ -26,7 +33,7 @@ def test_no_duplicate_quarterly_periods_apple():
     assert len(bs.periods) == len(set(bs.periods)), "Periods should be unique"
 
 
-@pytest.mark.fast
+@pytest.mark.network
 def test_quarterly_period_values_are_correct():
     """Q3 2025 should show June 2025 data, not September 2024 data"""
     c = Company("AAPL")
@@ -76,7 +83,7 @@ def test_validate_quarterly_period_end():
     assert validate_quarterly_period_end('Q3', date(2025, 9, 30), 12) == True
 
 
-@pytest.mark.fast
+@pytest.mark.network
 def test_quarterly_income_statement_no_duplicates():
     """Test quarterly income statement also has no duplicates"""
     c = Company("AAPL")
@@ -88,7 +95,7 @@ def test_quarterly_income_statement_no_duplicates():
     assert not duplicates, f"Found duplicate periods in income statement: {duplicates}"
 
 
-@pytest.mark.fast
+@pytest.mark.network
 def test_quarterly_cash_flow_no_duplicates():
     """Test quarterly cash flow statement also has no duplicates"""
     c = Company("AAPL")


### PR DESCRIPTION
Closes `edgartools-07lk.21`.

## The gap

`tests/issues/regression/` holds **1,746 tests and not one of them ran on a pull request.** All three PR-facing selectors exclude the tree explicitly:

```
test-fast     -m 'fast and not regression'
test-network  -m 'network and not slow and not regression'
test-slow     -m 'slow and not regression'
```

and `conftest.py` marked anything under `/regression/` with `regression` and then `continue`d, so those tests carried no `fast`/`network` marker to be selected by either. They ran only after merge, on the weekly / main-push Regression Tests workflow. A PR could break any of them and merge green.

CLAUDE.md instructs every bug fix to put its regression test in that tree, so **the better a contributor followed the docs, the less their test gated anything.**

## The change

Regression tests are now classified `fast` or `network`, and the fast ones join the PR gate.

| | before | after |
|---|---|---|
| regression tests in the PR gate | 0 | **934** |
| `test-fast` selector total | 3,243 | **4,177** |
| local wall-clock | 97s | 118s |

The network half still runs only in the Regression Tests workflow — PRs must not hammer the SEC endpoint, which is why that job excluded them to begin with. `test-network` and `test-slow` keep their `and not regression`; only `test-fast` drops it.

## Measured, not guessed

The tree was run with outbound TCP and DNS blocked, and every failure was re-run **with** the network to separate "needs SEC" from "already broken". All 159 passed, so none was broken. Of 122 unclassified files, 95 were offline in full.

**"Offline" means offline *alone*.** The measurement clears every `functools` cache in the `edgar` package before each test, so no test is credited with a fetch an earlier one had already cached. That stricter standard was necessary, not pedantry: four cassette-backed files are mostly offline, but 59 of their 170 tests also fetch the quarterly form index, which no cassette records. Under the lax standard *which of them fail depends on the xdist worker count* — 9 at `-n auto` here, a different 2 at `-n 16`, 3 at `-n 4`, and different again on a 4-core GitHub runner. No required check can be built on that.

Those four files (`test_424b_parser`, `test_fee_table`, `test_issue_2h4c`, `test_issue_868_869_offerings`) go to `network` whole rather than by node id — a node-id list lets a renamed test back into the gate silently. That holds 111 genuinely-offline tests out of the gate; **`edgartools-zuuu`** tracks decoupling the index fetch, which returns all 170 at once.

Four tests in `test_entityfacts_no_duplicate_quarterly_periods.py` were marked `@pytest.mark.fast` while calling `Company("AAPL")`. That cost nothing while the tree was excluded and would have broken the gate the moment it was let in.

**Unlisted regression files default to `fast` on purpose.** A new test that needs SEC and says so gets `network` from its own marker; one that forgets fails the gate on its first run — loud, and one marker from fixed. Defaulting the other way would file it back into the post-merge-only tree silently, which is the defect being closed.

## The second hole

`regression-tests.yml`'s push trigger named `tests/issues/regression/**`, `edgar/xbrl/**` and `edgar/entity/**`. A change under `edgar/documents/**` that added no regression file ran the suite in **no job at all** — and that is where the section-extraction defect cluster lives. Now `edgar/**`, which closes it as a class instead of one package at a time; docs- and script-only merges still skip it.

## Verification

- `test-ci-fast` (the selector CI runs): **4,177 passed, 7 skipped** in 118s.
- `-m 'regression and fast'` with sockets blocked and caches cleared: **933 passed** identically at `-n 4`, `-n 16` and `-n auto`.
- `-m 'regression and not fast and not network and not slow'`: **0 collected** — nothing is left unclassified.
- Both workflow files parse as YAML; `test-fast (3.13)` job name is untouched, so the required-check context is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)