### PR TITLE
Two guardrails that failed on suite load instead of on defects

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,6 +298,7 @@ def pytest_collection_modifyitems(config, items):
         'test_prospectus_section_flip_gate', 'test_prospectus_sections_surface',
         's1_section_flip_gate', 'test_def14a_section_flip_gate',
         'test_frontier', 'test_tier_c_judge', 'test_424b_xbrl',
+        'test_unavailable_partition',
         'test_offering_consumers', 'test_correspondence',
         'test_fix_438',
     ]

--- a/tests/issues/regression/test_issue_wbwn_table_matrix_quadratic.py
+++ b/tests/issues/regression/test_issue_wbwn_table_matrix_quadratic.py
@@ -53,6 +53,38 @@ class CountingList(list):
         return super().__len__()
 
 
+class CountingMatrix(TableMatrix):
+    """A TableMatrix whose grid counts every inspection, through a real build.
+
+    ``build_from_rows`` reassigns ``self.matrix``, so instrumenting the list
+    beforehand does not survive. Routing the attribute through a property keeps
+    the instrument attached across the reassignment, which is what lets the
+    scaling test measure the production code path rather than a stand-in.
+    """
+
+    @property
+    def matrix(self):
+        return self._matrix
+
+    @matrix.setter
+    def matrix(self, value):
+        self._matrix = CountingList(value)
+
+
+def count_grid_inspections(row_count: int) -> int:
+    """Times the grid is consulted while building ``row_count`` rows.
+
+    This is the cost the defect ran up: ``_is_occupied`` reads ``len(self.matrix)``
+    once per iteration of its scan, and the scan is what the short-circuit
+    removes. ``_place_cells`` indexes the grid directly and never asks its
+    length, so the number here is attributable to the occupancy pass alone.
+    """
+    rows = build_rows(row_count)
+    CountingList.len_calls = 0
+    CountingMatrix().build_from_rows([], rows)
+    return CountingList.len_calls
+
+
 class TestDimensionPassDoesNotConsultAnUnbuiltGrid:
     """The specific defect: occupancy was queried before the grid existed."""
 
@@ -113,23 +145,42 @@ class TestLargeTablesBuildInLinearTime:
         assert matrix.col_count == COLUMNS
 
     def test_scaling_is_not_quadratic(self):
-        """Quadratic growth quadruples per doubling; linear roughly doubles."""
+        """4x the rows must cost ~4x the grid inspections, not ~16x.
 
-        def build_seconds(row_count: int) -> float:
-            rows = build_rows(row_count)
-            start = time.perf_counter()
-            TableMatrix().build_from_rows([], rows)
-            return time.perf_counter() - start
+        Counted, not timed. This assertion used to compare wall clock against a
+        ~41ms baseline, and under full-suite load it failed at 9.1x
+        (0.041s -> 0.373s) while the code was perfectly linear — the quadratic
+        guard tripping on GC and scheduler noise rather than on the defect, three
+        attempts deep, because a 41ms baseline cannot support a ratio assertion
+        (bead edgartools-kzdr). Counting removes the runner from the measurement:
+        the numbers below are identical on an idle box and a saturated one.
 
-        baseline = build_seconds(1000)
-        quadrupled = build_seconds(4000)
+        The counts tie back to the original profile of accession
+        0000310522-18-000010, which recorded 95,976 ``_is_occupied`` calls at
+        4,000 rows driving 192,527,603 ``len`` calls. Fixed, those 95,976 calls
+        do one length check each instead of scanning every row above them.
+        """
+        baseline = count_grid_inspections(1000)
+        quadrupled = count_grid_inspections(4000)
 
-        # 4x the rows: ~4x if linear, ~16x if quadratic. Measured 6.7x before
-        # the fix at these sizes and 2-3x after, so 8x separates them with room
-        # for timer noise on a small baseline.
-        assert quadrupled < baseline * 8, (
-            f"4x rows cost {quadrupled / baseline:.1f}x the time "
-            f"({baseline:.3f}s -> {quadrupled:.3f}s), which looks quadratic"
+        # 4x the rows: 4x if linear, ~16x if quadratic. Measured exactly 4.00x
+        # fixed, so 5x separates the two without sitting on the boundary.
+        assert quadrupled < baseline * 5, (
+            f"4x rows cost {quadrupled / baseline:.1f}x the grid inspections "
+            f"({baseline:,} -> {quadrupled:,}), which looks quadratic"
+        )
+
+    def test_grid_inspection_cost_per_row_is_flat(self):
+        """The sharper statement: cost per row does not grow with the table.
+
+        A ratio can be satisfied by a curve that is merely sub-quadratic. Per-row
+        cost holding flat across a 16x size range is what linear actually means,
+        and it is the property the short-circuit restores.
+        """
+        per_row = {n: count_grid_inspections(n) / n for n in (250, 1000, 4000)}
+
+        assert max(per_row.values()) - min(per_row.values()) < 1.0, (
+            f"per-row grid inspections drift with table size: {per_row}"
         )
 
 

--- a/tests/offerings/eval/run_eval.py
+++ b/tests/offerings/eval/run_eval.py
@@ -16,6 +16,7 @@ Buckets per facet:
     deferred legitimately indeterminate (fee capacity on pay-as-you-go ASRs)
     bad      garbage or out-of-range  <-- the thing we never want to ship
     error    extractor raised
+    unavailable  SEC did not serve the filing — unmeasured, excluded from n
 
 Metrics:  coverage = (ok + deferred) / n     bad_rate = (bad + error + suspect) / n
 (a justified `deferred` is a correct resolution — an indeterminate pay-as-you-go
@@ -186,6 +187,31 @@ FACETS = {
 
 # --------------------------------------------------------------------------
 
+def _is_transport_failure(ex: BaseException) -> bool:
+    """Whether ``ex`` means "SEC did not give us the filing", not "the extractor broke".
+
+    The distinction decides whether an entry is measured at all. A filing that
+    could not be fetched is *unmeasured*: counting it as a defect makes the
+    ratchet report an extraction regression whenever the network is slow, which
+    is what made the guardrail fail under full-suite load — the suite shares one
+    rate limiter, so a busy run starves this eval's 44 fetches and the failures
+    land in bad_rate.
+
+    Deliberately narrow. Only transport and HTTP-status failures qualify; an
+    extractor that raises TypeError on a real response is still an ``error``,
+    which is the thing this eval exists to catch.
+    """
+    import httpx
+
+    if isinstance(ex, (httpx.HTTPError, ConnectionError, TimeoutError)):
+        return True
+    # edgar wraps some fetch failures in its own types; match on the SEC-facing
+    # ones by name so this does not depend on their import path staying put.
+    return type(ex).__name__ in {
+        "SECFilingNotFoundError", "SECHTMLResponseError", "IdentityNotSetException",
+    }
+
+
 def run(entries, only_facet=None):
     from edgar import find
     results = []
@@ -200,7 +226,8 @@ def run(entries, only_facet=None):
         try:
             bucket, value, reason, ctx = fn(find(e["accession"]))
         except Exception as ex:  # noqa: BLE001 — the harness must survive any filing
-            bucket, value, reason = "error", None, f"{type(ex).__name__}: {ex}"
+            bucket = "unavailable" if _is_transport_failure(ex) else "error"
+            value, reason = None, f"{type(ex).__name__}: {ex}"
 
         # Anchor ground-truth check (overrides bucket -> bad on mismatch).
         # Frontier entries are known coverage gaps: a None value is the documented
@@ -240,13 +267,20 @@ def summarize(results, include_frontier=False):
     extractor) are excluded by default so the ratchet measures regressions on the
     *supported* scope only — newly-added gap cases must not drag the floor down.
     Pass include_frontier=True to summarize the frontier set on its own.
+
+    ``n`` counts entries that were actually measured. Entries SEC would not serve
+    are tallied under ``unavailable`` and left out of ``n``, so a run degraded by
+    the network reports a smaller sample rather than a worse extractor. Callers
+    are expected to check ``unavailable`` themselves — a sample small enough to
+    flatter the rates is a failed measurement, not a pass.
     """
     by_facet = defaultdict(lambda: defaultdict(int))
     for r in results:
         if bool(r.get("frontier")) != include_frontier:
             continue
         by_facet[r["facet"]][r["bucket"]] += 1
-        by_facet[r["facet"]]["n"] += 1
+        if r["bucket"] != "unavailable":
+            by_facet[r["facet"]]["n"] += 1
     return by_facet
 
 
@@ -254,11 +288,13 @@ def print_dashboard(results):
     by_facet = summarize(results)
     print("\n=== Offerings Extraction Eval — Tier A + B ===\n")
     hdr = (f"{'facet':18}{'n':>4}{'ok':>5}{'susp':>6}{'null':>6}{'defer':>7}"
-           f"{'bad':>5}{'err':>5}{'coverage':>11}{'bad_rate':>10}{'verified':>10}")
+           f"{'bad':>5}{'err':>5}{'unavl':>7}{'coverage':>11}{'bad_rate':>10}{'verified':>10}")
     print(hdr)
     print("-" * len(hdr))
+    unavailable_total = 0
     for facet, c in sorted(by_facet.items()):
         n = c["n"]
+        unavailable_total += c["unavailable"]
         cov = (c["ok"] + c["deferred"]) / n if n else 0
         badr = (c["bad"] + c["error"] + c["suspect"]) / n if n else 0
         # verified = oracle-confirmed / oracle-judged (pass + fail), for this facet
@@ -266,7 +302,15 @@ def print_dashboard(results):
         passed = [r for r in judged if r["verified"]]
         vrate = f"{len(passed)}/{len(judged)}" if judged else "—"
         print(f"{facet:18}{n:>4}{c['ok']:>5}{c['suspect']:>6}{c['null']:>6}{c['deferred']:>7}"
-              f"{c['bad']:>5}{c['error']:>5}{cov:>10.0%}{badr:>10.0%}{vrate:>10}")
+              f"{c['bad']:>5}{c['error']:>5}{c['unavailable']:>7}{cov:>10.0%}{badr:>10.0%}{vrate:>10}")
+
+    if unavailable_total:
+        # Rates above are computed over what was measured, so an unremarked
+        # unavailable count would make a half-finished run read as a clean one.
+        print(f"\n!! {unavailable_total} entr{'y' if unavailable_total == 1 else 'ies'} "
+              f"could not be fetched and are excluded from every rate above. "
+              f"These are network failures, not extraction results — rerun before "
+              f"reading anything into the numbers.")
 
     bad = [r for r in results if r["bucket"] in ("bad", "error", "suspect")
            and not r.get("frontier")]

--- a/tests/offerings/eval/test_eval_ratchet.py
+++ b/tests/offerings/eval/test_eval_ratchet.py
@@ -16,6 +16,12 @@ import pytest
 
 EVAL_DIR = Path(__file__).parent
 
+# How many unfetchable entries still leave a sample worth judging. The corpus is
+# 44 entries; a couple of transient SEC failures should not fail the run, but a
+# handful means the rates are being computed over a sample small enough to move
+# on its own, and the honest report is that nothing was measured.
+MAX_UNAVAILABLE = 3
+
 
 def _load():
     return (json.loads((EVAL_DIR / "corpus.json").read_text()),
@@ -31,11 +37,31 @@ def test_offerings_eval_meets_thresholds():
     corpus, thresholds = _load()
     by_facet = summarize(run(corpus))
 
+    # A filing SEC would not serve is unmeasured, not a defect. Counting fetch
+    # failures as 'bad' is what made this guardrail fail under full-suite load:
+    # the suite shares one rate limiter, a busy run starves these 44 fetches, and
+    # a quality ratchet then reports an extraction regression that never happened.
+    # They are excluded from the rates and bounded separately here, so a degraded
+    # run says "could not measure" instead of either passing on a rump sample or
+    # blaming the extractor.
+    unavailable = sum(c["unavailable"] for c in by_facet.values())
+    measured = sum(c["n"] for c in by_facet.values())
+    assert unavailable <= MAX_UNAVAILABLE, (
+        f"{unavailable} of {unavailable + measured} corpus entries could not be "
+        f"fetched from SEC, so this run did not measure extraction quality. "
+        f"Rerun on a quiet connection; if it persists, the corpus has rotted and "
+        f"the accessions need rechecking."
+    )
+
     failures = []
     for facet, limits in thresholds.items():
         c = by_facet.get(facet)
         assert c, f"no results for facet {facet}"
         n = c["n"]
+        assert n, (
+            f"every entry for facet {facet} was unavailable "
+            f"({c['unavailable']} fetch failures), so it was not measured"
+        )
         # A justified 'deferred' (indeterminate pay-as-you-go shelf) is a correct
         # resolution, so it counts toward coverage alongside 'ok'.
         coverage = (c["ok"] + c["deferred"]) / n

--- a/tests/offerings/eval/test_unavailable_partition.py
+++ b/tests/offerings/eval/test_unavailable_partition.py
@@ -1,0 +1,119 @@
+"""
+Fast unit tests for the eval harness's unavailable (unfetched) accounting.
+
+A filing SEC would not serve is *unmeasured*, not a defect. Before this
+partition existed, every fetch failure landed in the ``error`` bucket and counted
+toward ``bad_rate``, so ``test_eval_ratchet`` reported an extraction regression
+whenever the network was slow. It failed exactly that way under full-suite load:
+the suite shares one rate limiter, a busy run starves the eval's 44 fetches, and
+a quality guardrail blamed the extractor for it.
+
+The partition has to hold in both directions, which is what these pin. A
+transport failure must not be counted as bad; an extractor that genuinely raises
+must still be, because that is the thing the eval exists to catch. Neither
+touches the network.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+EVAL_DIR = Path(__file__).parent
+sys.path.insert(0, str(EVAL_DIR))
+
+from run_eval import _is_transport_failure, summarize  # noqa: E402
+
+
+def _r(facet, bucket, frontier=False):
+    return {"facet": facet, "bucket": bucket, "frontier": frontier}
+
+
+class TestTransportFailuresAreRecognised:
+    """What counts as "SEC did not give us the filing"."""
+
+    def test_httpx_transport_and_status_errors(self):
+        import httpx
+
+        request = httpx.Request("GET", "https://www.sec.gov/x")
+        assert _is_transport_failure(httpx.ConnectError("refused", request=request))
+        assert _is_transport_failure(httpx.ReadTimeout("timed out", request=request))
+        assert _is_transport_failure(httpx.RemoteProtocolError("reset", request=request))
+        assert _is_transport_failure(httpx.HTTPStatusError(
+            "429", request=request, response=httpx.Response(429, request=request)))
+
+    def test_builtin_connection_and_timeout_errors(self):
+        assert _is_transport_failure(ConnectionResetError("peer reset"))
+        assert _is_transport_failure(TimeoutError("timed out"))
+
+    def test_edgar_fetch_failures_matched_by_name(self):
+        """Matched by name so this does not break when they are moved."""
+        for name in ("SECFilingNotFoundError", "SECHTMLResponseError",
+                     "IdentityNotSetException"):
+            assert _is_transport_failure(type(name, (Exception,), {})("boom")), name
+
+
+class TestExtractorFailuresAreStillDefects:
+    """The silence check: the partition must not become a blanket amnesty."""
+
+    @pytest.mark.parametrize("exception", [
+        TypeError("unsupported operand type(s)"),
+        AttributeError("'NoneType' object has no attribute 'text'"),
+        ValueError("could not convert string to float"),
+        KeyError("total_offering_amount"),
+        IndexError("list index out of range"),
+        ZeroDivisionError("division by zero"),
+    ])
+    def test_an_extractor_crash_is_not_unavailable(self, exception):
+        assert not _is_transport_failure(exception)
+
+
+class TestUnavailableIsExcludedFromTheSample:
+
+    def test_unavailable_does_not_count_toward_n(self):
+        results = [
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "unavailable"),
+        ]
+        by_facet = summarize(results)
+        assert by_facet["fee_capacity"]["n"] == 2
+        assert by_facet["fee_capacity"]["unavailable"] == 1
+
+    def test_a_fetch_failure_no_longer_moves_the_bad_rate(self):
+        """The regression in one assertion.
+
+        Two filings measured clean, one unfetchable. Counted the old way that is
+        a 33% bad_rate against a ceiling most facets set near zero — a failure
+        caused entirely by the network.
+        """
+        by_facet = summarize([
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "unavailable"),
+        ])
+        c = by_facet["fee_capacity"]
+        bad_rate = (c["bad"] + c["error"] + c["suspect"]) / c["n"]
+        assert bad_rate == 0.0
+
+    def test_a_real_error_still_moves_the_bad_rate(self):
+        by_facet = summarize([
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "ok"),
+            _r("fee_capacity", "error"),
+        ])
+        c = by_facet["fee_capacity"]
+        assert c["n"] == 3
+        assert (c["bad"] + c["error"] + c["suspect"]) / c["n"] == pytest.approx(1 / 3)
+
+    def test_an_all_unavailable_facet_reports_an_empty_sample(self):
+        """n == 0 rather than a coverage of 100% over nothing.
+
+        The ratchet asserts on this: a facet whose every entry failed to fetch
+        was not measured, and must not read as a pass.
+        """
+        by_facet = summarize([
+            _r("fee_capacity", "unavailable"),
+            _r("fee_capacity", "unavailable"),
+        ])
+        assert by_facet["fee_capacity"]["n"] == 0
+        assert by_facet["fee_capacity"]["unavailable"] == 2


### PR DESCRIPTION
Both commits fix the same class of problem from opposite ends of the repo: a quality guardrail whose failure signal was contaminated by how busy the test runner was. Neither changes library code.

## 1. The quadratic-scaling guard was timing a 41ms baseline (`edgartools-kzdr`)

`test_scaling_is_not_quadratic` compared wall clock at 1,000 rows against 4,000 and asserted the ratio stayed under 8x. Under full-suite load it failed at **9.1x (0.041s -> 0.373s) while the code was perfectly linear** — three runs deep. A 41ms baseline cannot support a ratio assertion; GC and scheduler noise clear the threshold on their own.

It now counts grid inspections instead. `_is_occupied` reads `len(self.matrix)` once per iteration of the scan the fix removed, so the count *is* the cost the defect ran up, and it reads identically on an idle box and a saturated one. `CountingMatrix` routes the grid through a property so the instrument survives `build_from_rows` reassigning it — the measurement stays on the production path rather than a stand-in.

The counts tie back to the original profile of accession `0000310522-18-000010`: 95,976 `_is_occupied` calls at 4,000 rows driving 192,527,603 `len` calls. Fixed, those 95,976 calls do one length check each. **Measured exactly 4.00x against ~16x quadratic**, so the new 5x threshold separates the two without sitting on the boundary.

Adds a sharper companion test: per-row cost holding flat across a 16x size range. A ratio alone can be satisfied by a merely sub-quadratic curve; flat per-row cost is what linear actually means.

## 2. An unfetchable filing counted as an extraction defect

Every fetch failure in the offerings eval landed in the `error` bucket and counted toward `bad_rate`, so `test_eval_ratchet` reported an extraction regression whenever the network was slow. It failed exactly that way under full-suite load — the suite shares one rate limiter, a busy run starves the eval's 44 fetches, and the guardrail blamed the extractor for the runner.

A filing SEC would not serve is *unmeasured*, not a defect. Transport and HTTP-status failures now go to an `unavailable` bucket excluded from `n`, so a degraded run reports a smaller sample rather than a worse extractor. The dashboard prints the total so a shrunken sample cannot pass unnoticed.

The partition is deliberately narrow, and `test_unavailable_partition.py` pins it in both directions:

- An extractor raising `TypeError`/`AttributeError`/`ValueError`/`KeyError` on a real response is **still an `error`** — that is the thing this eval exists to catch.
- A facet whose every entry failed to fetch reports `n == 0`, not 100% coverage over nothing.
- The regression itself, in one assertion: two filings measured clean plus one unfetchable used to read as a 33% `bad_rate` against a ceiling most facets set near zero.

`tests/conftest.py` classifies the new file as fast. Without that line it would have run in **no CI job at all**, per the marker fall-through hole closed on 2026-08-04. Verified it passes with the fast runner (13 passed, not deselected).

## Verification

```
hatch run test-fast tests/issues/regression/test_issue_wbwn_table_matrix_quadratic.py \
                    tests/offerings/eval/test_eval_ratchet.py \
                    tests/offerings/eval/test_unavailable_partition.py
22 passed
```

No CHANGELOG entry — test-only, nothing here reaches a user deciding whether to upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)