### PR TITLE
docs(contributing): an entry standard so changelog length stops tracking agent context

### DIFF
--- a/.claude/agents/release-specialist.md
+++ b/.claude/agents/release-specialist.md
@@ -38,11 +38,11 @@ You orchestrate the entire release lifecycle from preparation through publicatio
    - Ensure version follows semantic versioning (MAJOR.MINOR.PATCH)
    - Handle pre-release versions (alpha, beta, rc) when specified
 
-3. **Changelog Generation**
-   - Parse commit history since last release
-   - Group changes by type (Features, Bug Fixes, Breaking Changes, etc.)
-   - Generate clear, user-friendly changelog entries
-   - Update CHANGELOG.md or NEWS file
+3. **Changelog Generation** — see "The Changelog Entry Standard" below, which is
+   binding on this project and overrides generic changelog habits
+   - Fold `## [Unreleased]` into a dated `## [X.Y.Z] - YYYY-MM-DD` section
+   - Group changes by type (Added, Changed, Fixed, Performance, Removed)
+   - Rewrite each entry to the standard as you fold it
    - Include contributor acknowledgments
 
 4. **Release Execution**
@@ -78,7 +78,9 @@ When executing a release, follow this systematic approach:
 
 3. **Prepare Release**
    - Update version numbers
-   - Generate/update changelog
+   - Fold `[Unreleased]` into a dated section, rewriting each entry to the
+     Changelog Entry Standard, and check the `docs/upgrade/<major>.md` coverage
+     of every behaviour change in it
    - Create release commit
    - Tag the release
 
@@ -93,6 +95,51 @@ When executing a release, follow this systematic approach:
    - Confirm git tag and GitHub release are live
    - Report built artifact paths and the exact manual-publish command for the maintainer to run
    - Verify all automated processes completed
+
+## The Changelog Entry Standard
+
+`CHANGELOG.md` entries on this project are compiled from AI session context, so
+without a cap their length tracks the writing agent's context rather than what a
+reader needs — which is why the file has three visibly different style eras. You
+apply this standard mechanically when `[Unreleased]` folds at release. The full
+statement of it lives in `CONTRIBUTING.md` under "Changelog Entries"; read that
+section before you fold, and keep the two in agreement.
+
+**The rewrite, per entry:**
+
+1. **Lead with the symptom, in a bold sentence-case sentence naming the public
+   symbol in backticks.** What a user saw go wrong, not what the code did.
+2. **One to three sentences after the lead** for cause and fix. **80 words is a
+   hard cap for the whole entry.** Cut to the cap by dropping investigation
+   detail, never by dropping the ground-truth anchor.
+3. **Keep exactly one ground-truth anchor** — a real filing plus the wrong value
+   beside the right one ("on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7
+   was cut off at 149,459 of its 158,411 characters"). If a long entry carries
+   several, keep the one that best shows who was affected.
+4. **Reference is `(GH #NNN)` and nothing else.** Strip commit hashes. Strip bead
+   IDs — `.beads/` is gitignored, so `(edgartools-sg9k)` points at something no
+   reader can open. If an entry cites only a bead ID, find the GitHub issue or
+   drop the reference; do not invent a number.
+5. **Keep attribution**: `(GH #NNN, thanks @kmatosli)`.
+6. **Disambiguate the import path** where a symbol name is not unique
+   (`edgar.xbrl.facts.FactQuery` vs `edgar.entity.query.FactQuery`).
+7. **Do not delete the long version — relocate it.** Before you cut an entry,
+   confirm the detail survives in the PR body, the commit message, or the
+   regression test docstring under `tests/issues/regression/`. If it exists
+   nowhere else, put it in the regression test docstring first.
+
+**Do not rewrite entries in already-released sections.** The standard applies
+from adoption forward; historical eras stay as filed.
+
+**Verify against the code, not against the changelog.** Before folding, execute
+the claims that carry numbers. The changelog is a compiled view and drifts —
+a figure transcribed from it has already been wrong once on this project.
+
+**Breaking-change check at fold time.** Every entry under `### Changed` or
+`### Removed` that alters observable behaviour must have a matching section in
+`docs/upgrade/<major>.md`. If one is missing, add it — old behaviour, new
+behaviour, and the mechanical rewrite where one exists — or report it as a
+release blocker.
 
 ## Decision Framework
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,81 @@ Cassettes are loaded as plain data — recorded requests, headers and response
 bodies only. `hatch run check-cassettes` verifies this and runs in CI ahead of
 the test jobs; run it locally if you are about to run a branch you did not write.
 
+## Changelog Entries
+
+`CHANGELOG.md` is read by someone deciding whether an upgrade affects them. An
+entry is the compiled short view of a change, not the record of the
+investigation behind it. New entries go under `## [Unreleased]`, in the
+`### Added` / `### Changed` / `### Fixed` / `### Performance` / `### Removed`
+section they belong to, and are folded into a dated version at release.
+
+**Symptom first, in a bold sentence-case lead that names the public symbol in
+backticks** — what a user saw go wrong, not what the code did. Then one to three
+sentences for the cause and the fix. Eighty words is the cap for the whole
+entry. An entry that will not fit is carrying material that belongs somewhere
+else.
+
+**Give it one ground-truth anchor.** Name a real filing and put the wrong value
+beside the right one — "on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7
+was cut off at 149,459 of its 158,411 characters". A number the reader can check
+against SEC is what separates an entry from a claim, and it is usually the same
+number the regression test asserts.
+
+**End with `(GH #NNN)`, and nothing else.** No commit hashes, and no bead IDs:
+`.beads/` is not in a clone, so an internal issue ID in a public file points at
+something no reader can open. Keep contributor attribution —
+`(GH #NNN, thanks @kmatosli)`.
+
+**Name the import path when the symbol is ambiguous.** `edgar.xbrl.facts.FactQuery`
+and `edgar.entity.query.FactQuery` are different classes with the same method
+names, so "`FactQuery.to_dataframe()` changed" sends a reader to the wrong one.
+
+**The long version is relocated, not deleted.** The regex that backtracked, the
+corpus of 1,940 tables, the three different messages pandas produced — that
+belongs in the PR body and the commit message, and in the docstring of the
+regression test under `tests/issues/regression/`. Someone debugging the same
+code finds it there; someone reading the changelog wants to know whether the bug
+reached them.
+
+**Write the entry from the code, not from your notes.** Run every claim before
+you write it down. The changelog is a compiled view and drifts from the source,
+so transcribing a figure out of it is how a wrong number ships.
+
+**A breaking change carries one more obligation.** The entry goes under
+`### Changed` or `### Removed`, and the same PR adds a section to
+`docs/upgrade/<next-major>.md` giving the behaviour before, the behaviour after,
+and the mechanical rewrite where one exists.
+
+### Calibration
+
+Before — the entry as filed in 5.44.1: 171 words, an accurate account of the
+investigation, abridged here:
+
+> **`filing["Item 7"]` hung indefinitely on some 10-Ks** — `CrossReferenceIndex.has_index()`
+> matched the cross-reference heading, then probed for the index table with a
+> single regex nesting six lazy quantifiers under `DOTALL` against the *entire*
+> filing HTML. Where the heading matched but the table shape did not, it
+> backtracked catastrophically: on ODP Corp's FY2025 10-K (5.6MB) the call did
+> not finish within 45 seconds. A successful match returned instantly, so only
+> the non-matching case was affected. It is reached from `TenK.__getitem__`, so
+> any item lookup on an affected 10-K hung — and because `re` holds the GIL
+> throughout, one such filing froze every other thread in the process […]
+> (GH #928)
+
+After — 75 words, the same change:
+
+> **`filing["Item 7"]` hung indefinitely on 10-Ks with a cross-reference heading
+> but no index table.** The detection probe was a regex nesting six lazy
+> quantifiers under `DOTALL` and ran against the entire filing HTML, so it
+> backtracked catastrophically. ODP Corp's FY2025 10-K (5.6MB) did not finish
+> within 45 seconds, and because `re` holds the GIL, one such filing froze every
+> other thread in the process. Detection now scans the index table row by row.
+> (GH #928)
+
+Nothing in the first version was wrong; all of it is still on record, in the PR
+and the regression test. The standard applies from adoption forward — existing
+entries are not rewritten.
+
 ## Documentation Structure
 
 EdgarTools uses a three-tier documentation system:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -185,6 +185,35 @@ Commit message prefixes:
 - `style:` - Code style changes
 - `chore:` - Maintenance tasks
 
+#### Changelog entries
+
+If your change is user-visible, add an entry to `## [Unreleased]` in
+`CHANGELOG.md`, under `### Added` / `### Changed` / `### Fixed` /
+`### Performance` / `### Removed`. An entry is the short view of a change, not
+the record of the investigation behind it:
+
+- **Symptom first**, in a bold sentence-case lead naming the public symbol in
+  backticks — what a user saw go wrong, not what the code did. Then one to three
+  sentences for the cause and the fix, 80 words for the whole entry.
+- **One ground-truth anchor.** Name a real filing and put the wrong value beside
+  the right one — "on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7 was
+  cut off at 149,459 of its 158,411 characters". Usually the same number your
+  regression test asserts.
+- **End with `(GH #NNN)`** and nothing else — no commit hashes, no internal
+  issue IDs. Attribution stays: `(GH #NNN, thanks @kmatosli)`.
+- **Name the import path when the symbol is ambiguous.**
+  `edgar.xbrl.facts.FactQuery` and `edgar.entity.query.FactQuery` are different
+  classes with the same method names.
+- **The long version goes in the PR body and the regression test docstring**,
+  not in the changelog. Nothing is lost; a reader deciding whether to upgrade
+  just isn't the audience for it.
+- **Write it from the code.** Run every claim before you write it down — the
+  changelog is a compiled view and drifts from the source.
+
+A breaking change also adds a section to `docs/upgrade/<next-major>.md` in the
+same PR: behaviour before, behaviour after, and the mechanical rewrite where one
+exists.
+
 ### 6. Push & Pull Request
 
 ```bash


### PR DESCRIPTION
`CHANGELOG.md` has three visible style eras — 5.20-5.21 title-case labels with commit hashes, 5.37-5.40 medium entries with bead IDs, 5.43+ forensic 150-250 word narratives — because entries are compiled from AI session context, so their length tracks the writing agent's context rather than what a reader needs.

This is `edgartools-07lk.18` deliverable (1). Deliverable (2), `docs/upgrade/6.0.md`, shipped in #973.

## The standard

- **Symptom first**, in a bold sentence-case lead naming the public symbol in backticks — what a user saw go wrong, not what the code did. One to three sentences after it. **80 words for the whole entry.**
- **One ground-truth anchor** — a real filing plus the wrong value beside the right one, usually the same number the regression test asserts.
- **`(GH #NNN)` as the only reference.** No commit hashes, and no bead IDs: `.beads/` is gitignored, so `(edgartools-sg9k)` in a public file points at something no reader can open. Contributor attribution stays.
- **Disambiguate the import path** where a symbol name is not unique — `edgar.xbrl.facts.FactQuery` and `edgar.entity.query.FactQuery` are different classes with the same method names.
- **A breaking change also adds a `docs/upgrade/<major>.md` section in the same PR** — behaviour before, behaviour after, mechanical rewrite where one exists.

The forensic narrative is **relocated, not deleted**: PR body, commit message, and the regression test docstring under `tests/issues/regression/`, where someone debugging the same code will find it.

## Calibration

The GH #928 entry, 171 words as filed, against the same change at 75 words. Nothing in the first version is wrong — it is written for a different reader.

## Where it is encoded

| File | Form |
|---|---|
| `CONTRIBUTING.md` | full prose section, next to the cassette policy |
| `docs/contributing.md` | condensed bulleted form, mirroring how the cassette policy is split across the two files |
| `.claude/agents/release-specialist.md` | fold-time mechanics — a 7-step rewrite applied when `[Unreleased]` folds, with a missing `docs/upgrade` section reported as a release blocker |

## Verification

Every factual claim in the standard was checked rather than asserted: `.beads/` is ignored at `.gitignore:14`; `tests/issues/regression/` and `docs/upgrade/6.0.md` both exist; the Ambac anchor (`0000874501-23-000040`, Item 7 cut to 149,459 of 158,411 characters) is the value already in the changelog; and both calibration examples were word-counted (171 and 75) rather than estimated. Docs only — no code paths touched.

Applies from adoption forward; historical entries are not rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)