### PR TITLE
6.0: settle the target date and the branching model

### DIFF
--- a/engineering/6.0-release-plan.md
+++ b/engineering/6.0-release-plan.md
@@ -1,8 +1,9 @@
 # EdgarTools 6.0 Release Plan
 
-**Status**: Draft (2026-07-28)
+**Status**: Draft (2026-07-28) · target date and branching model settled 2026-08-05
 **Tracking**: `edgartools-07lk` (epic) — children `07lk.1`–`07lk.4`, plus linked existing beads
-**Current version**: 5.43.1
+**Current version**: 5.45.1
+**Target release**: 2026-11-09 (rationale in *Timing*, below)
 
 ## Principles
 
@@ -171,6 +172,80 @@ attention is the scarce resource; these items protect it.
 | Repo slim reprioritized P2→P1 | `07lk.12.3` | Cloud AI environments clone fresh per session; 2.2 GB is a tax on every contribution |
 | Review PR #919 with cluster context | `llmp.6.7` | Pilot for the aligned-contributor flow |
 
+## Timing (settled 2026-08-05)
+
+**Target: 2026-11-09.** Three facts pick that week, and they agree.
+
+*Python 3.10 reaches end of life on 2026-10-31.* Releasing after that date makes
+the floor bump self-justifying — "3.10 is EOL, 6.0 requires ≥3.11" — instead of
+an argument we have to make. Releasing before it means pushing users off a
+runtime upstream still supports.
+
+*pandas 3.0 has already decided the floor for us.* 3.0.0 shipped 2026-01-21
+(3.0.5 as of 2026-07-22) and declares `requires-python >=3.11`. `b7j4` is
+therefore one decision, not two: there is no 6.0 that takes the pandas 3.0 floor
+and keeps Python 3.10.
+
+*The tail is small and we are late, not early.* Python 3.10 is 3.8% of downloads
+over the last 180 days — less than 3.14's 8.9%. Under SPEC 0, the numpy/pandas
+convention of dropping a Python ~3 years after release, 3.10 was due to go
+around October 2024. Treat 3.8% as an upper bound: PyPI counts include CI and
+mirrors, and the real users behind it skew toward locked enterprise
+environments — the cohort whose own policy moves them once 3.10 goes EOL.
+
+No later, either: 3.11's EOL is 2027-10-31, so slipping past November reaches no
+further natural boundary and buys nothing external.
+
+## Branching and release model (settled 2026-08-05)
+
+**No long-running 6.0 branch. Freeze releases, not commits.**
+
+Everything lands on `main`. Phases 0 and 1 ship as 5.x, exactly as they have
+been. For Phase 2, `main` goes briefly unreleasable rather than a branch going
+briefly divergent.
+
+*Why not a release branch, in this repo specifically.* Our own throughput is the
+argument against it: 38 PRs merged in the 9 days after this plan opened, 13 of
+them in section extraction — the subsystem Phase 2 both deletes (`07lk.3`) and
+relocates (`07lk.12.1`). A long-lived branch would spend its life absorbing
+conflicts from our own fix stream, and the faster `main` moves the more it
+costs. The reorg is rename-heavy, and git merges renames badly when the other
+side edited the moved files; the mitigation we already chose for that is
+announced landing windows (`07lk.16`), which is a trunk technique. A second base
+branch would also tax the contributor program (`07lk.15`) by making every
+compiled help-wanted issue explain which branch to target, duplicate or drift
+from the PR gate that `07lk.21` just established, and add cross-branch conflicts
+across a 530 MB cassette corpus that may yet be re-recorded (`07lk.12.3`).
+
+*The lever that makes this work is additive staging.* Most Phase 2 items have a
+half that ships in 5.x under the current model, which shrinks the irreducible
+window to a handful of removals and gives users a release stream that warns them
+before 6.0 breaks them:
+
+| Item | Additive half — ships in 5.x | Irreducible break |
+|------|------------------------------|-------------------|
+| `iirl` / `1h9c` naming | add new names, deprecate old | remove old names |
+| `07lk.5` public API | declare `__all__`, ship `py.typed` | enforce privacy |
+| `07lk.10` exceptions | add hierarchy, warn on silent `None` | flip returns to raises |
+| `07lk.3` `edgar.files` | deprecation warnings (Phase 0) | delete package |
+| `07lk.12.1` tree moves | new paths behind import shims | drop shims |
+| `07lk.11` bs4 | per-file lxml migrations | drop the dependency |
+
+`q2iz` (httpx2 exception namespace) and `b7j4` (pandas 3.0 / Python floor) are
+the two that cannot be staged; they land inside the window.
+
+*Hotfixes during the window.* If a 5.x patch is needed while `main` is
+unreleasable, branch `5.x` **from the last 5.x tag** at that moment. That is a
+maintenance branch carrying backports only — short-lived and cheap, the opposite
+shape from a feature branch running ahead of trunk.
+
+*The condition that would reverse this.* If the freeze window needs to run
+longer than about six weeks, a branch starts paying for itself. Keep it short by
+staging aggressively before October. The decision stays reversible in the cheap
+direction — we can still cut a branch at freeze time if staging went worse than
+expected, whereas unwinding a branch carried since August is the expensive
+direction.
+
 ## Sequencing
 
 **Phase 0 — still on 5.x (start now)**
@@ -199,9 +274,16 @@ httpx2 swap with exception re-exports (`q2iz` + `07lk.10`) · pandas 3.0 / drop
 source-tree moves and renames (`07lk.12.1`, with `07lk.5` declaring the new
 surface) · wheel excludes for dev tooling (`07lk.12.1` item 5)
 
-**Release**
+**The freeze window — ~2026-10-12 to 2026-11-02**
+5.x releases stop. The irreducible breaks land on `main`, which is knowingly
+unreleasable for the duration. Everything that could be staged additively should
+already have shipped in 5.x by the time this opens — the window's length is set
+by how much did not.
+
+**Release — 2026-11-09**
 Migration guide (one entry per break) · changelog · perf numbers vs the Phase 0
-baseline as the release story.
+baseline as the release story. Then 5.x maintenance ends and `main` resumes
+normal releases as 6.x.
 
 ## Open questions
 
@@ -210,5 +292,8 @@ baseline as the release story.
 2. Should httpx/httpx2 become optional extras (paultiq's 0.6.0 pattern) or a
    hard swap?
 3. Do we drop the PyPy classifier in 6.0 or keep testing it? (Relevant if a
-   PyO3 accelerator is ever revisited.)
-4. Timeline: no date attached yet — Phase 0 items are all startable today.
+   PyO3 accelerator is ever revisited.) Belongs with `b7j4`, which is already
+   editing the same classifier block.
+
+*Answered 2026-08-05:* ~~4. Timeline~~ — target 2026-11-09 with a freeze window
+opening ~2026-10-12; see *Timing* and *Branching and release model*.


### PR DESCRIPTION
The plan carried *"Timeline: no date attached yet"* as an open question while the GitHub milestone quietly said 2026-08-15, and it said nothing at all about how breaking changes would be sequenced against a live 5.x release stream. This settles both and records the reasoning, so neither gets re-litigated in October.

No code changes — `engineering/6.0-release-plan.md` only. The GitHub milestone has been moved to match, and two beads now own the execution.

## Target: 2026-11-09

Three facts pick that week, and they agree:

**Python 3.10 reaches EOL on 2026-10-31.** Releasing after it makes the floor bump self-justifying — "3.10 is EOL, 6.0 requires ≥3.11" — instead of an argument we have to make. Releasing before means pushing users off a runtime upstream still supports.

**pandas 3.0 has already decided the floor.** 3.0.0 shipped 2026-01-21 (3.0.5 as of 2026-07-22) and declares `requires-python >=3.11`. `b7j4` is therefore one decision, not two: there is no 6.0 that takes the pandas 3.0 floor and keeps Python 3.10.

**The tail is small, and we're late rather than early.** Python 3.10 is 3.8% of downloads over the last 180 days — less than 3.14's 8.9%. Under SPEC 0, the numpy/pandas convention of dropping a Python ~3 years after release, 3.10 was due to go around October 2024.

Not later either: 3.11's EOL is 2027-10-31, so slipping past November reaches no further natural boundary and buys nothing external.

## No long-running 6.0 branch — freeze releases, not commits

Everything lands on `main`. Phases 0 and 1 ship as 5.x, as they have been. For Phase 2, `main` goes briefly unreleasable rather than a branch going briefly divergent.

The argument against a release branch is specific to this repo, and it's our own throughput: **38 PRs merged in the 9 days after this plan opened, 13 of them in section extraction** — the subsystem Phase 2 both deletes (`07lk.3`) and relocates (`07lk.12.1`). A long-lived branch would spend its life absorbing conflicts from our own fix stream, and the faster `main` moves the more it costs.

Reinforcing reasons: the reorg is rename-heavy and git merges renames badly when the other side edited the moved files — the mitigation we already chose for that (`07lk.16` landing windows) is a trunk technique. A second base branch would also make every compiled help-wanted issue explain which branch to target, undercutting `07lk.15`; duplicate or drift from the PR gate `07lk.21` just established; and add cross-branch conflicts over a 530 MB cassette corpus that may yet be re-recorded.

## The lever that makes it work

Most Phase 2 items have an additive half that ships in 5.x behind a deprecation, which shrinks the irreducible window to a handful of removals and gives users a release stream that *warns* them before 6.0 *breaks* them. Only `q2iz` (httpx2 exception namespace) and `b7j4` (pandas/Python floor) genuinely cannot be staged. The full table is in the new section.

**Hotfixes during the window** branch `5.x` *from the last 5.x tag* — backport-only, short-lived, the opposite shape from a feature branch running ahead of trunk.

**Reversal condition**, stated in the doc so it isn't a matter of memory: if the window needs to run longer than ~6 weeks, a branch starts paying for itself. Cutting a branch *at* freeze time is cheap; unwinding one carried since August is not.

## Also in here

Sequencing now ends with the freeze window (~2026-10-12 to 2026-11-02) rather than jumping straight to "Release", and open question 4 is answered in place rather than deleted, so the reasoning stays visible next to the question it settles. Open question 3 (PyPy classifier) picks up a note that it belongs with `b7j4`, which is already editing the same classifier block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)