### PR TITLE
test: give the hatch test env the plugin that replays its cassettes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,11 +260,30 @@ test-reproduction = "pytest tests/issues/reproductions/ -m 'reproduction' {args}
 test-full = "pytest --ignore=tests/perf {args}"
 
 [tool.hatch.envs.test]
+# Keep this list in step with what CI installs (see the pip install lines in
+# .github/workflows/python-hatch-workflow.yml) and with the default env's pins.
+# A plugin missing here does not fail — it changes what the tests mean. Without
+# pytest-vcr and vcrpy, `@pytest.mark.vcr` is an unregistered marker, no cassette
+# is opened, and the request goes to the network or the local HTTP cache while
+# the run still reports passed. That is the "a cassette existing is not replay"
+# failure one level further down: the cassette can be right and the runner still
+# never open it.
 dependencies = [
   "pytest",
   "pytest-cov",
   "pytest-env",
-  "pytest-asyncio"
+  "pytest-xdist",
+  "pytest-asyncio",
+  "pytest-retry",
+  "pytest-mock",
+  "pytest-vcr",
+  # Pin <8.2 for the same reason as the default env: vcrpy 8.2.0's httpx stub
+  # crashes deserializing a cassette with a null reason phrase.
+  "vcrpy<8.2",
+  "filelock",
+  "tqdm",
+  "responses",
+  "freezegun==1.5.1"
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,36 @@ def pytest_addoption(parser):
     parser.addoption("--enable-cache", action="store_true", help="Enable HTTP cache")
 
 
+def _require_vcr_plugin_if_cassettes_are_used(config, items):
+    """Fail loudly when cassette-backed tests run without the plugin that replays them.
+
+    The ``vcr`` marker is registered in pyproject, so an environment with no
+    pytest-vcr installed does not warn about an unknown marker — it silently
+    ignores the marker, opens no cassette, and lets the request go to the network
+    or the local HTTP cache. The run still reports passed, which makes it worse
+    than a failure: the suite looks like it verified against recorded responses
+    while verifying against whatever the machine happened to have.
+
+    That is what the hatch ``test`` matrix env did until its dependency list was
+    brought in step with CI (bead edgartools-ov2m). This hook is the guard, not
+    the fix — it turns a silent downgrade into a collection error the next time
+    the two lists drift apart.
+    """
+    if not any(item.get_closest_marker("vcr") for item in items):
+        return
+    # pytest-vcr registers under the short name "vcr"; the module name is checked
+    # too so that disabling it explicitly (-p no:vcr) is caught the same way.
+    if any(config.pluginmanager.hasplugin(name) for name in ("vcr", "pytest_vcr")):
+        return
+    raise pytest.UsageError(
+        "Tests marked @pytest.mark.vcr were collected, but pytest-vcr is not "
+        "installed in this environment, so no cassette would be replayed and the "
+        "tests would reach the network while still reporting passed. Install "
+        "pytest-vcr and vcrpy<8.2 (see [tool.hatch.envs.test] in pyproject.toml), "
+        "or deselect the cassette-backed tests."
+    )
+
+
 def pytest_configure(config):
     """
     - Disables caching for testing
@@ -211,7 +241,7 @@ def pytest_runtest_call(item):
             pytest.skip(f"SEC returned transient empty response: {exc_value}")
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(config, items):
     """
     Automatically add markers to tests based on file patterns.
 
@@ -222,6 +252,8 @@ def pytest_collection_modifyitems(items):
 
     Only adds markers to tests that don't already have fast/network/slow markers.
     """
+    _require_vcr_plugin_if_cassettes_are_used(config, items)
+
     # Files that are definitely fast (no network calls - parsing, processing, rendering)
     FAST_PATTERNS = [
         'test_html', 'test_documents', 'test_xbrl', 'test_tables', 'test_table',


### PR DESCRIPTION
`[tool.hatch.envs.test]` declared `pytest`, `pytest-cov`, `pytest-env` and `pytest-asyncio` — no `pytest-vcr` and no `vcrpy`. Those live only in the default env.

A cassette-backed test run through the matrix env therefore lost replay **silently**: the `vcr` marker is registered in pyproject, so nothing warned about an unknown marker, no cassette was opened, and the request went to the network or the local HTTP cache while the run still reported passed.

Bead `edgartools-ov2m`. Found while investigating `edgartools-60or`, where it briefly fooled me into thinking a test replayed when it hadn't.

## The demonstration

Same test, same machine, before this change:

```
hatch run test.py312:python -m pytest -p tests._offline_harness <the 4x3k vcr test>
-> NetworkBlockedError

hatch run test-offline-audit <the same test>
-> 1 passed in 0.90s
```

The socket block is what exposed it. Run without the harness, the matrix env reported the test passing in 1.45s while never touching its cassette — which is how this survived unnoticed.

## CI is not affected

The workflow pip-installs `pytest-vcr` and `vcrpy<8.2` directly in all three test jobs rather than going through the hatch test env. This was a local-developer footgun — but it defeats the "a cassette existing is not replay" rule one level further down: the cassette can be correct and the runner still never open it.

## The change

**The env list** is now in step with what CI installs, pins included, and carries a comment saying so. Added: `pytest-xdist`, `pytest-retry`, `pytest-mock`, `pytest-vcr`, `vcrpy<8.2`, `filelock`, `tqdm`, `responses`, `freezegun==1.5.1`.

**The guard**, because two hand-maintained lists will drift again. Collection now fails with a usable message when tests marked `vcr` are collected and the plugin is absent. Verified in three directions:

| | result |
|---|---|
| default env (has the plugin) | passes — 6 passed |
| rebuilt matrix env | passes — 6 passed |
| `-p no:vcr` | errors with the message — the exact regression it guards |

Fast gate unchanged at 3,218 passed. No CHANGELOG entry: this is test infrastructure, not user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)