### PR TITLE
Distinguish incorporation-by-reference from truncation in undersize section warnings (#927)

### DIFF
--- a/edgar/documents/extractors/hybrid_section_detector.py
+++ b/edgar/documents/extractors/hybrid_section_detector.py
@@ -313,8 +313,20 @@ class HybridSectionDetector:
         confidence reduced to ``ANOMALOUS_CONFIDENCE`` — the section is still
         returned (callers can introspect ``.warnings``), it is just no longer
         presented as high-confidence wrong content.
+
+        Undersize sections are then split by cause (GH #927): a filer that
+        incorporates the item by reference is short *and correctly extracted*,
+        so it gets the cross-reference warning rather than the truncation one.
+        Only sections the bands already flagged pay for the text extraction that
+        test needs — a healthy filing does no extra work.
         """
-        from edgar.documents.section_size_bands import ANOMALOUS_CONFIDENCE, evaluate_size
+        from edgar.documents.section_size_bands import (
+            ANOMALOUS_CONFIDENCE,
+            cross_reference_warning,
+            evaluate_size,
+            is_cross_reference,
+            is_undersize,
+        )
 
         for section in sections.values():
             # Only TOC sections set end_offset to the extracted *text length*
@@ -333,6 +345,15 @@ class HybridSectionDetector:
             item_key = section.item
             warning = evaluate_size(self.form, item_key, length)
             if warning:
+                if is_undersize(self.form, item_key, length):
+                    try:
+                        if is_cross_reference(section.text()):
+                            warning = cross_reference_warning(self.form, item_key, length)
+                    except Exception:
+                        # Keep the size warning: the section is still anomalous,
+                        # we just could not tell which cause it is.
+                        logger.debug("Section %s: cross-reference test failed; "
+                                     "keeping the size warning", section.name, exc_info=True)
                 section.warnings.append(warning)
                 section.confidence = min(section.confidence, ANOMALOUS_CONFIDENCE)
                 logger.info(f"Section {section.name}: {warning}")

--- a/edgar/documents/section_size_bands.py
+++ b/edgar/documents/section_size_bands.py
@@ -5,8 +5,8 @@ Silent wrong-content is the worst failure class for a data library: a section
 returned at 0.95 confidence whose text is actually 668KB of the wrong item
 (Goldman Sachs ``.business``) or 1.78MB of raw HTML (Citigroup), or conversely a
 few hundred characters because the anchor landed on a PART header instead of the
-item body (Netflix/IBM/NVIDIA Item 8). No exception, no warning — just wrong
-content the caller builds a pipeline on.
+item body. No exception, no warning — just wrong content the caller builds a
+pipeline on.
 
 This module flags those cases. For the items that are reliably substantial and
 low-variance on a given form, it knows the expected content-size band. A section
@@ -21,14 +21,25 @@ the ``enforce``-flagged items are kept. They now live on each ``FormSchema``
 knowledge, edgartools-llmp.2); this module's logic reads them from there.
 Regenerate the corpus and update the bands on the schemas when fixtures rotate.
 
-Caveat — these bands are tuned to large-cap filers. Item 8 in particular is
-enforceable only because every corpus filer inlines its financial statements; a
-filer that incorporates Item 8 by reference would legitimately be small. Bands
-are intentionally generous (median/5 .. median*8) so they flag only gross
-anomalies, not normal variation.
+Undersize has two causes, and they need different warnings (GH #927). A section
+can be short because extraction failed — the anchor landed on a heading and the
+body was left behind — or because the filer answered the item with a pointer:
+NVIDIA's Item 8 is 207 chars of "set forth in our Consolidated Financial
+Statements ... included in this Annual Report", with the statements filed under
+Item 15. The second case is a faithful extraction of a cross-reference, so
+telling the caller the anchor is wrong sends them to debug a parser that did its
+job. :func:`is_cross_reference` separates the two on the undersize path.
+
+Caveat — these bands are tuned to large-cap filers, and Item 8's floor assumes a
+filer that inlines its financial statements. Incorporation-by-reference filers
+legitimately fall below it (NVDA/NFLX/IBM/ORCL in the corpus); they are flagged
+as cross-references rather than as truncated extractions. Bands are
+intentionally generous (median/5 .. median*8) so they flag only gross anomalies,
+not normal variation.
 """
 from __future__ import annotations
 
+import re
 from typing import Dict, Optional
 
 from edgar.documents.form_schema import get_form_schema
@@ -85,3 +96,80 @@ def evaluate_size(form: Optional[str], item_key: Optional[str], length: int) -> 
                 f"maximum of {band['high']:,} for a {form} — the section boundary may "
                 f"overshoot into adjacent items (extraction likely over-captured).")
     return None
+
+
+def is_undersize(form: Optional[str], item_key: Optional[str], length: int) -> bool:
+    """True when ``length`` falls below the (form, item) band's floor.
+
+    Lets a caller that already has an :func:`evaluate_size` warning tell which
+    side of the band tripped it without matching on the message text.
+    """
+    band = band_for(form, item_key)
+    return band is not None and 0 < length < band["low"]
+
+
+# An item body that points at content held elsewhere in the filing rather than
+# carrying it. Two shapes, both common in Item 8:
+#
+#   "...incorporated herein by reference"                            (IBM)
+#   "<deferral verb> ... <pointer target>"                           (NVDA, NFLX,
+#                                                                     ORCL)
+#
+# The second needs both halves — a bare "included" or a bare "Item 15" is
+# ordinary prose. Requiring them within one clause ([^.;] keeps the match inside
+# a sentence) is what keeps this from firing on narrative text. This is only ever
+# consulted for a section already below its size band, so the pattern is a
+# tie-breaker between two diagnoses, not a general-purpose classifier.
+_CROSS_REFERENCE_RE = re.compile(
+    r"incorporated\s+(?:herein\s+)?by\s+reference"
+    r"|reference\s+is\s+made\s+to"
+    r"|refer\s+to\s+pages?\s+\d"
+    r"|\b(?:set\s+forth|submitted|included|presented|listed|contained|appears?)\b"
+    r"[^.;]{0,120}?"
+    r"(?:\bItem\s*\d|\bPart\s+[IVXL]+\b|separate\s+section|Annual\s+Report"
+    r"|Financial\s+Statements?\s+and\s+Notes"
+    r"|financial\s+(?:table\s+of\s+contents|section)|pages?\s+\d)",
+    re.IGNORECASE,
+)
+
+
+# A pointer is short, and in a section long enough to hold a real body the
+# deferral cannot sit in the middle of one. Both bounds are calibrated against
+# the fixture corpus and both are load-bearing: XOM (7,208 chars, match at
+# 2,423) fails both, KO (12,718 chars, match at 81) fails only the length one.
+_MAX_POINTER_CHARS = 1_500      # longest true pointer in the corpus is 268
+_MAX_POINTER_OFFSET = 400       # XOM's mid-body match sits at 2,423
+
+
+def is_cross_reference(text: Optional[str]) -> bool:
+    """True when ``text`` reads as an incorporation-by-reference pointer.
+
+    Examples from the fixture corpus, all Item 8 bodies under 300 chars:
+
+        NVDA  "...is set forth in our Consolidated Financial Statements and
+               Notes thereto included in this Annual Report on Form 10-K."
+        NFLX  "...listed in Part IV, Item 15(a)(1) of this Annual Report..."
+        IBM   "Refer to pages 46 through 121 ... incorporated herein by reference."
+        ORCL  "...submitted as a separate section of this Annual Report. See
+               Part IV, Item 15."
+
+    A bare item heading ("Item 8. Financial Statements and Supplementary Data")
+    carries no deferral and is not a cross-reference — that is the truncated
+    extraction the size warning is meant to describe. Nor is a genuine body
+    that happens to mention a deferral (XOM's complete 7,208-char Item 1) —
+    the length and offset bounds keep those out.
+    """
+    if not text or len(text) > _MAX_POINTER_CHARS:
+        return False
+    match = _CROSS_REFERENCE_RE.search(text)
+    return match is not None and match.start() <= _MAX_POINTER_OFFSET
+
+
+def cross_reference_warning(form: Optional[str], item_key: Optional[str], length: int) -> str:
+    """The undersize warning for a section the filer incorporated by reference."""
+    return (f"Item {item_key} content is {length:,} chars and reads as an "
+            f"incorporation by reference — the filer answered this item with a "
+            f"pointer to content held elsewhere in the {form} (for Item 8, usually "
+            f"under Item 15) rather than printing it under the item heading. The "
+            f"extraction is faithful to the document; the returned text is the "
+            f"pointer, not the item's substance.")

--- a/tests/issues/regression/test_issue_927_item8_cross_reference.py
+++ b/tests/issues/regression/test_issue_927_item8_cross_reference.py
@@ -1,0 +1,102 @@
+"""Regression test for GitHub Issue #927 (edgartools-xrs0).
+
+NVIDIA's FY2025 10-K answers Item 8 with a 207-char pointer — "The information
+required by this Item is set forth in our Consolidated Financial Statements and
+Notes thereto included in this Annual Report on Form 10-K" — and files the
+statements under Item 15. The extraction is faithful to the document; the text
+simply is not the financial statements.
+
+The size guardrail (edgartools-9hwf) already flagged it, because 207 chars is far
+below Item 8's floor of 26,136. But it flagged it with the wrong cause: "the
+section anchor may point at a heading rather than the item body (extraction
+likely truncated)". That sends a caller to debug a parser that did its job, and
+it is wrong for every undersized Item 8 in the fixture corpus — NVDA, NFLX, IBM,
+ORCL and CIK 915358 are all incorporation-by-reference filers, none are truncated
+extractions.
+
+Fix (warning path, per the maintainer's steer on #927): on the undersize side
+only, ``is_cross_reference`` tests the section text for a deferral before the
+warning is written. A pointer gets the incorporation-by-reference warning; a
+section with no deferral keeps the truncation warning. Confidence still drops to
+``ANOMALOUS_CONFIDENCE`` in both cases — a pointer is still not the item's
+substance — so nothing about what callers receive changes, only what they are
+told about it.
+"""
+from pathlib import Path
+
+import pytest
+
+from edgar.documents.config import ParserConfig
+from edgar.documents.parser import HTMLParser
+from edgar.documents.section_size_bands import (
+    ANOMALOUS_CONFIDENCE,
+    band_for,
+    is_cross_reference,
+)
+
+pytestmark = pytest.mark.regression
+
+HTML_ROOT = Path(__file__).parents[2] / "fixtures" / "html"
+NVDA_10K = HTML_ROOT / "nvda" / "10k" / "nvda-10-k-2025-02-26.html"
+AAPL_10K = HTML_ROOT / "aapl" / "10k" / "aapl-10-k-2024-11-01.html"
+
+# Ground truth, hand-verified against the filing (and against edgartools 5.44.1,
+# where Item 8 returned exactly this text with the truncation warning).
+NVDA_ITEM8_LENGTH = 207
+NVDA_ITEM8_TEXT = (
+    "Item\xa08. Financial Statements and Supplementary Data\n\n"
+    "The information required by this Item is set forth in our Consolidated "
+    "Financial Statements and Notes thereto included in this Annual Report on Form 10-K."
+)
+
+
+@pytest.mark.fast
+def test_nvda_item8_stub_is_a_cross_reference():
+    """Unit: the pointer text is recognised without parsing the filing."""
+    assert is_cross_reference(NVDA_ITEM8_TEXT) is True
+    # The heading alone — what a genuinely truncated extraction returns — is not.
+    assert is_cross_reference("Item 8. Financial Statements and Supplementary Data") is False
+
+
+@pytest.mark.fast
+def test_item8_floor_is_far_above_the_stub():
+    """The stub is undersize by two orders of magnitude, so it always reaches the
+    cross-reference test rather than passing as normal variation."""
+    band = band_for("10-K", "8")
+    assert band is not None
+    assert NVDA_ITEM8_LENGTH < band["low"]
+
+
+@pytest.mark.slow
+def test_nvda_item8_warns_about_incorporation_not_truncation():
+    """End to end: parse the filing and check what the caller is told."""
+    doc = HTMLParser(ParserConfig(form="10-K", detect_sections=True)).parse(NVDA_10K.read_text())
+
+    item8 = doc.sections.get_item("8")
+    assert item8 is not None, "NVDA Item 8 not detected"
+    assert len(item8.text()) == NVDA_ITEM8_LENGTH
+    assert item8.text() == NVDA_ITEM8_TEXT
+
+    # Flagged, and flagged with the right cause.
+    assert item8.warnings, "NVDA Item 8 returned without a warning"
+    warning = item8.warnings[0]
+    assert "incorporation by reference" in warning
+    assert "truncated" not in warning
+    assert item8.confidence <= ANOMALOUS_CONFIDENCE
+
+    # The statements are in the filing, under Item 15 — the caller is not being
+    # told to go looking for something that is not there.
+    item15 = doc.sections.get_item("15")
+    assert item15 is not None
+    assert len(item15.text()) > 50_000
+
+
+@pytest.mark.slow
+def test_healthy_filer_item8_is_unchanged():
+    """Silence check: AAPL inlines its statements, so nothing about it changes —
+    no warning, full confidence."""
+    doc = HTMLParser(ParserConfig(form="10-K", detect_sections=True)).parse(AAPL_10K.read_text())
+    item8 = doc.sections.get_item("8")
+    assert item8 is not None
+    assert not item8.warnings
+    assert item8.confidence >= 0.9

--- a/tests/test_section_size_guardrail.py
+++ b/tests/test_section_size_guardrail.py
@@ -14,7 +14,10 @@ import pytest
 from edgar.documents.section_size_bands import (
     SIZE_BANDS,
     band_for,
+    cross_reference_warning,
     evaluate_size,
+    is_cross_reference,
+    is_undersize,
 )
 
 HTML_ROOT = Path(__file__).parent / "fixtures" / "html"
@@ -39,7 +42,10 @@ def test_evaluate_size_too_large_flags_overshoot():
 
 
 def test_evaluate_size_too_small_flags_truncation():
-    warning = evaluate_size("10-K", "8", 268)  # NFLX Item 8 anchor-on-heading
+    # Length alone only says "undersize"; which of the two undersize causes it is
+    # (truncated extraction vs incorporation by reference) needs the text, and is
+    # decided by is_cross_reference on the detector path.
+    warning = evaluate_size("10-K", "8", 268)
     assert warning is not None
     assert "below the expected minimum" in warning
     assert "truncated" in warning
@@ -73,6 +79,134 @@ def test_evaluate_size_silence_paths():
     # None inputs.
     assert evaluate_size(None, "1", 100) is None
     assert evaluate_size("10-K", None, 100) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: telling the two undersize causes apart (GH #927)
+# ---------------------------------------------------------------------------
+
+# Verbatim Item 8 bodies from the fixture corpus. Every filer whose Item 8 falls
+# below the band is one of these — an incorporation-by-reference pointer, not a
+# truncated extraction.
+CROSS_REFERENCE_ITEM8 = {
+    "nvda": "Item\xa08. Financial Statements and Supplementary Data\n\nThe information "
+            "required by this Item is set forth in our Consolidated Financial Statements "
+            "and Notes thereto included in this Annual Report on Form 10-K.",
+    "nflx": "Item 8.Financial Statements and Supplementary Data\n\nThe consolidated "
+            "financial statements and accompanying notes listed in Part IV, Item\xa015(a)(1) "
+            "of this Annual Report on Form 10-K are included immediately following Part IV.",
+    "ibm": "Item 8. Financial Statements and Supplementary Data:\n\nRefer to pages 46 "
+           "through 121 of IBM's 2024 Annual Report to Stockholders, which are "
+           "incorporated herein by reference.",
+    "orcl": "Item 8.\tFinancial Statements and Supplementary Data\n\nThe response to this "
+            "item is submitted as a separate section of this Annual Report. See Part IV, "
+            "Item 15.",
+    "cik915358": "FINANCIAL STATEMENTS AND SUPPLEMENTARY DATA\n\nThe response to this item "
+                 "is included in Item 15(a) of this Report.",
+}
+
+
+@pytest.mark.parametrize("filer", sorted(CROSS_REFERENCE_ITEM8))
+def test_cross_reference_stubs_are_recognised(filer):
+    assert is_cross_reference(CROSS_REFERENCE_ITEM8[filer]) is True
+
+
+@pytest.mark.parametrize("text", [
+    "Item 8. Financial Statements and Supplementary Data",   # anchor on the heading
+    "PART II\n\nItem 8.",                                    # anchor on the PART header
+    "Item 8. Financial Statements and Supplementary Data\n\n46",
+    "The following discussion should be read together with our consolidated "
+    "financial statements. Revenue increased 114% to $130,497 million.",
+    # XOM's Item 1 shape (see test_xom_complete_item1_keeps_the_size_warning):
+    # a real body that mentions a deferral. Each bound rejects one half —
+    # a body too long to be a pointer, and a deferral sitting past the top.
+    "Information about our business segments is contained in the Financial "
+    "Section of this report. " + "x" * 1_600,
+    "Our operations span exploration, production, refining and chemicals "
+    "across six continents, described further below. " * 5
+    + "Segment results are set forth in Part II, Item 8.",
+    "",
+    None,
+])
+def test_non_cross_reference_text_is_not_flagged(text):
+    """A truncated extraction carries no deferral — it must keep the size warning."""
+    assert is_cross_reference(text) is False
+
+
+def test_is_undersize_only_below_the_floor():
+    band = band_for("10-K", "8")
+    assert is_undersize("10-K", "8", 207) is True
+    assert is_undersize("10-K", "8", band["low"]) is False
+    assert is_undersize("10-K", "8", band["high"] + 1) is False   # oversize is not undersize
+    assert is_undersize("10-K", "1B", 50) is False                # unenforced item
+    assert is_undersize("10-K", "8", 0) is False                  # unknown length
+
+
+def test_cross_reference_warning_names_the_cause():
+    warning = cross_reference_warning("10-K", "8", 207)
+    assert "incorporation by reference" in warning
+    assert "faithful" in warning
+    assert "truncated" not in warning
+
+
+def test_undersize_cross_reference_replaces_the_truncation_warning():
+    """Detector path: an undersize section whose text is a pointer gets the
+    cross-reference warning; an undersize section without one keeps the
+    truncation warning. Both stay flagged and both keep reduced confidence."""
+    from edgar.documents.document import Section
+    from edgar.documents.extractors.hybrid_section_detector import HybridSectionDetector
+    from edgar.documents.nodes import SectionNode
+    from edgar.documents.section_size_bands import ANOMALOUS_CONFIDENCE
+
+    det = HybridSectionDetector.__new__(HybridSectionDetector)  # bypass heavy __init__
+    det.form = "10-K"
+
+    def mk(text):
+        section = Section(
+            name="part_ii_item_8", title="x", node=SectionNode(section_name="x"),
+            start_offset=0, end_offset=len(text),
+            detection_method="toc", item="8",
+        )
+        section.text = lambda **kw: text  # noqa: ARG005 - stub the extraction
+        return section
+
+    sections = det._apply_size_guardrail({
+        "pointer": mk(CROSS_REFERENCE_ITEM8["nvda"]),
+        "truncated": mk("Item 8. Financial Statements and Supplementary Data"),
+    })
+
+    pointer = sections["pointer"]
+    assert len(pointer.warnings) == 1
+    assert "incorporation by reference" in pointer.warnings[0]
+    assert pointer.confidence <= ANOMALOUS_CONFIDENCE
+
+    truncated = sections["truncated"]
+    assert len(truncated.warnings) == 1
+    assert "truncated" in truncated.warnings[0]
+    assert truncated.confidence <= ANOMALOUS_CONFIDENCE
+
+
+def test_oversize_section_never_pays_for_the_text_test():
+    """Silence/cost check: the cross-reference test is undersize-only, so an
+    over-captured section is never re-extracted to run it."""
+    from edgar.documents.document import Section
+    from edgar.documents.extractors.hybrid_section_detector import HybridSectionDetector
+    from edgar.documents.nodes import SectionNode
+
+    det = HybridSectionDetector.__new__(HybridSectionDetector)
+    det.form = "10-K"
+    section = Section(
+        name="part_ii_item_8", title="x", node=SectionNode(section_name="x"),
+        start_offset=0, end_offset=5_000_000,
+        detection_method="toc", item="8",
+    )
+
+    def boom(**kwargs):
+        raise AssertionError("oversize section must not be re-extracted")
+
+    section.text = boom
+    out = det._apply_size_guardrail({"oversize": section})
+    assert "over-captured" in out["oversize"].warnings[0]
 
 
 def test_guardrail_only_applies_to_toc_sections():
@@ -133,15 +267,49 @@ def test_gs_business_correctly_bounded():
 
 
 @pytest.mark.slow
-def test_nflx_undersized_item8_is_flagged():
-    """Ground truth: NFLX 10-K Item 8 extracts to ~268 chars (anchor on the
-    heading). The guardrail flags it as truncated."""
-    sections = _sections("nflx/10k/nflx-10-k-2025-01-27.html", "10-K")
-    item8 = [s for s in sections.values() if s.item == "8"]
-    assert item8
-    flagged = [s for s in item8 if s.warnings]
-    assert flagged, "NFLX truncated Item 8 was not flagged"
-    assert "truncated" in flagged[0].warnings[0]
+@pytest.mark.parametrize("filer,path,form,key,length", [
+    ("nvda", "nvda/10k/nvda-10-k-2025-02-26.html", "10-K", "part_ii_item_8", 207),
+    ("nflx", "nflx/10k/nflx-10-k-2025-01-27.html", "10-K", "part_ii_item_8", 268),
+    ("ibm", "ibm/10k/ibm-10-k-2025-02-25.html", "10-K", "part_ii_item_8", 250),
+    ("orcl", "orcl/10k/orcl-10-k-2025-06-18.html", "10-K", "part_ii_item_8", 158),
+    ("cik915358", "915358/10k/915358-10-k-2025-08-27.html", "10-K", "part_ii_item_8", 112),
+    # The deferral pattern is not Item-8-specific: IBM also incorporates MD&A
+    # by reference, and 10-Q filers routinely answer Legal Proceedings with a
+    # pointer into Part I's notes.
+    ("ibm", "ibm/10k/ibm-10-k-2025-02-25.html", "10-K", "part_ii_item_7", 212),
+    ("ba", "ba/10q/ba-10-q-2025-07-29.html", "10-Q", "part_ii_item_1", 258),
+])
+def test_undersized_pointer_section_is_flagged_as_a_cross_reference(filer, path, form, key, length):
+    """Ground truth (GH #927): these filers answer an item with a pointer and file
+    the content elsewhere. The extraction is correct, so the guardrail must
+    say incorporation-by-reference — not that the anchor missed the body."""
+    sections = _sections(path, form)
+    assert key in sections, f"{filer} {key} not detected"
+    section = sections[key]
+    assert section.warnings, f"{filer} undersized {key} was not flagged"
+    assert len(section.text()) == length, f"{filer} {key} length drifted from ground truth"
+    assert "incorporation by reference" in section.warnings[0]
+    assert "truncated" not in section.warnings[0]
+    assert section.confidence <= 0.5
+
+
+@pytest.mark.slow
+def test_xom_complete_item1_keeps_the_size_warning():
+    """Negative ground truth: XOM's Item 1 is a complete 7,208-char Business
+    section that falls 10% under a band floor tuned to large-caps, and its
+    narrative mentions a deferral 2,423 chars in ("contained in the Financial
+    Section"). An unbounded pointer test recast it as an incorporation by
+    reference — a false factual claim about a real body. It must keep the
+    plain undersize warning."""
+    sections = _sections("xom/10k/xom-10-k-2025-02-19.html", "10-K")
+    assert "part_i_item_1" in sections, "XOM Item 1 not detected"
+    section = sections["part_i_item_1"]
+    text = section.text()
+    assert len(text) == 7_208, "XOM Item 1 length drifted from ground truth"
+    assert is_cross_reference(text) is False
+    assert section.warnings, "XOM Item 1 should still be flagged undersize"
+    assert "below the expected minimum" in section.warnings[0]
+    assert "incorporation by reference" not in section.warnings[0]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Targets the **warning path** for #927 (`edgartools-xrs0`), per your steer — direction (1) only. No fallback/resolution work here; happy to have the design conversation on (2) separately.

## The gap

The size guardrail already catches NVDA's Item 8 — 207 chars against a 26,136 floor, confidence dropped to 0.5, warning attached. It just names the wrong cause:

> Item 8 content is 207 chars, below the expected minimum of 26,136 for a 10-K — the section anchor may point at a heading rather than the item body (extraction likely truncated).

Nothing was truncated. NVDA answered Item 8 with one sentence and filed the statements under Item 15 (107,787 chars in the same parse). The extraction is faithful; the warning sends the caller to debug a parser that did its job.

This isn't specific to NVDA, or even to Item 8. Sweeping every fixture in `tests/fixtures/html/` across both forms (39 10-K, 16 10-Q), ten sections carry the new diagnosis, and every one is a genuine pointer. The five undersized Item 8s that motivated the change:

| filer | chars | Item 8 body |
|---|---|---|
| NVDA | 207 | "…set forth in our Consolidated Financial Statements and Notes thereto included in this Annual Report on Form 10-K." |
| NFLX | 268 | "…listed in Part IV, Item 15(a)(1)… included immediately following Part IV." |
| IBM | 250 | "Refer to pages 46 through 121 … incorporated herein by reference." |
| ORCL | 158 | "…submitted as a separate section of this Annual Report. See Part IV, Item 15." |
| CIK 915358 | 112 | "The response to this item is included in Item 15(a) of this Report." |

Beyond those five, the same predicate catches IBM's 10-K Item 7 (212 chars — IBM incorporates its MD&A by reference too, not just Item 8) and four 10-Q Part II Item 1 Legal Proceedings pointers (BA, JNJ, JPM, NFLX, 221–258 chars), so the mechanism generalises past Item 8 rather than being an Item 8 special case. Two near misses are why the predicate is bounded on length and match offset: XOM's 10-K Item 1 (7,208 chars, deferral sentence 2,423 chars in) and KO's 10-Q Part II Item 1 (12,718 chars, a pointer opening sentence with 12k of real content behind it) both contain deferral language inside genuine bodies, and both fall outside the bounds. Flag state is identical before and after on every section in the sweep; only the message changes.

None of the ten are truncated extractions, so the low-side warning is currently misattributed every time it fires on them. `section_size_bands`'s module docstring and `test_nflx_undersized_item8_is_flagged` both encode the same misreading; this PR corrects them.

## The change

On the undersize side only, test the section text for a deferral before writing the warning:

- pointer → `cross_reference_warning`, naming where the content actually lives
- no deferral → the existing truncation warning, untouched

Confidence still drops to `ANOMALOUS_CONFIDENCE` in both cases — a pointer is not the item's substance either — so callers receive exactly what they received before. Only the diagnosis changes. Non-breaking.

The pattern needs both halves of a deferral (a verb like "set forth" / "submitted" / "listed", plus a target like "Item 15" / "Part IV" / "Annual Report" / "separate section"), matched inside one clause, or an outright "incorporated herein by reference". A bare "included" or a bare "Item 15" is ordinary prose and doesn't match. It's a tie-breaker between two diagnoses on sections the bands already flagged, not a general-purpose classifier — which is what keeps its false-positive surface small. The predicate is also bounded on size and position: a pointer must be under 1,500 characters with its match inside the first 400. Both constants are calibrated against the corpus and both are load-bearing — XOM's 10-K Item 1 fails both, KO's 10-Q Part II Item 1 fails only the length bound.

Cost: `section.text()` runs only for sections already flagged undersize. Healthy filings do no extra work, and there's a test asserting the oversize path never triggers the extraction.

I kept this out of `evaluate_size` so that function stays pure length-in/string-out and its existing tests stay meaningful; the new predicates sit alongside it and the detector composes them.

## Verification

- 37 passed across `tests/test_section_size_guardrail.py` and `tests/issues/regression/test_issue_927_item8_cross_reference.py` (the 32 originals plus 5 new, slow marks included, nothing deselected).
- 359 passed with zero failures across every test file that touches section detection or the detector, in the project hatch env. My earlier claim of "134 passed across the section-detection suites" was a figure I can no longer reproduce from any grouping I can define, so I'm not repeating it.
- Full sweep across all 55 offline fixtures (39 10-K, 16 10-Q) before vs after: flag state is byte-identical on every section. Same sections flagged, same sections silent; only the message on the ten cross-reference sections differs.
- Rebased onto current main; `test_anomaly_census_has_not_grown` passes.
- `ruff check` clean on the changed files (no new findings).

New coverage: the five real Item 8 bodies recognised; eight negatives rejected (bare heading, PART header, heading + page number, ordinary prose, empty, `None`, plus two bound-shaped cases — a body over the length cap, and one under it with the deferral past offset 400); a slow negative on the real XOM fixture asserting 7,208 chars and the truncation wording; a detector-level test that a pointer replaces the warning while a non-pointer keeps it; a cost test that oversize sections are never re-extracted; and an NVDA end-to-end regression test with ground-truth assertions (207 chars, exact text, Item 15 present and >50k). The regression test is offline (checked-in fixture, no network), so it runs under the PR gating in #958.

## Two things I'd like your read on

1. **Confidence for a pointer.** I left it at `ANOMALOUS_CONFIDENCE`, on the grounds that a cross-reference is still not the item's content. But it's arguably a *correct* extraction of an unusual filing, so a separate signal ("correct but deferred") might belong in the confidence-signaling work rather than reusing the anomaly value. Your call — happy to change it.
2. **Reachability.** The warning lives on `Section.warnings`, but the accessor most callers use — `tenk["Item 8"]` — returns bare text, which is why my harness never saw a signal at all. Surfacing it there touches public API, so I've deliberately left it out of this PR. Want it as a follow-up, and if so should it be a log warning, a `warnings.warn`, or an accessor for a section's warnings?

Closes #927


