### PR TITLE
perf(filings): resolve an accession from full-text search, not the quarterly index

### DIFF
--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -2640,10 +2640,42 @@ def summarize_files(data: pd.DataFrame) -> pd.DataFrame:
             )
 
 
+def _filing_from_efts(accession_number: str):
+    """Resolve an accession through EDGAR full-text search, or None.
+
+    An accession carries no CIK, and every document URL needs one, so opening a
+    filing from an accession alone always costs a lookup. This is the cheap way
+    to pay it: ~2 KB against 4.1 MB gzipped per quarter probed, which expands to
+    41 MB to parse (bead edgartools-vx29).
+
+    None means "ask the quarterly index" — EFTS indexes 2001 onward, so older
+    filings legitimately miss here, and a network failure is deliberately also a
+    miss rather than an error. The index route stays correct for everything;
+    this only makes the common case cheap.
+    """
+    from edgar.search.efts import resolve_accession
+
+    fields = resolve_accession(accession_number)
+    if not fields:
+        return None
+    return Filing(
+        cik=fields["cik"],
+        company=fields["company"],
+        form=fields["form"],
+        filing_date=fields["filing_date"],
+        accession_no=accession_number,
+        related_entities=fields["related_entities"],
+    )
+
+
 @cache_except_none(maxsize=16)
 def get_filing_by_accession(accession_number: str, year: int):
     """Cache-friendly version that takes year as parameter instead of using datetime.now()"""
     assert re.match(r"\d{10}-\d{2}-\d{6}", accession_number)
+
+    filing = _filing_from_efts(accession_number)
+    if filing is not None:
+        return filing
 
     # Only search quarters that exist - for current year, limit to current quarter
     current_year, current_quarter = current_year_and_quarter()
@@ -2660,6 +2692,12 @@ def get_filing_by_accession(accession_number: str, year: int):
 def get_by_accession_number_enriched(accession_number: str):
     """Get filing with all related entities populated using PyArrow"""
     year = int("19" + accession_number[11:13]) if accession_number[11] == '9' else int("20" + accession_number[11:13])
+
+    # EFTS returns every filer on the filing in one ~2 KB response, which is the
+    # same thing the quarter scan below reconstructs from a 41 MB index.
+    filing = _filing_from_efts(accession_number)
+    if filing is not None:
+        return filing
 
     # Only search quarters that exist - for current year, limit to current quarter
     current_year, current_quarter = current_year_and_quarter()

--- a/edgar/search/efts.py
+++ b/edgar/search/efts.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import List, Optional, Union
 
 logger = logging.getLogger(__name__)
@@ -633,3 +635,100 @@ def _format_accession(adsh: str) -> str:
     if len(adsh) == 18:
         return f"{adsh[:10]}-{adsh[10:12]}-{adsh[12:]}"
     return adsh
+
+
+# ---------------------------------------------------------------------------
+# Accession lookup
+# ---------------------------------------------------------------------------
+
+# "Airbnb, Inc.  (ABNB)  (CIK 0001559720)" -> "Airbnb, Inc."
+#
+# EFTS decorates the filer name with a ticker and CIK, each separated by two
+# spaces. The quarterly index carries the bare name, and callers compare against
+# it, so the decoration is stripped. Anchoring on the double space matters:
+# single-spaced parentheses are part of company names ("BANK OF AMERICA CORP
+# /DE/" is fine, but plenty of filers are "... (DELAWARE)").
+_EFTS_NAME_DECORATION = re.compile(r"\s{2,}\([^)]*\)")
+
+
+def _clean_display_name(display_name: str) -> str:
+    return _EFTS_NAME_DECORATION.sub("", display_name).strip()
+
+
+def resolve_accession(accession_number: str) -> Optional[dict]:
+    """Look up a filing's index fields from EDGAR full-text search.
+
+    Resolving an accession to a ``Filing`` needs four fields the accession does
+    not carry — cik, company, form and filing date — and the CIK is not optional:
+    every document URL is ``/Archives/edgar/data/{cik}/{accession}/...``. The
+    quarterly full-index answers this, but costs 4.1 MB gzipped per quarter
+    probed, expanding to 41 MB to parse. This answers the same question in
+    roughly 2 KB (bead edgartools-vx29).
+
+    Returns a dict of ``cik``, ``company``, ``form``, ``filing_date`` and
+    ``related_entities``, or ``None`` when EFTS has no filing under this
+    accession — which is expected and not an error: the full-text index starts
+    in 2001, so anything earlier must fall back to the quarterly index.
+
+    Hits are filtered on ``adsh``. EFTS is a *text* search, so a filing that
+    merely quotes another filing's accession number matches the query too, and
+    taking the first hit would occasionally resolve the wrong filing.
+
+    Multi-filer filings resolve to their first filer, with the rest in
+    ``related_entities``. EDGAR serves the documents under every filer's CIK, so
+    any of them fetches; the order can differ from the quarterly index's.
+    """
+    import orjson
+
+    from edgar.httprequests import get_with_retry
+
+    normalized = accession_number.replace("-", "")
+
+    try:
+        response = get_with_retry(EFTS_BASE_URL, params={"q": f'"{accession_number}"'})
+        hits = orjson.loads(response.content).get("hits", {}).get("hits", [])
+    except Exception as exc:  # network, rate limit, schema drift
+        logger.debug("EFTS accession lookup failed for %s: %s", accession_number, exc)
+        return None
+
+    for hit in hits:
+        source = hit.get("_source", {})
+        if source.get("adsh", "").replace("-", "") != normalized:
+            continue
+
+        ciks = source.get("ciks") or []
+        names = source.get("display_names") or []
+        if not ciks or not source.get("form") or not source.get("file_date"):
+            # A hit that cannot furnish the four fields is no better than a miss;
+            # let the caller fall back rather than build a half-filled Filing.
+            return None
+
+        # Indexed off ciks rather than zipped with names: the two lists are
+        # parallel in every response seen, but a zip would silently drop a filer
+        # if they ever diverge, and a filer is the one field that must not go
+        # missing — it is what the document URL is built from.
+        # EFTS dates are ISO strings; the quarterly index yields datetime.date.
+        # Callers compare against date objects (tests/test_filing.py:721 asserts
+        # == datetime.date(2023, 3, 6)), so the string has to be parsed here or
+        # this route silently changes Filing.filing_date's type.
+        try:
+            filing_date = datetime.strptime(source["file_date"], "%Y-%m-%d").date()
+        except (TypeError, ValueError):
+            return None
+
+        entities = [
+            {"cik": int(cik),
+             "company": _clean_display_name(names[i]) if i < len(names) else "",
+             "form": source["form"],
+             "filing_date": filing_date}
+            for i, cik in enumerate(ciks)
+        ]
+        return {
+            "cik": int(ciks[0]),
+            "company": _clean_display_name(names[0]) if names else "",
+            "form": source["form"],
+            "filing_date": filing_date,
+            "related_entities": entities[1:],
+        }
+
+    return None

--- a/tests/issues/regression/test_issue_vx29_efts_accession.py
+++ b/tests/issues/regression/test_issue_vx29_efts_accession.py
@@ -1,0 +1,184 @@
+"""Regression tests for edgartools-vx29: resolving an accession without the index.
+
+An accession number carries no CIK, and every document URL is
+``/Archives/edgar/data/{cik}/{accession}/...``, so opening a filing from an
+accession alone always costs a lookup. It used to be paid by downloading
+quarterly full-index files until the accession turned up — 4.1 MB gzipped per
+quarter probed, expanding to 41 MB to parse — to learn four short fields.
+
+EDGAR full-text search answers the same question in about 2 KB. It only indexes
+2001 onward, so the index remains the fallback and must stay correct.
+
+These tests pin the three things that can go wrong: the wrong filing being
+resolved (EFTS is a text search, so a filing quoting another's accession number
+matches the query), a half-filled Filing being returned instead of falling back,
+and an EFTS outage turning into an exception instead of a fallback.
+"""
+from datetime import date
+
+import pytest
+
+from edgar._filings import _filing_from_efts
+from edgar.search.efts import _clean_display_name, resolve_accession
+
+
+def _efts_response(payload):
+    """Minimal stand-in for the object get_with_retry returns."""
+    import orjson
+
+    class _Response:
+        content = orjson.dumps(payload)
+
+    return _Response()
+
+
+def _hit(adsh, ciks, names, form="424B5", file_date="2025-12-31"):
+    return {"_source": {"adsh": adsh, "ciks": ciks, "display_names": names,
+                        "form": form, "file_date": file_date}}
+
+
+class TestResolutionIsForTheRequestedFiling:
+    """EFTS is a text search; matching the query is not the same as being it."""
+
+    def test_a_filing_quoting_another_accession_does_not_win(self, monkeypatch):
+        """The decisive case. A filing that cites 0001493152-25-029712 in its
+        text matches a phrase search for it, and ranks first here. Taking
+        hits[0] would resolve the citing filing — right accession asked for,
+        wrong filing returned, and no error anywhere."""
+        wanted = "0001493152-25-029712"
+        payload = {"hits": {"hits": [
+            _hit("0009999999-25-000001", ["0000111111"], ["Some Other Filer  (CIK 0000111111)"]),
+            _hit(wanted, ["0000749647"], ["Imunon, Inc.  (IMNN)  (CIK 0000749647)"]),
+        ]}}
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response(payload))
+
+        fields = resolve_accession(wanted)
+        assert fields["cik"] == 749647
+        assert fields["company"] == "Imunon, Inc."
+
+    def test_only_a_citing_filing_matches_so_it_falls_back(self, monkeypatch):
+        """No hit carries the accession: that is a miss, not a wrong answer."""
+        payload = {"hits": {"hits": [
+            _hit("0009999999-25-000001", ["0000111111"], ["Some Other Filer  (CIK 0000111111)"]),
+        ]}}
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response(payload))
+
+        assert resolve_accession("0001493152-25-029712") is None
+
+
+class TestFallbackRatherThanAHalfAnswer:
+    """None means "ask the index". A partial Filing would be worse than that."""
+
+    def test_no_hits_returns_none(self, monkeypatch):
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response({"hits": {"hits": []}}))
+        assert resolve_accession("0000912057-97-000920") is None
+
+    @pytest.mark.parametrize("missing", ["ciks", "form", "file_date"])
+    def test_a_hit_missing_a_required_field_returns_none(self, monkeypatch, missing):
+        """Every one of these is needed to build a usable Filing, and the CIK
+        most of all — it is what the document URL is built from."""
+        hit = _hit("0001493152-25-029712", ["0000749647"], ["Imunon, Inc.  (IMNN)  (CIK 0000749647)"])
+        hit["_source"][missing] = [] if missing == "ciks" else None
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response({"hits": {"hits": [hit]}}))
+
+        assert resolve_accession("0001493152-25-029712") is None
+
+    def test_efts_failure_is_a_miss_not_an_exception(self, monkeypatch):
+        """An EFTS outage must degrade to the slow path, not break lookups."""
+        def _boom(*args, **kwargs):
+            raise ConnectionError("efts.sec.gov unreachable")
+
+        monkeypatch.setattr("edgar.httprequests.get_with_retry", _boom)
+        assert resolve_accession("0001493152-25-029712") is None
+        assert _filing_from_efts("0001493152-25-029712") is None
+
+
+class TestMultiFilerFilings:
+    def test_every_filer_is_kept(self, monkeypatch):
+        """BofA structured notes are filed by the issuer and guaranteed by the
+        parent. EDGAR serves the documents under either CIK; both are kept, the
+        first as the filing's own and the rest as related entities."""
+        payload = {"hits": {"hits": [_hit(
+            "0001918704-24-002559",
+            ["0001682472", "0000070858"],
+            ["BofA Finance LLC  (CIK 0001682472)",
+             "BANK OF AMERICA CORP /DE/  (CIK 0000070858)"],
+            form="424B2", file_date="2024-12-31",
+        )]}}
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response(payload))
+
+        filing = _filing_from_efts("0001918704-24-002559")
+        assert (filing.cik, filing.company) == (1682472, "BofA Finance LLC")
+        assert [e["cik"] for e in filing._related_entities] == [70858]
+
+    def test_a_filer_without_a_display_name_is_still_kept(self, monkeypatch):
+        """The lists are parallel in every response seen. If they ever are not,
+        losing a CIK is the one outcome that must not happen."""
+        payload = {"hits": {"hits": [_hit(
+            "0001918704-24-002559", ["0001682472", "0000070858"],
+            ["BofA Finance LLC  (CIK 0001682472)"], form="424B2", file_date="2024-12-31",
+        )]}}
+        monkeypatch.setattr("edgar.httprequests.get_with_retry",
+                            lambda *a, **k: _efts_response(payload))
+
+        filing = _filing_from_efts("0001918704-24-002559")
+        assert [e["cik"] for e in filing._related_entities] == [70858]
+
+
+class TestDisplayNameCleaning:
+    """EFTS decorates names with ticker and CIK; the index carries them bare."""
+
+    @pytest.mark.parametrize("display,expected", [
+        ("Airbnb, Inc.  (ABNB)  (CIK 0001559720)", "Airbnb, Inc."),
+        ("BANK OF AMERICA CORP /DE/  (CIK 0000070858)", "BANK OF AMERICA CORP /DE/"),
+        ("Imunon, Inc.  (IMNN)  (CIK 0000749647)", "Imunon, Inc."),
+    ])
+    def test_decoration_is_stripped(self, display, expected):
+        assert _clean_display_name(display) == expected
+
+    def test_single_spaced_parentheses_are_part_of_the_name(self):
+        """Anchored on the double space EFTS uses, so a filer whose real name
+        ends in parentheses keeps them."""
+        assert _clean_display_name("ACME HOLDINGS (DELAWARE)") == "ACME HOLDINGS (DELAWARE)"
+
+
+class TestAgainstEdgar:
+    @pytest.mark.network
+    def test_resolves_a_known_filing_to_its_index_fields(self):
+        """Ground truth: Imunon's 424B5, verified against EDGAR."""
+        fields = resolve_accession("0001493152-25-029712")
+        assert fields == {
+            "cik": 749647,
+            "company": "Imunon, Inc.",
+            "form": "424B5",
+            "filing_date": date(2025, 12, 31),
+            "related_entities": [],
+        }
+
+    @pytest.mark.network
+    def test_filing_date_is_a_date_not_the_string_efts_returns(self):
+        """The quarterly index yields datetime.date and callers compare against
+        one. EFTS returns "2025-12-31"; handing that through unparsed changes
+        Filing.filing_date's type on a path users cannot see."""
+        filing = _filing_from_efts("0001493152-25-029712")
+        assert filing.filing_date == date(2025, 12, 31)
+        assert isinstance(filing.filing_date, date)
+
+    @pytest.mark.network
+    def test_pre_2001_accession_is_a_miss_and_the_index_still_resolves_it(self):
+        """EFTS starts in 2001. This is why the index route cannot be removed:
+        a 1997 filing misses here and must still come back from get_filings."""
+        from edgar import get_by_accession_number
+
+        assert resolve_accession("0000912057-97-011160") is None
+
+        filing = get_by_accession_number("0000912057-97-011160")
+        assert filing is not None
+        assert filing.cik == 225261
+        assert filing.form == "10-Q"
+        assert str(filing.filing_date) == "1997-03-31"


### PR DESCRIPTION
`find("0001493152-25-029712")` now takes **0.3s** instead of downloading and parsing a quarterly index; `get_by_accession_number` takes **0.16s**.

## Why this is not a `Filing(accession)` constructor

An accession carries no CIK, and every document URL is `/Archives/edgar/data/{cik}/{accession}/...`. Opening a filing from an accession alone **always** costs a lookup — only the price is negotiable.

It was being paid by downloading full-index files quarter by quarter until the accession turned up, to learn four short fields. EDGAR full-text search answers the same question in ~2 KB, and `edgar/search/efts.py` already spoke to it, so this is plumbing rather than new capability.

## Correcting myself

The zuuu commits called the index "a ~30 MB fetch". Measured on 2025 QTR4:

| | |
|---|---|
| over the wire (gzip) | **4.1 MB** |
| decompressed | **41.1 MB** |

The 30 MB figure was the *decompressed* size — which is what cassettes recorded, because conftest sets `decode_compressed_response`. The bytes reclaimed in those PRs were measured from real files and stand; the **network** cost was overstated. The real user-facing cost is the gunzip and pyarrow parse, not the transfer.

## The index route stays

EFTS indexes 2001 onward, so anything older misses and falls through to the quarter scan unchanged — verified on a real 1997 10-Q, which still resolves with fields matching the index exactly. An EFTS failure is deliberately also a miss rather than an exception, so an outage degrades to the slow path instead of breaking lookups.

## Hits are filtered on `adsh`

EFTS is a *text* search: a filing that quotes another filing's accession number matches the query too, and can outrank it. Taking `hits[0]` would resolve the wrong filing while looking entirely successful. There is a test for exactly this.

## Measured against ground truth

All **54** accessions in `tests/_offline_filings.py`, whose fields came from the index, were resolved through this path: **50 identical, 0 misses**.

The other 4 are BofA structured notes, filed by an issuer and guaranteed by a parent. EFTS orders the filers `[issuer, guarantor]` where the index picked the guarantor, so **`Filing.cik` and `.company` change for multi-filer filings**. Nothing is lost — the index's pick lands in `related_entities`, `all_ciks` is sorted and identical, and EDGAR serves the documents under either CIK (both return 200) — but it is a visible change for anyone reading `.company` off a multi-filer filing, and worth a line in the 6.0 notes.

## A defect the existing suite caught

`test_filing.py:721` asserts `filing_date == datetime.date(2023, 3, 6)`, and EFTS returns `"2023-03-06"`. Handing the string through would have changed `Filing.filing_date`'s type on a path nobody looks at. It is parsed now, and a test pins the type rather than only the value.

## Verified

- **4,353** fast tests pass.
- **137** network tests across `test_filing`, `test_edgar`, `test_filing_metadata`, `test_multi_entity_filings` and `test_current_filings` pass, including the multi-entity assertions on `all_ciks` and related-entity names.
- 15 new regression tests, 13 of which run offline.

Closes edgartools-vx29

🤖 Generated with [Claude Code](https://claude.com/claude-code)