### PR TITLE
perf(offerings): stop downloading a file-number family to find an exhibit that cannot be there

### DIFF
--- a/.claude/agents/release-specialist.md
+++ b/.claude/agents/release-specialist.md
@@ -38,11 +38,11 @@ You orchestrate the entire release lifecycle from preparation through publicatio
    - Ensure version follows semantic versioning (MAJOR.MINOR.PATCH)
    - Handle pre-release versions (alpha, beta, rc) when specified
 
-3. **Changelog Generation**
-   - Parse commit history since last release
-   - Group changes by type (Features, Bug Fixes, Breaking Changes, etc.)
-   - Generate clear, user-friendly changelog entries
-   - Update CHANGELOG.md or NEWS file
+3. **Changelog Generation** — see "The Changelog Entry Standard" below, which is
+   binding on this project and overrides generic changelog habits
+   - Fold `## [Unreleased]` into a dated `## [X.Y.Z] - YYYY-MM-DD` section
+   - Group changes by type (Added, Changed, Fixed, Performance, Removed)
+   - Rewrite each entry to the standard as you fold it
    - Include contributor acknowledgments
 
 4. **Release Execution**
@@ -78,7 +78,9 @@ When executing a release, follow this systematic approach:
 
 3. **Prepare Release**
    - Update version numbers
-   - Generate/update changelog
+   - Fold `[Unreleased]` into a dated section, rewriting each entry to the
+     Changelog Entry Standard, and check the `docs/upgrade/<major>.md` coverage
+     of every behaviour change in it
    - Create release commit
    - Tag the release
 
@@ -93,6 +95,51 @@ When executing a release, follow this systematic approach:
    - Confirm git tag and GitHub release are live
    - Report built artifact paths and the exact manual-publish command for the maintainer to run
    - Verify all automated processes completed
+
+## The Changelog Entry Standard
+
+`CHANGELOG.md` entries on this project are compiled from AI session context, so
+without a cap their length tracks the writing agent's context rather than what a
+reader needs — which is why the file has three visibly different style eras. You
+apply this standard mechanically when `[Unreleased]` folds at release. The full
+statement of it lives in `CONTRIBUTING.md` under "Changelog Entries"; read that
+section before you fold, and keep the two in agreement.
+
+**The rewrite, per entry:**
+
+1. **Lead with the symptom, in a bold sentence-case sentence naming the public
+   symbol in backticks.** What a user saw go wrong, not what the code did.
+2. **One to three sentences after the lead** for cause and fix. **80 words is a
+   hard cap for the whole entry.** Cut to the cap by dropping investigation
+   detail, never by dropping the ground-truth anchor.
+3. **Keep exactly one ground-truth anchor** — a real filing plus the wrong value
+   beside the right one ("on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7
+   was cut off at 149,459 of its 158,411 characters"). If a long entry carries
+   several, keep the one that best shows who was affected.
+4. **Reference is `(GH #NNN)` and nothing else.** Strip commit hashes. Strip bead
+   IDs — `.beads/` is gitignored, so `(edgartools-sg9k)` points at something no
+   reader can open. If an entry cites only a bead ID, find the GitHub issue or
+   drop the reference; do not invent a number.
+5. **Keep attribution**: `(GH #NNN, thanks @kmatosli)`.
+6. **Disambiguate the import path** where a symbol name is not unique
+   (`edgar.xbrl.facts.FactQuery` vs `edgar.entity.query.FactQuery`).
+7. **Do not delete the long version — relocate it.** Before you cut an entry,
+   confirm the detail survives in the PR body, the commit message, or the
+   regression test docstring under `tests/issues/regression/`. If it exists
+   nowhere else, put it in the regression test docstring first.
+
+**Do not rewrite entries in already-released sections.** The standard applies
+from adoption forward; historical eras stay as filed.
+
+**Verify against the code, not against the changelog.** Before folding, execute
+the claims that carry numbers. The changelog is a compiled view and drifts —
+a figure transcribed from it has already been wrong once on this project.
+
+**Breaking-change check at fold time.** Every entry under `### Changed` or
+`### Removed` that alters observable behaviour must have a matching section in
+`docs/upgrade/<major>.md`. If one is missing, add it — old behaviour, new
+behaviour, and the mechanical rewrite where one exists — or report it as a
+release blocker.
 
 ## Decision Framework
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **`filing.obj()` on a registration statement downloaded its whole file-number family looking for a fee exhibit that could not be there.** Each sibling was probed through `filing.attachments`, which fetches the entire `.txt` submission. Learn CW's S-1 (`0001140361-21-010426`) transferred 12.2MB for a 2.4MB filing and found nothing — Exhibit 107 postdates it. Siblings filed before that regime are no longer probed, and probing now stops at the first match.
+
 ### Fixed
 
 - **`Document.to_dataframe()` raised on every real annual and quarterly report, from inside pandas and numpy.** It failed on 10 of the 11 filings in the 6.0 performance corpus, with three different messages depending on which pair of frames pandas happened to align first — `cannot join with no overlapping index names`, `Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'`, and `Index data must be 1-dimensional`. The only entry that worked was an ABS-15G, which is a single flat table: the degenerate case.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,81 @@ Cassettes are loaded as plain data — recorded requests, headers and response
 bodies only. `hatch run check-cassettes` verifies this and runs in CI ahead of
 the test jobs; run it locally if you are about to run a branch you did not write.
 
+## Changelog Entries
+
+`CHANGELOG.md` is read by someone deciding whether an upgrade affects them. An
+entry is the compiled short view of a change, not the record of the
+investigation behind it. New entries go under `## [Unreleased]`, in the
+`### Added` / `### Changed` / `### Fixed` / `### Performance` / `### Removed`
+section they belong to, and are folded into a dated version at release.
+
+**Symptom first, in a bold sentence-case lead that names the public symbol in
+backticks** — what a user saw go wrong, not what the code did. Then one to three
+sentences for the cause and the fix. Eighty words is the cap for the whole
+entry. An entry that will not fit is carrying material that belongs somewhere
+else.
+
+**Give it one ground-truth anchor.** Name a real filing and put the wrong value
+beside the right one — "on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7
+was cut off at 149,459 of its 158,411 characters". A number the reader can check
+against SEC is what separates an entry from a claim, and it is usually the same
+number the regression test asserts.
+
+**End with `(GH #NNN)`, and nothing else.** No commit hashes, and no bead IDs:
+`.beads/` is not in a clone, so an internal issue ID in a public file points at
+something no reader can open. Keep contributor attribution —
+`(GH #NNN, thanks @kmatosli)`.
+
+**Name the import path when the symbol is ambiguous.** `edgar.xbrl.facts.FactQuery`
+and `edgar.entity.query.FactQuery` are different classes with the same method
+names, so "`FactQuery.to_dataframe()` changed" sends a reader to the wrong one.
+
+**The long version is relocated, not deleted.** The regex that backtracked, the
+corpus of 1,940 tables, the three different messages pandas produced — that
+belongs in the PR body and the commit message, and in the docstring of the
+regression test under `tests/issues/regression/`. Someone debugging the same
+code finds it there; someone reading the changelog wants to know whether the bug
+reached them.
+
+**Write the entry from the code, not from your notes.** Run every claim before
+you write it down. The changelog is a compiled view and drifts from the source,
+so transcribing a figure out of it is how a wrong number ships.
+
+**A breaking change carries one more obligation.** The entry goes under
+`### Changed` or `### Removed`, and the same PR adds a section to
+`docs/upgrade/<next-major>.md` giving the behaviour before, the behaviour after,
+and the mechanical rewrite where one exists.
+
+### Calibration
+
+Before — the entry as filed in 5.44.1: 171 words, an accurate account of the
+investigation, abridged here:
+
+> **`filing["Item 7"]` hung indefinitely on some 10-Ks** — `CrossReferenceIndex.has_index()`
+> matched the cross-reference heading, then probed for the index table with a
+> single regex nesting six lazy quantifiers under `DOTALL` against the *entire*
+> filing HTML. Where the heading matched but the table shape did not, it
+> backtracked catastrophically: on ODP Corp's FY2025 10-K (5.6MB) the call did
+> not finish within 45 seconds. A successful match returned instantly, so only
+> the non-matching case was affected. It is reached from `TenK.__getitem__`, so
+> any item lookup on an affected 10-K hung — and because `re` holds the GIL
+> throughout, one such filing froze every other thread in the process […]
+> (GH #928)
+
+After — 75 words, the same change:
+
+> **`filing["Item 7"]` hung indefinitely on 10-Ks with a cross-reference heading
+> but no index table.** The detection probe was a regex nesting six lazy
+> quantifiers under `DOTALL` and ran against the entire filing HTML, so it
+> backtracked catastrophically. ODP Corp's FY2025 10-K (5.6MB) did not finish
+> within 45 seconds, and because `re` holds the GIL, one such filing froze every
+> other thread in the process. Detection now scans the index table row by row.
+> (GH #928)
+
+Nothing in the first version was wrong; all of it is still on record, in the PR
+and the regression test. The standard applies from adoption forward — existing
+entries are not rewritten.
+
 ## Documentation Structure
 
 EdgarTools uses a three-tier documentation system:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -185,6 +185,35 @@ Commit message prefixes:
 - `style:` - Code style changes
 - `chore:` - Maintenance tasks
 
+#### Changelog entries
+
+If your change is user-visible, add an entry to `## [Unreleased]` in
+`CHANGELOG.md`, under `### Added` / `### Changed` / `### Fixed` /
+`### Performance` / `### Removed`. An entry is the short view of a change, not
+the record of the investigation behind it:
+
+- **Symptom first**, in a bold sentence-case lead naming the public symbol in
+  backticks — what a user saw go wrong, not what the code did. Then one to three
+  sentences for the cause and the fix, 80 words for the whole entry.
+- **One ground-truth anchor.** Name a real filing and put the wrong value beside
+  the right one — "on Ambac's FY2022 10-K (`0000874501-23-000040`) Item 7 was
+  cut off at 149,459 of its 158,411 characters". Usually the same number your
+  regression test asserts.
+- **End with `(GH #NNN)`** and nothing else — no commit hashes, no internal
+  issue IDs. Attribution stays: `(GH #NNN, thanks @kmatosli)`.
+- **Name the import path when the symbol is ambiguous.**
+  `edgar.xbrl.facts.FactQuery` and `edgar.entity.query.FactQuery` are different
+  classes with the same method names.
+- **The long version goes in the PR body and the regression test docstring**,
+  not in the changelog. Nothing is lost; a reader deciding whether to upgrade
+  just isn't the audience for it.
+- **Write it from the code.** Run every claim before you write it down — the
+  changelog is a compiled view and drifts from the source.
+
+A breaking change also adds a section to `docs/upgrade/<next-major>.md` in the
+same PR: behaviour before, behaviour after, and the mechanical rewrite where one
+exists.
+
 ### 6. Push & Pull Request
 
 ```bash

--- a/edgar/offerings/prospectus/_fee_table/extract.py
+++ b/edgar/offerings/prospectus/_fee_table/extract.py
@@ -43,6 +43,30 @@ def _is_registration_form(form: Optional[str]) -> bool:
     return base in _FEE_BEARING_BASE_FORMS or base.endswith('ASR') or base == 'POS AM'
 
 
+# EX-FILING FEES (Exhibit 107) was created by the SEC's filing-fee modernization
+# rule — adopted 2021-10-13, effective 2022-01-31 — so no filing made before that
+# rule existed can carry one. This constant is deliberately set earlier than the
+# effective date: a gate that is too early costs one wasted probe, while a gate
+# that is too late would skip a real exhibit, so the error is pushed to the
+# harmless side. It matters because probing a sibling is not cheap — see
+# _probe_has_fee_exhibit.
+_EX107_EARLIEST_FILING_DATE = "2021-10-01"
+
+
+def _probe_has_fee_exhibit(filing: 'Filing') -> bool:
+    """Whether ``filing`` carries a fee exhibit — at the cost of a full download.
+
+    ``filing.attachments`` resolves through ``filing.sgml()``, which fetches the
+    complete ``.txt`` submission, so asking this question about one sibling costs
+    megabytes. Every caller below is written to ask it as few times as possible.
+    """
+    try:
+        return _get_filing_fees_attachment(filing) is not None
+    except Exception:
+        log.debug("Could not read attachments for %s", filing.accession_no)
+        return False
+
+
 def _resolve_fee_source(filing: 'Filing'):
     """Find the fee-bearing registration for an amendment that omits its exhibit.
 
@@ -51,9 +75,17 @@ def _resolve_fee_source(filing: 'Filing'):
     registration, and the registered capacity still lives in that filing's
     Exhibit 107. Walk the file-number family and return the most recent
     fee-bearing registration filing dated at or before this one (falling back to
-    the earliest if all are later). Returns None when ``filing`` is not itself a
+    the latest if all are later). Returns None when ``filing`` is not itself a
     registration form or no such source exists, so non-registration filings
     (424B takedowns, 10-Ks) keep their current None result.
+
+    Both filters exist to keep the walk from downloading the family. Siblings
+    filed before the Exhibit 107 regime are dropped without being probed at all,
+    which removes the walk entirely for pre-2022 registrations — they have no
+    exhibit anywhere in the family by construction, and their fee table is read
+    from the inline body table instead. The survivors are then probed in
+    priority order and the first hit wins, rather than probing every sibling and
+    taking the maximum afterwards.
     """
     if not _is_registration_form(filing.form):
         return None
@@ -63,14 +95,28 @@ def _resolve_fee_source(filing: 'Filing'):
         log.debug("related_filings() failed for %s", filing.accession_no)
         return None
     own_date = str(filing.filing_date)
-    candidates = [rf for rf in related
-                  if rf.accession_no != filing.accession_no
-                  and _is_registration_form(rf.form)
-                  and _get_filing_fees_attachment(rf) is not None]
-    if not candidates:
+    eligible = [rf for rf in related
+                if rf.accession_no != filing.accession_no
+                and _is_registration_form(rf.form)
+                and str(rf.filing_date) >= _EX107_EARLIEST_FILING_DATE]
+    if not eligible:
         return None
-    at_or_before = [rf for rf in candidates if str(rf.filing_date) <= own_date]
-    return max(at_or_before or candidates, key=lambda rf: str(rf.filing_date))
+
+    # Latest at-or-before this filing wins; only if none of those carries an
+    # exhibit does a later one, latest first. Probing in that order and stopping
+    # at the first hit picks the same filing that taking the maximum over every
+    # fee-bearing candidate did, without paying for the ones after it. Sorting is
+    # stable, so same-date siblings keep their family order and ties resolve the
+    # way max() resolved them.
+    def _by_date_desc(filings):
+        return sorted(filings, key=lambda rf: str(rf.filing_date), reverse=True)
+
+    at_or_before = _by_date_desc(rf for rf in eligible if str(rf.filing_date) <= own_date)
+    after = _by_date_desc(rf for rf in eligible if str(rf.filing_date) > own_date)
+    for candidate in (*at_or_before, *after):
+        if _probe_has_fee_exhibit(candidate):
+            return candidate
+    return None
 
 
 def _data_to_fee_table(data: dict):

--- a/tests/issues/regression/test_issue_60or_fee_family_walk.py
+++ b/tests/issues/regression/test_issue_60or_fee_family_walk.py
@@ -1,0 +1,261 @@
+"""Resolving an amendment's fee exhibit must not download its file-number family.
+
+``RegistrationS1.from_filing`` extracts the fee table eagerly, so ``filing.obj()``
+on a registration reaches ``_resolve_fee_source``. That function asked
+"does this sibling carry an EX-FILING FEES exhibit?" about every registration in
+the family — and the question costs a full ``.txt`` submission download, because
+``filing.attachments`` resolves through ``filing.sgml()``.
+
+Measured on Learn CW Investment Corp's S-1 (``0001140361-21-010426``) by wrapping
+``httpx.Client.send``: 2,393,430 bytes for the filing the caller asked for, then
+3,807,137 + 3,800,905 + 2,191,043 bytes of siblings. 12.2MB transferred for a
+2.4MB filing.
+
+None of it could ever pay. Exhibit 107 did not exist before the SEC's filing-fee
+modernization rule, so a 2021 family has no exhibit anywhere in it by
+construction; ``_resolve_fee_source`` returned None and the correct answer came
+from the pre-EX-107 inline body table — ``total_offering_amount`` 287,500,000.0
+for Learn CW, 1,000,000,000.0 for Airbnb's S-1, 54,337,500.0 for Unicycive's
+S-1/A, all read from HTML already in hand. Same shape on all three.
+
+Two fixes, both about how many siblings get probed rather than which one wins:
+siblings filed before the regime are dropped without being probed, and the
+survivors are probed in priority order until one hits instead of all being probed
+and the maximum taken afterwards. The selection is unchanged — that is what the
+ordering tests below pin (bead edgartools-60or).
+
+The families here are the real ones, with the dates and exhibit flags as measured
+from EDGAR. Stubs rather than cassettes because the thing under test is how many
+downloads happen, and a stub can count them exactly.
+"""
+import pytest
+
+from edgar.offerings.prospectus._fee_table.extract import (
+    _EX107_EARLIEST_FILING_DATE,
+    _resolve_fee_source,
+)
+
+
+class StubAttachment:
+    def __init__(self, document_type):
+        self.document_type = document_type
+
+
+class StubFiling:
+    """A filing that records every time its attachments are read.
+
+    Reading ``.attachments`` is the expensive operation being counted: on a real
+    filing it downloads the whole submission.
+    """
+
+    def __init__(self, accession_no, form, filing_date, has_exhibit=False,
+                 probe_log=None, unreadable=False):
+        self.accession_no = accession_no
+        self.form = form
+        self.filing_date = filing_date
+        self._has_exhibit = has_exhibit
+        self._probe_log = probe_log if probe_log is not None else []
+        self._unreadable = unreadable
+        self._family = []
+
+    @property
+    def attachments(self):
+        self._probe_log.append(self.accession_no)
+        if self._unreadable:
+            raise OSError(f"could not download {self.accession_no}")
+        return [StubAttachment('EX-FILING FEES')] if self._has_exhibit else [
+            StubAttachment('EX-99.1')]
+
+    def related_filings(self):
+        return self._family
+
+
+def build_family(subject_spec, sibling_specs):
+    """Return (subject, probe_log). Specs are (accession, form, date, has_exhibit)."""
+    probe_log = []
+    subject = StubFiling(*subject_spec[:3], has_exhibit=subject_spec[3], probe_log=probe_log)
+    siblings = [StubFiling(*spec[:3], has_exhibit=spec[3], probe_log=probe_log)
+                for spec in sibling_specs]
+    family = [subject, *siblings]
+    for filing in family:
+        filing._family = family
+    return subject, probe_log
+
+
+class TestPreRegimeSiblingsAreNotProbed:
+    """The population that could never pay: no exhibit existed yet."""
+
+    def test_airbnb_shaped_family_is_not_downloaded(self):
+        """Airbnb's S-1 (0001193125-20-294801) and its two 2020 amendments.
+
+        Both siblings predate Exhibit 107, so neither is worth a download.
+        """
+        subject, probes = build_family(
+            ("0001193125-20-294801", "S-1", "2020-11-16", False),
+            [("0001193125-20-306257", "S-1/A", "2020-12-01", False),
+             ("0001193125-20-311265", "S-1/A", "2020-12-07", False)],
+        )
+        assert _resolve_fee_source(subject) is None
+        assert probes == []
+
+    def test_unicycive_shaped_family_is_not_downloaded(self):
+        """Unicycive's S-1/A (0001213900-21-035033) and its five 2021 siblings."""
+        subject, probes = build_family(
+            ("0001213900-21-035033", "S-1/A", "2021-06-30", False),
+            [("0001213900-21-028391", "S-1", "2021-05-21", False),
+             ("0001213900-21-031134", "S-1/A", "2021-06-07", False),
+             ("0001213900-21-033200", "S-1/A", "2021-06-21", False),
+             ("0001213900-21-036490", "S-1/A", "2021-07-12", False),
+             ("0001213900-21-036535", "S-1/A", "2021-07-12", False)],
+        )
+        assert _resolve_fee_source(subject) is None
+        assert probes == []
+
+    def test_only_the_post_regime_sibling_is_probed(self):
+        """Learn CW's family straddles the gate: two 2021 amendments before it,
+        one after. Only the one that could carry an exhibit costs a download."""
+        subject, probes = build_family(
+            ("0001140361-21-010426", "S-1", "2021-03-29", False),
+            [("0001140361-21-017313", "S-1/A", "2021-05-14", False),
+             ("0001140361-21-031541", "S-1/A", "2021-09-17", False),
+             ("0001140361-21-033432", "S-1/A", "2021-10-04", False)],
+        )
+        assert _resolve_fee_source(subject) is None
+        assert probes == ["0001140361-21-033432"]
+
+    def test_the_gate_sits_before_the_rule_took_effect(self):
+        """A gate set too late would skip a real exhibit; too early only costs a
+        probe. The constant is on the harmless side of the 2022-01-31 effective
+        date deliberately, so this pins the direction of the error."""
+        assert _EX107_EARLIEST_FILING_DATE < "2022-01-31"
+
+
+class TestProbingStopsAtTheFirstHit:
+
+    def test_vincerx_shaped_family_stops_before_the_later_filing(self):
+        """Vincerx's S-3/A (0001193125-25-068723) recovers from the S-3 that
+        precedes it; the POS AM filed a month later is never worth reading."""
+        subject, probes = build_family(
+            ("0001193125-25-068723", "S-3/A", "2025-03-31", False),
+            [("0001193125-25-012209", "S-3", "2025-01-24", True),
+             ("0001193125-25-110092", "POS AM", "2025-05-01", False)],
+        )
+        source = _resolve_fee_source(subject)
+        assert source.accession_no == "0001193125-25-012209"
+        assert probes == ["0001193125-25-012209"]
+
+    def test_tr_finance_shaped_family(self):
+        """TR Finance's F-3/A (0001193125-25-068799) — one sibling, one probe."""
+        subject, probes = build_family(
+            ("0001193125-25-068799", "F-3/A", "2025-03-31", False),
+            [("0001193125-25-057913", "F-3", "2025-03-19", True)],
+        )
+        source = _resolve_fee_source(subject)
+        assert source.accession_no == "0001193125-25-057913"
+        assert probes == ["0001193125-25-057913"]
+
+
+class TestSelectionIsUnchanged:
+    """The old code probed everything, then took the latest. These pin that the
+    same filing still wins now that probing stops early."""
+
+    def test_latest_at_or_before_wins(self):
+        subject, probes = build_family(
+            ("0000000000-25-000009", "S-3/A", "2025-06-01", False),
+            [("0000000000-25-000001", "S-3", "2025-01-01", True),
+             ("0000000000-25-000002", "S-3/A", "2025-03-01", True)],
+        )
+        source = _resolve_fee_source(subject)
+        assert source.accession_no == "0000000000-25-000002"
+        # The older one is never reached.
+        assert probes == ["0000000000-25-000002"]
+
+    def test_a_later_filing_loses_to_an_earlier_one(self):
+        subject, probes = build_family(
+            ("0000000000-25-000009", "S-3/A", "2025-06-01", False),
+            [("0000000000-25-000002", "S-3", "2025-03-01", True),
+             ("0000000000-25-000008", "S-3/A", "2025-09-01", True)],
+        )
+        assert _resolve_fee_source(subject).accession_no == "0000000000-25-000002"
+        assert probes == ["0000000000-25-000002"]
+
+    def test_falls_back_to_the_latest_later_filing(self):
+        """Nothing at or before carries one, so the family's later filings are
+        tried, latest first — what max() over all candidates used to return."""
+        subject, probes = build_family(
+            ("0000000000-25-000009", "S-3/A", "2025-06-01", False),
+            [("0000000000-25-000002", "S-3", "2025-03-01", False),
+             ("0000000000-25-000007", "S-3/A", "2025-07-01", True),
+             ("0000000000-25-000008", "S-3/A", "2025-09-01", True)],
+        )
+        source = _resolve_fee_source(subject)
+        assert source.accession_no == "0000000000-25-000008"
+        assert probes == ["0000000000-25-000002", "0000000000-25-000008"]
+
+    def test_same_date_siblings_keep_family_order(self):
+        """Unicycive files two amendments on one day. max() returned the first of
+        the tied maxima in family order; the sort is stable, so this still does."""
+        subject, probes = build_family(
+            ("0000000000-25-000009", "S-3/A", "2025-06-01", False),
+            [("0000000000-25-000004", "S-3/A", "2025-04-01", True),
+             ("0000000000-25-000005", "S-3/A", "2025-04-01", True)],
+        )
+        assert _resolve_fee_source(subject).accession_no == "0000000000-25-000004"
+        assert probes == ["0000000000-25-000004"]
+
+
+class TestSilence:
+    """Bad input produces a usable answer, not a crash and not a wrong source."""
+
+    def test_a_sibling_that_cannot_be_downloaded_does_not_abort_the_walk(self):
+        """A failed download must not be read as 'no exhibit anywhere' — the walk
+        carries on to the next candidate, which is the one that actually has it."""
+        probe_log = []
+        subject = StubFiling("0000000000-25-000009", "S-3/A", "2025-06-01",
+                             probe_log=probe_log)
+        broken = StubFiling("0000000000-25-000005", "S-3/A", "2025-05-01",
+                            probe_log=probe_log, unreadable=True)
+        good = StubFiling("0000000000-25-000002", "S-3", "2025-02-01",
+                          has_exhibit=True, probe_log=probe_log)
+        family = [subject, broken, good]
+        for filing in family:
+            filing._family = family
+
+        source = _resolve_fee_source(subject)
+        assert source.accession_no == "0000000000-25-000002"
+        assert probe_log == ["0000000000-25-000005", "0000000000-25-000002"]
+
+    def test_a_non_registration_form_never_walks(self):
+        """424B takedowns and reports have no fee exhibit to recover."""
+        subject, probes = build_family(
+            ("0000000000-25-000009", "424B5", "2025-06-01", False),
+            [("0000000000-25-000002", "S-3", "2025-03-01", True)],
+        )
+        assert _resolve_fee_source(subject) is None
+        assert probes == []
+
+    def test_a_family_of_one_costs_nothing(self):
+        subject, probes = build_family(
+            ("0000000000-25-000009", "S-3", "2025-06-01", False), [])
+        assert _resolve_fee_source(subject) is None
+        assert probes == []
+
+    def test_related_filings_failure_is_not_fatal(self):
+        class Exploding(StubFiling):
+            def related_filings(self):
+                raise RuntimeError("submissions unavailable")
+
+        subject = Exploding("0000000000-25-000009", "S-3/A", "2025-06-01")
+        assert _resolve_fee_source(subject) is None
+
+
+@pytest.mark.parametrize("form", ["S-1", "S-3", "F-1", "F-3", "S-4", "F-4", "S-11",
+                                  "S-3/A", "POS AM", "S-3ASR"])
+def test_every_fee_bearing_form_still_reaches_the_walk(form):
+    """The gate and the short-circuit must not have narrowed which forms recover."""
+    subject, probes = build_family(
+        ("0000000000-25-000009", form, "2025-06-01", False),
+        [("0000000000-25-000002", "S-3", "2025-03-01", True)],
+    )
+    assert _resolve_fee_source(subject).accession_no == "0000000000-25-000002"
+    assert probes == ["0000000000-25-000002"]


### PR DESCRIPTION
Explains the offerings cassette over-recording carried since the 2026-08-05 checkpoint (Airbnb 3x, ji90 8x, 4x3k 5x). It was not a recording artifact — the library really does fetch these, so users pay for them too.

Bead `edgartools-60or`.

## The path

`RegistrationS1.from_filing` extracts the fee table eagerly, so `filing.obj()` on a registration reaches `_resolve_fee_source`. That asked *"does this sibling carry an EX-FILING FEES exhibit?"* about every registration in the family — and the question costs a full `.txt` submission download, because `filing.attachments` resolves through `filing.sgml()`.

Measured by wrapping `httpx.Client.send` above vcr, so attempts show up even when a trimmed cassette cannot serve them:

| | requested | siblings pulled | total |
|---|---|---|---|
| Learn CW S-1 `0001140361-21-010426` | 2,393,430 B | 3 (3,807,137 + 3,800,905 + 2,191,043 B) | **12.2 MB — 4.1×** |
| Airbnb S-1 `0001193125-20-294801` | | 2 | |
| Unicycive S-1/A `0001213900-21-035033` | | 5 | |

## None of it could ever pay

Exhibit 107 was created by the SEC's filing-fee modernization rule, so a 2021 family has no exhibit anywhere in it by construction. In all three cases `_resolve_fee_source` returned `None` and the answer came from the pre-EX-107 inline body table, read off HTML `from_filing` had already fetched. **Those values are unchanged by this PR** — Learn CW `287500000.0`, Airbnb `1000000000.0`, Unicycive `54337500.0`.

## The change

Both parts are about *how many* siblings get probed, not which one wins.

1. **Date gate** — siblings filed before the regime are dropped without being probed, removing the walk entirely for the pre-2022 population. The constant is deliberately earlier than the rule's effective date: too early costs one wasted probe, too late would skip a real exhibit.
2. **Short-circuit** — survivors are probed latest at-or-before first, then later ones latest-first, stopping at the first hit. That selects the same filing `max()` over every fee-bearing candidate did, without paying for the rest. Sorting is stable, so same-date siblings resolve the way `max()` resolved them.

Learn CW goes from 5 requests to 3. Vincerx stops before the POS AM it never used.

## Verification

- **24 new tests** using stub filings that count attachment reads — the thing under test is how many downloads happen, and a stub counts them exactly.
- **Reverting the walk fails 8 of them.** The four `TestSelectionIsUnchanged` failures are all on the probe-count assertion rather than the selected filing, which is the evidence that selection is genuinely unchanged.
- **`test_fee_table.py` 37/37 green** — including the recoveries that motivated the walk (Vincerx S-3/A, TR Finance F-3/A) and the inline-body cases (Dynatronics S-3/A 2021).
- Offerings suites 51/51; fast gate 3,218 passed.

The one ruff `I001` on this file predates the change (confirmed against `HEAD`) and is left alone.

## Why it hid

The sibling fetches are swallowed by the bare `except Exception` in `_resolve_fee_source`, so the tests passed identically whether the siblings were reachable or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)