### PR TITLE
Record Citi's cross-reference-index sizes as understood, not broken

### DIFF
--- a/tests/test_section_boundary_corpus.py
+++ b/tests/test_section_boundary_corpus.py
@@ -62,8 +62,22 @@ GROUND_TRUTH = {
 # cvx 10-K was here until edgartools-gegs fixed its incorporation-by-reference
 # recovery (Item 7/8 now recovered, Item 14 clamped); removed so a cvx regression
 # re-trips this guard.
+#
+# ('c', '10-K') joined the set at ab3a1725 (#951) and is NOT a boundary bug —
+# measured before recording it. That commit taught the parser to read
+# Citigroup's FORM 10-K CROSS-REFERENCE INDEX, which maps items to printed page
+# ranges instead of labelling them in the body, so items became extractable for
+# the first time. They are legitimately enormous and legitimately overlapping:
+# Item 8 is pages 142-313 of a 16.7MB filing and opens on "CONSOLIDATED BALANCE
+# SHEET", Item 7 opens on "MANAGEMENT'S DISCUSSION AND ANALYSIS", and Items 7
+# and 7A both cite pages 70-129 because Citi's market-risk disclosure lives
+# inside MD&A. The slices land where they should; the >300k marker is a
+# heuristic tuned for filings that label their items in the body, and a
+# cross-reference index is a different shape. See the bead for the sharper fix
+# (exempt detection_method='index' from the size markers), which would let this
+# entry come back out.
 ANOMALY_BASELINE = {
-    ("915358", "10-K"), ("bac", "10-K"),
+    ("915358", "10-K"), ("bac", "10-K"), ("c", "10-K"),
     ("gbdc", "10-K"), ("gbdc", "10-Q"), ("gs", "10-K"), ("gs", "10-Q"),
     ("ibm", "10-K"), ("jpm", "10-K"), ("jpm", "10-Q"), ("ms", "10-K"),
     ("nflx", "10-K"), ("nvda", "10-K"), ("orcl", "10-K"), ("xom", "10-Q"),


### PR DESCRIPTION
`main`'s slow lane has failed since `ab3a1725` (#951) on one assertion — `('c', '10-K')` joining the size-anomalous set. This unbreaks it, and corrects a diagnosis I got wrong.

Tests only.

## I filed this as a boundary regression. It isn't one.

I opened the bead from the census failure message alone, and called it end-boundary overflow. Then I measured it, and the measurement says the opposite.

`#951` taught the parser to read Citigroup's `FORM 10-K CROSS-REFERENCE INDEX`, which maps items to printed page ranges rather than labelling them in the body. Items became extractable for the first time, and they are legitimately enormous and legitimately overlapping:

| | |
|---|---|
| Item 8 | pages 142–313 of a 16.7 MB filing; text opens on **"CONSOLIDATED BALANCE SHEET"** |
| Item 7 | opens on **"MANAGEMENT'S DISCUSSION AND ANALYSIS OF FINANCIAL CONDITION"** |
| Items 7 **and** 7A | both cite pages **70–129** |

That last row is the whole thing: Citi's market-risk disclosure sits inside MD&A, so one page legitimately serves two items — which is what a cross-reference index does. The 1.53x sum-of-items-over-document figure I cited as evidence of overshoot is the expected arithmetic of that mechanism, not the GH #871 bleed class.

The slices land where they should.

## What's actually wrong

`scoring.auto_markers` applies a `>300k` oversize threshold tuned for filings that label items in the body. A cross-reference-index filing is a different shape, and the heuristic fires on correct extraction.

## Why recorded rather than exempted

The sharper fix is to exempt `detection_method='index'` from the size markers, which would let this entry come back out of the baseline. That needs the detection method threaded through `scoring.measure_fixture` — which does not carry it today — and the same treatment in `build_corpus.py` so the manifest agrees. Wider than unbreaking `main` justifies, so it is on the bead (`edgartools-rk02`, now P2 since `main` is green again) rather than in here.

The cost is stated in the code comment rather than left implicit: **a genuine future overshoot on Citi will no longer re-trip this census**, and Citi is the corpus's hardest filing.

## Separate finding, not fixed here

`test_no_section_overlap` is parameterized over the 9 `GROUND_TRUTH` tickers only, so it never runs on `c`. A test whose entire purpose is catching overlap is blind to the corpus's most overlap-prone filing. It should run over the full corpus — though it would need the same index-awareness first, since a ratio above 1.0 is *correct* for these filings. Also on the bead.

## Verified

`pytest tests/test_section_boundary_corpus.py` — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)