### PR TITLE
Rebuild the new-vs-legacy section parity benchmark, and pin it (edgartools-zqjn)

### DIFF
--- a/tests/fixtures/parser_corpus/parity_benchmark.py
+++ b/tests/fixtures/parser_corpus/parity_benchmark.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+"""New-vs-legacy section-extraction parity benchmark (edgartools-zqjn).
+
+Rebuilt 2026-08-05, after the original was lost with the January-2026 baseline
+(New 64.7% / Legacy 74.0% / -9.2%) it produced — leaving every section-extraction
+fix since then unmeasured against the parser we plan to delete.
+
+WHY IT LIVES HERE AND NOT IN ``tests/manual/``. The original was written to
+``tests/manual/benchmark_section_extraction.py``, and **``tests/manual/`` is
+gitignored** (``.gitignore`` line 58). That is the whole reason it vanished: it
+could never have been committed from that path, and ``git add`` would have
+refused it silently. Both ``zqjn`` and ``dt1f`` still name the old path, so
+anyone following those references lands on a directory git will not track. This
+file sits next to ``scoring.py`` and ``build_corpus.py`` instead — tracked,
+purpose-built for corpus measurement, and beside the fixtures it measures. Do
+not move it back.
+
+WHAT IT ANSWERS. Removing ``edgar.files`` (``07lk.3``) means deleting
+``ChunkedDocument``, and three consumers still lean on it: ``EightK.items`` uses
+it as a Strategy-2 backfill, ``TenK``/``TenQ`` fall back to it, and ``TwentyF``
+*prefers* it as the primary path. The gate for deleting it is evidence that the
+new parser finds everything the legacy one finds. That is a differential
+question, not a score question, so the differential is the primary output:
+
+    both        found by new and legacy      (safe)
+    new_only    found by new alone           (new parser wins)
+    legacy_only found by legacy alone        <-- THE WORK LIST. Must reach zero
+                                                 per form before that form's
+                                                 fallback can be deleted.
+
+The ``legacy_only`` set per form is the deliverable ``dt1f`` needs.
+
+WHY OFFLINE. The original benchmark fetched 96 filings by accession, which made
+it slow, rate-limited, and non-reproducible once a filing moved. This one reads
+committed fixtures only, so it is deterministic and runnable in CI. The corpus is
+also *era-stratified* through ``text_boundary_corpus`` (1996-2026 in five bands),
+which matters here: the claim that legacy wins on old filer-agent HTML (``mpjh``
+/ GH #870) is exactly the kind of thing a modern-only corpus cannot see.
+
+READING THE NUMBERS — two traps this harness is built to avoid.
+
+1. *8-K item granularity.* Legacy cannot express 8-K subitems: it reports Item
+   8.01 as ``'Item 8'`` and Item 5.02 as ``'Item 5'``, while the new parser
+   reports ``item_801`` / ``item_502``. Comparing those as strings would score a
+   legacy *limitation* as a new-parser miss. Coverage is therefore compared at
+   the coarsest granularity both parsers can express (the major number), and the
+   subitem precision the new parser adds is reported separately rather than
+   folded into the score.
+
+2. *Filings where both find nothing.* Pre-2002 8-Ks are frequently plain-text
+   bodies with no item structure at all; both parsers correctly return nothing.
+   Counting those as a shared failure would drag both scores toward zero and hide
+   the actual delta, so they are reported as ``both_blind`` and excluded from the
+   per-form coverage rates.
+
+USAGE
+    python tests/fixtures/parser_corpus/parity_benchmark.py
+    python tests/fixtures/parser_corpus/parity_benchmark.py --form 8-K --form 20-F
+    python tests/fixtures/parser_corpus/parity_benchmark.py --json out.json
+
+``tests/test_section_parity_ratchet.py`` imports ``measure``/``build_corpus``
+from here and pins the result, so a regression fails a test rather than waiting
+for someone to re-run the benchmark by hand.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import warnings
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Anchored on this file's own directory, the way scoring.py does it, so the
+# paths survive the file being moved again.
+_CORPUS_DIR = Path(__file__).resolve().parent
+FIXTURES = _CORPUS_DIR.parent
+_REPO_ROOT = FIXTURES.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# The legacy parser warns on every construction by design (it is deprecated and
+# this benchmark exists to retire it). Silence it so the report stays readable.
+warnings.filterwarnings("ignore")
+
+from edgar.documents.config import ParserConfig  # noqa: E402
+from edgar.documents.parser import HTMLParser  # noqa: E402
+from edgar.files.htmltools import ChunkedDocument  # noqa: E402
+
+HTML_CORPUS = FIXTURES / "html"
+ERA_CORPUS = FIXTURES / "text_boundary_corpus"
+
+# Forms that gate the deletion, in the order they block it. 10-K is included as
+# the control: it was already at parity in January and a regression there would
+# invalidate the rest of the run.
+GATE_FORMS = ["8-K", "20-F", "10-Q", "10-K"]
+
+# Canonical item lists, used only for the secondary coverage-vs-expected rate.
+# 8-K is deliberately absent: an 8-K reports only the items it has, so there is
+# no denominator and a percentage would be meaningless. The differential is the
+# metric that works for every form.
+EXPECTED_ITEMS: Dict[str, List[str]] = {
+    "10-K": ["1", "1A", "1B", "1C", "2", "3", "4", "5", "6", "7", "7A", "8", "9",
+             "9A", "9B", "9C", "10", "11", "12", "13", "14", "15", "16"],
+    "10-Q": ["1", "1A", "2", "3", "4", "5", "6"],
+    "20-F": ["1", "2", "3", "4", "4A", "5", "6", "7", "8", "9", "10", "11", "12",
+             "13", "14", "15", "16A", "16B", "16C", "16D", "16E", "16F", "16G",
+             "16H", "17", "18", "19"],
+}
+
+# Sections the new parser emits that are not items and must not enter the
+# comparison (legacy has no equivalent concept).
+NON_ITEM_SECTIONS = {"signatures", "cover", "cover_page", "exhibits", "toc"}
+
+
+# ---------------------------------------------------------------------------
+# Normalisation — the part that decides whether the numbers mean anything.
+# ---------------------------------------------------------------------------
+
+_NEW_ITEM_RE = re.compile(r"^(?:part_[ivx]+_)?item[_\s]*(\d+)([a-z]?)$", re.IGNORECASE)
+_LEGACY_ITEM_RE = re.compile(r"^item\s*(\d+)(?:\.(\d+))?\s*([a-z]?)$", re.IGNORECASE)
+
+
+def normalise_new(section_name: str, form: str) -> Optional[str]:
+    """Map a new-parser section name to a canonical item key.
+
+    ``part_ii_item_7a`` -> ``7A``. For 8-K the parser packs the subitem into the
+    digits (``item_801`` is Item 8.01); we return the major number only, because
+    that is the granularity legacy can also express. ``subitem_of`` below
+    recovers the precision for the separate precision report.
+    """
+    if section_name.lower() in NON_ITEM_SECTIONS:
+        return None
+    m = _NEW_ITEM_RE.match(section_name)
+    if not m:
+        return None
+    digits, suffix = m.group(1), m.group(2)
+    if form == "8-K":
+        # 8-K majors are single-digit (1-9), so a 3-digit group is major+minor.
+        return digits[0] if len(digits) == 3 else digits
+    return f"{digits}{suffix}".upper()
+
+
+def subitem_of(section_name: str, form: str) -> Optional[str]:
+    """The full 8-K subitem (``item_801`` -> ``8.01``), or None."""
+    if form != "8-K":
+        return None
+    m = _NEW_ITEM_RE.match(section_name)
+    if not m or len(m.group(1)) != 3:
+        return None
+    d = m.group(1)
+    return f"{d[0]}.{d[1:]}"
+
+
+def normalise_legacy(item_name: str, form: str) -> Optional[str]:
+    """Map a legacy ``list_items()`` entry to the same canonical item key.
+
+    ``'Item 7A'`` -> ``7A``. Legacy occasionally emits a decimal for 8-K; take
+    the major number so both sides land on the same granularity.
+    """
+    m = _LEGACY_ITEM_RE.match(item_name.strip())
+    if not m:
+        return None
+    major, _minor, suffix = m.group(1), m.group(2), m.group(3)
+    if form == "8-K":
+        return major
+    return f"{major}{suffix}".upper()
+
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+def build_corpus(forms: List[str]) -> List[dict]:
+    """Every committed fixture for the requested forms, with provenance.
+
+    Two sources with different shapes: the modern per-ticker tree (10-K/10-Q
+    only, 2024-2025) and the era-stratified tree (all four gate forms, 1996-2026,
+    three filings per era). Era is carried through to the report because the
+    old-HTML bands are where legacy is claimed to win.
+    """
+    entries: List[dict] = []
+    dir_for_form = {"10-K": "10k", "10-Q": "10q"}
+
+    for form in forms:
+        subdir = dir_for_form.get(form)
+        if subdir:
+            for path in sorted(HTML_CORPUS.glob(f"*/{subdir}/*.html")):
+                entries.append({
+                    "form": form, "path": path, "era": "modern",
+                    "label": f"{path.parent.parent.name}/{subdir}",
+                })
+        for path in sorted(ERA_CORPUS.glob(f"*/{form}/*.html")):
+            entries.append({
+                "form": form, "path": path, "era": path.parent.parent.name,
+                "label": path.stem,
+            })
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+def measure(entry: dict) -> dict:
+    """Run both parsers over one fixture and return the per-filing differential.
+
+    A parser that raises is recorded as an error with an empty item set rather
+    than aborting the run: a crash on one filing is itself a finding, and on a
+    100-fixture corpus it must not cost the other 99.
+    """
+    form = entry["form"]
+    html = entry["path"].read_text(errors="ignore")
+
+    new_items: Set[str] = set()
+    new_subitems: Set[str] = set()
+    new_error = None
+    try:
+        doc = HTMLParser(ParserConfig(form=form, detect_sections=True)).parse(html)
+        for name in doc.sections:
+            key = normalise_new(name, form)
+            if key:
+                new_items.add(key)
+            sub = subitem_of(name, form)
+            if sub:
+                new_subitems.add(sub)
+    except Exception as exc:  # noqa: BLE001 — a crash is a result, not a stop
+        new_error = f"{type(exc).__name__}: {exc}"[:200]
+
+    legacy_items: Set[str] = set()
+    legacy_error = None
+    try:
+        for name in ChunkedDocument(html).list_items():
+            key = normalise_legacy(name, form)
+            if key:
+                legacy_items.add(key)
+    except Exception as exc:  # noqa: BLE001
+        legacy_error = f"{type(exc).__name__}: {exc}"[:200]
+
+    return {
+        "form": form,
+        "era": entry["era"],
+        "label": entry["label"],
+        "size": len(html),
+        "new": sorted(new_items),
+        "legacy": sorted(legacy_items),
+        "new_subitems": sorted(new_subitems),
+        "both": sorted(new_items & legacy_items),
+        "new_only": sorted(new_items - legacy_items),
+        "legacy_only": sorted(legacy_items - new_items),
+        "both_blind": not new_items and not legacy_items,
+        "new_error": new_error,
+        "legacy_error": legacy_error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def _rate(found: int, expected: int) -> str:
+    return f"{found / expected:.1%}" if expected else "—"
+
+
+def report(results: List[dict]) -> None:
+    by_form: Dict[str, List[dict]] = defaultdict(list)
+    for r in results:
+        by_form[r["form"]].append(r)
+
+    print("\n" + "=" * 78)
+    print("SECTION-EXTRACTION PARITY — new HTMLParser vs legacy ChunkedDocument")
+    print("=" * 78)
+
+    print("\n## Differential (the deletion gate)\n")
+    hdr = (f"{'form':7}{'filings':>8}{'blind':>7}{'both':>7}{'new_only':>10}"
+           f"{'legacy_only':>13}{'new tot':>9}{'legacy tot':>12}")
+    print(hdr)
+    print("-" * len(hdr))
+    for form in GATE_FORMS:
+        rs = by_form.get(form)
+        if not rs:
+            continue
+        blind = sum(r["both_blind"] for r in rs)
+        both = sum(len(r["both"]) for r in rs)
+        new_only = sum(len(r["new_only"]) for r in rs)
+        legacy_only = sum(len(r["legacy_only"]) for r in rs)
+        print(f"{form:7}{len(rs):>8}{blind:>7}{both:>7}{new_only:>10}"
+              f"{legacy_only:>13}{both + new_only:>9}{both + legacy_only:>12}")
+
+    print("\n## Coverage vs the canonical item list\n")
+    print("Filings where BOTH parsers found nothing are excluded — see the module")
+    print("docstring. 8-K has no canonical list, so it has no rate.\n")
+    hdr2 = f"{'form':7}{'scored':>8}{'new':>9}{'legacy':>9}{'delta':>9}"
+    print(hdr2)
+    print("-" * len(hdr2))
+    for form in GATE_FORMS:
+        rs = [r for r in by_form.get(form, []) if not r["both_blind"]]
+        expected = EXPECTED_ITEMS.get(form)
+        if not rs or not expected:
+            if rs:
+                print(f"{form:7}{len(rs):>8}{'—':>9}{'—':>9}{'—':>9}")
+            continue
+        denom = len(rs) * len(expected)
+        exp = set(expected)
+        new_hits = sum(len(set(r["new"]) & exp) for r in rs)
+        legacy_hits = sum(len(set(r["legacy"]) & exp) for r in rs)
+        delta = (new_hits - legacy_hits) / denom
+        print(f"{form:7}{len(rs):>8}{_rate(new_hits, denom):>9}"
+              f"{_rate(legacy_hits, denom):>9}{delta:>+9.1%}")
+
+    print("\n## legacy_only — the work list for dt1f\n")
+    print("Every entry here is a section the parser we plan to DELETE finds and")
+    print("the one we plan to KEEP does not. Each form's list must reach zero")
+    print("before that form's chunked_document fallback can be removed.\n")
+    any_gap = False
+    for form in GATE_FORMS:
+        rs = [r for r in by_form.get(form, []) if r["legacy_only"]]
+        if not rs:
+            continue
+        any_gap = True
+        total = sum(len(r["legacy_only"]) for r in rs)
+        print(f"  {form} — {total} missed across {len(rs)} filings")
+        for r in rs:
+            print(f"      [{r['era']}] {r['label']:<34} missing {r['legacy_only']}")
+    if not any_gap:
+        print("  (none — every item legacy finds, the new parser also finds)")
+
+    print("\n## 8-K subitem precision\n")
+    eight = by_form.get("8-K", [])
+    if eight:
+        with_sub = [r for r in eight if r["new_subitems"]]
+        n_sub = sum(len(r["new_subitems"]) for r in with_sub)
+        print(f"  Legacy reports 8-K items at major-number granularity only")
+        print(f"  ('Item 8', never 'Item 8.01'). The new parser resolved")
+        print(f"  {n_sub} subitems across {len(with_sub)} filings — a capability")
+        print(f"  legacy does not have, and not visible in the scores above.")
+
+    errors = [r for r in results if r["new_error"] or r["legacy_error"]]
+    if errors:
+        print("\n## Parser errors\n")
+        for r in errors:
+            who = "new" if r["new_error"] else "legacy"
+            print(f"  [{r['form']} {r['label']}] {who}: {r['new_error'] or r['legacy_error']}")
+
+    print("\n## Both-blind filings\n")
+    blind = [r for r in results if r["both_blind"]]
+    if blind:
+        by_era: Dict[str, int] = defaultdict(int)
+        for r in blind:
+            by_era[f"{r['form']} {r['era']}"] += 1
+        print(f"  {len(blind)} filings where NEITHER parser found an item:")
+        for k in sorted(by_era):
+            print(f"      {k}: {by_era[k]}")
+        print("  Excluded from the coverage rates. Worth an eyeball — some are")
+        print("  genuinely item-less (pre-2002 plain-text bodies), but a modern")
+        print("  filing in this list is a real gap in both parsers.")
+    else:
+        print("  (none)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--form", action="append", choices=GATE_FORMS,
+                    help="limit to one or more forms (repeatable)")
+    ap.add_argument("--json", type=Path, help="write the per-filing results here")
+    args = ap.parse_args()
+
+    forms = args.form or GATE_FORMS
+    corpus = build_corpus(forms)
+    if not corpus:
+        print("No fixtures found — is the fixture corpus present?", file=sys.stderr)
+        return 1
+
+    print(f"Measuring {len(corpus)} fixtures across {len(forms)} forms "
+          f"(both parsers, offline)...", file=sys.stderr)
+    results = []
+    started = time.perf_counter()
+    for i, entry in enumerate(corpus, 1):
+        print(f"  [{i}/{len(corpus)}] {entry['form']:<5} {entry['label']}",
+              file=sys.stderr)
+        results.append(measure(entry))
+    elapsed = time.perf_counter() - started
+
+    report(results)
+    print(f"\n({len(corpus)} fixtures in {elapsed:.1f}s)")
+
+    if args.json:
+        args.json.write_text(json.dumps(results, indent=2))
+        print(f"Per-filing results written to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/parser_corpus/parity_benchmark.py
+++ b/tests/fixtures/parser_corpus/parity_benchmark.py
@@ -72,7 +72,7 @@ import time
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 # Anchored on this file's own directory, the way scoring.py does it, so the
 # paths survive the file being moved again.

--- a/tests/test_section_parity_ratchet.py
+++ b/tests/test_section_parity_ratchet.py
@@ -1,0 +1,156 @@
+"""New-vs-legacy section-extraction parity ratchet (edgartools-zqjn).
+
+The gate for deleting ``edgar.files``/``ChunkedDocument`` (``07lk.3``) is
+evidence that the new parser finds everything the legacy one finds. This test
+pins that evidence so it stays true between now and the 6.0 freeze window,
+instead of being re-discovered by hand — which is how the January-2026 baseline
+was lost in the first place.
+
+The measurement lives in ``tests/fixtures/parser_corpus/parity_benchmark.py``;
+run it directly for the full report, per-form coverage, and the work list.
+
+WHAT THIS GUARDS. ``BASELINE_GAPS`` is every (form, filing, item) the legacy
+parser finds and the new one misses, as measured on 2026-08-05 over 115 committed
+fixtures. The assertion is a **subset** check, mirroring the anomaly census in
+``test_section_boundary_corpus.py``: the live gap set may shrink freely, and any
+*new* gap fails. So a fix that closes ``wfc/10k`` needs no change here, while a
+change that breaks a currently-clean filing turns this red.
+
+WHY SUBSET AND NOT EQUALITY. Equality would force every parser improvement to
+edit this file, which makes the guard an obstacle rather than a safety net.
+Tighten the baseline deliberately, in the commit that closes a gap, so the
+recorded set keeps ratcheting down toward the empty set that unblocks deletion.
+
+Deliberately NOT asserted: the coverage percentages. They move with the corpus
+and read as precision the sample size does not support. The differential is the
+thing the deletion decision actually rests on.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "fixtures" / "parser_corpus"))
+import parity_benchmark  # noqa: E402
+
+# Offline, but re-parses 115 fixtures through two parsers (~140s). Slow lane.
+pytestmark = pytest.mark.slow
+
+
+# Measured 2026-08-05 on main. Each entry is a section the parser we plan to
+# DELETE finds and the one we plan to KEEP does not.
+#
+# Three shapes are visible here, and they are the work list for dt1f:
+#
+#   1. Two systematic pattern gaps on modern 10-Ks. Item 16 (Form 10-K Summary)
+#      is missed on axp/cvx/jnj and one era filing; Item 1C (Cybersecurity, new
+#      in 2023) on bac/jpm/tsla. Both look like detection-pattern holes rather
+#      than per-filing damage, so each is likely one fix for several filings.
+#   2. Five near-total failures, where the new parser returns almost nothing on
+#      a filing legacy handles: wfc/10k (10 core items including 1, 1A, 7, 8 —
+#      a live bug on a modern large-bank filing) and four era fixtures. The
+#      20-F outlier 0001144204-10-017467 is EDGARizer-generated filer-agent
+#      HTML: 12,880 <font> tags and zero <p>, the class edgartools-mpjh tracks.
+#   3. Singletons, most of them pre-2015 HTML.
+BASELINE_GAPS = {
+    ("8-K", "0001104659-03-004925"): ["9"],
+    ("8-K", "0001437749-16-028287"): ["2"],
+    ("10-K", "0000927356-01-000369"): ["7"],
+    ("10-K", "0000950153-99-001234"): ["1", "10", "11", "12", "13", "14", "2",
+                                       "3", "4", "5", "6", "7", "7A", "8", "9"],
+    ("10-K", "0001193125-10-073212"): ["9A"],
+    ("10-K", "0001193125-21-101193"): ["1", "10", "11", "1B", "5"],
+    ("10-K", "0001193125-21-101902"): ["16"],
+    ("10-K", "0001376474-16-000635"): ["1", "10", "11", "12", "13", "14", "15",
+                                       "1A", "1B", "2", "3", "4", "5", "6", "7",
+                                       "7A", "8", "9", "9A", "9B"],
+    ("10-K", "axp/10k"): ["16"],
+    ("10-K", "bac/10k"): ["1C"],
+    ("10-K", "cvx/10k"): ["16"],
+    ("10-K", "jnj/10k"): ["16"],
+    ("10-K", "jpm/10k"): ["1C"],
+    ("10-K", "tsla/10k"): ["1C"],
+    ("10-K", "wfc/10k"): ["1", "1A", "1B", "1C", "2", "3", "7", "7A", "8", "9A"],
+    ("10-Q", "0001193125-21-082408"): ["1"],
+    ("10-Q", "gs/10q"): ["5", "6"],
+    ("20-F", "0000928385-01-500187"): ["7"],
+    ("20-F", "0001062993-16-008650"): ["11", "16", "6"],
+    ("20-F", "0001144204-10-017467"): ["1", "10", "11", "12", "13", "14", "15",
+                                       "16A", "16B", "16C", "16D", "16E", "16F",
+                                       "16G", "2", "3", "4A", "5", "6", "7", "8",
+                                       "9"],
+}
+
+# Filings where NEITHER parser finds an item — 16 of them, every one pre-2009.
+# Not a parity signal (the delta is zero), but pinned so a *modern* filing
+# joining them is caught: that would be a gap in both parsers at once.
+BASELINE_BOTH_BLIND = 16
+
+
+@pytest.fixture(scope="module")
+def measured():
+    corpus = parity_benchmark.build_corpus(parity_benchmark.GATE_FORMS)
+    assert corpus, "fixture corpus is missing — nothing was measured"
+    return [parity_benchmark.measure(entry) for entry in corpus]
+
+
+def _live_gaps(measured):
+    return {
+        (r["form"], r["label"]): set(r["legacy_only"])
+        for r in measured if r["legacy_only"]
+    }
+
+
+class TestTheLegacyParserFindsNothingNew:
+    """The deletion gate: no section may be legacy-only that was not already."""
+
+    def test_no_new_parity_gap_appears(self, measured):
+        baseline = {k: set(v) for k, v in BASELINE_GAPS.items()}
+        live = _live_gaps(measured)
+
+        regressions = {
+            key: sorted(items - baseline.get(key, set()))
+            for key, items in live.items()
+            if items - baseline.get(key, set())
+        }
+        assert not regressions, (
+            "the new parser lost ground against the parser we plan to delete: "
+            f"{regressions}. Each entry is an item legacy finds and new does "
+            "not, on a filing where that was not previously true."
+        )
+
+    def test_closed_gaps_are_recorded(self, measured):
+        """The ratchet's other half: tighten the baseline when a gap closes.
+
+        Not a failure of the parser — a failure to bank the win. Left un-banked,
+        the baseline keeps permitting a gap that no longer exists, and the guard
+        silently loosens.
+        """
+        baseline = {k: set(v) for k, v in BASELINE_GAPS.items()}
+        live = _live_gaps(measured)
+
+        stale = {
+            key: sorted(items - live.get(key, set()))
+            for key, items in baseline.items()
+            if items - live.get(key, set())
+        }
+        assert not stale, (
+            f"these recorded gaps are closed — remove them from BASELINE_GAPS "
+            f"in the same commit that closed them: {stale}"
+        )
+
+
+class TestBothParsersStillSeeTheSameCorpus:
+
+    def test_both_blind_set_does_not_grow(self, measured):
+        blind = [r for r in measured if r["both_blind"]]
+        assert len(blind) <= BASELINE_BOTH_BLIND, (
+            f"{len(blind)} filings now yield no items from EITHER parser, up "
+            f"from {BASELINE_BOTH_BLIND}: "
+            f"{[(r['form'], r['label']) for r in blind]}"
+        )
+
+    def test_neither_parser_crashes(self, measured):
+        errors = [(r["form"], r["label"], r["new_error"] or r["legacy_error"])
+                  for r in measured if r["new_error"] or r["legacy_error"]]
+        assert not errors, f"parser raised on: {errors}"


### PR DESCRIPTION
Deleting `edgar.files` in 6.0 (`07lk.3`) means deleting `ChunkedDocument`, and three consumers still lean on it: `EightK.items` uses it as a Strategy-2 backfill, `TenK`/`TenQ` fall back to it, and `TwentyF` *prefers* it as the primary path. The gate for removing it is evidence that the new parser finds everything the legacy one finds — and that evidence hasn't existed since January, because the benchmark that produced it was lost.

Tests only. No library code changes.

## Why the original was lost

It lived at `tests/manual/benchmark_section_extraction.py`, and **`tests/manual/` is gitignored** (`.gitignore:58`). It could never have been committed from that path; `git add` would have refused it silently. Both `zqjn` and `dt1f` still name it, so anyone following those references lands on a directory git will not track.

The rebuild sits at `tests/fixtures/parser_corpus/parity_benchmark.py` instead, beside `scoring.py` and `build_corpus.py` — tracked, purpose-built for corpus measurement, and next to the fixtures it measures.

## The January baseline was wrong, in the new parser's favour

| Form | Jan 2026 | Now | |
|---|---|---|---|
| 10-K | +0.8% | **−1.0%** | slipped |
| 10-Q | −17.5% | **−0.5%** | nearly closed |
| 20-F | −62.7% | **−8.4%** | nearly closed |
| 8-K | unmeasured | **at parity** | 14 both, 2 each way |

"20-F: New 0.0% / not implemented" is dead — the new parser returns 25–28 items on modern 20-Fs, sits at exact parity with legacy on 9 of 15 fixtures, and beats it on one.

**Answer to the question blocking `07lk.3`:** no form is ready for fallback removal yet, but none is far off, and 8-K is closest — 2 legacy-only sections on pre-2017 filings, against 16 subitems only the new parser can resolve.

## The remaining gap is concentrated, not diffuse

90 legacy-only sections, in three shapes:

1. **Two detection-pattern holes on modern 10-Ks** — Item 16 (Form 10-K Summary) on axp/cvx/jnj, Item 1C (Cybersecurity, new in 2023) on bac/jpm/tsla. Each looks like one fix covering several filings. Worth noting `dt1f`'s task list names Items 9C and 14; neither appears now, so that list was stale too.
2. **Five near-total failures** — `wfc/10k` missing 10 core items including 1, 1A, 7, 8 on a modern large-bank filing, and 20-F `0001144204-10-017467` carrying 22 misses alone. That one is EDGARizer filer-agent HTML (12,880 `<font>` tags, zero `<p>`) — the `mpjh`/GH #870 class **inverted**: there chunked fails on filer-agent HTML, here the new parser does.
3. A tail of pre-2015 singletons.

The full list is in the report output and in `BASELINE_GAPS`.

## Two measurement traps handled explicitly

**8-K granularity.** Legacy cannot express subitems — it reports Item 8.01 as `'Item 8'` and Item 5.02 as `'Item 5'`. Comparing raw strings would score a legacy *limitation* as a new-parser miss. Coverage is compared at the coarsest granularity both parsers can express, and the 16 subitems only the new parser resolves are reported separately rather than folded into the score.

**Filings where both find nothing.** 16 of them, every one pre-2009, mostly plain-text bodies with no item structure. Counting them as shared failures would drag both scores toward zero and hide the actual delta, so they're reported as `both_blind` and excluded from the rates.

## Offline by design

115 committed fixtures, no network, versus the original's 96 accession fetches — deterministic and CI-viable at 138s. Era-stratified 1996–2026 via `text_boundary_corpus`, which matters because the claim that legacy wins on old filer-agent HTML is invisible to a modern-only corpus. It's how trap 2 and the EDGARizer finding surfaced at all.

## The ratchet

`tests/test_section_parity_ratchet.py` pins the differential as a subset assertion, mirroring the anomaly census in `test_section_boundary_corpus.py`: the gap may shrink freely, any new gap fails. A companion test asserts the converse — a *closed* gap must be removed from the baseline in the same commit — because a baseline that keeps permitting gaps which no longer exist is a guard that silently loosens.

I did **not** bolt 8-K/20-F fixtures into `test_section_boundary_corpus.py` as the bead suggested. Its `manifest.json` is a stale h44r-era snapshot `main` already diverges from; pinning the differential directly is the actual deletion gate.

## One decision for you

`test-slow` skips pull requests by design (`python-hatch-workflow.yml:174`), so **this ratchet will not gate PRs** — it runs on push to main and nightly, catching a regression after merge rather than before. The stated reason slow tests skip PRs is that they're "often network-heavy"; this one is fully offline and deterministic at 136s, so it's a candidate for the offline-slow lane #958 introduced. I've left it in the default lane rather than making that call unilaterally.

## Verification

```
pytest tests/test_section_parity_ratchet.py     # 4 passed in 136s
python tests/fixtures/parser_corpus/parity_benchmark.py   # full report
```

Confirmed deselected from `test-fast`. `zqjn` stays open: the full-document markdown parity comparison it also asks for (gating the `Filing.markdown()` reroute, GH #886) is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)