### PR TITLE
build(deps): lift the httpxthrottlecache cap via the [httpx] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`httpxthrottlecache` is no longer capped below 0.5.0.** The cap existed because 0.5.0 hard-required the `httpx2` fork, which edgartools does not use. 0.6.0 reversed that and declares `httpx` and `httpx2` as optional extras, so the dependency is now `httpxthrottlecache[httpx]>=0.6.0` — five months of upstream releases become reachable while edgartools stays on plain `httpx`. The `[httpx]` extra is required rather than cosmetic: from 0.6.0 the package installs neither transport by default. Whether to adopt `httpx2` is a separate decision and is not made here.
+
+- **Removed the `HttpxThrottleCache._get_httpx_transport_params` monkeypatch.** It was added when the upstream method dropped the `verify` parameter, which left users behind SSL-inspecting corporate proxies unable to turn verification off. Upstream extracts `verify` itself now, making the patch not merely redundant but a liability — shadowing an upstream method silently reverts any later fix to it. A new test pins the behaviour the patch protected, so an upstream regression fails in CI rather than in the field.
+
 - **`EntityFactsParser._parse_date` no longer swallows every exception type.** It caught bare `Exception` and returned `None`; it now catches `ValueError` and `TypeError`, the two a date parse can legitimately raise. Malformed and non-string input still yields `None`, but an unanticipated failure surfaces instead of being silently absorbed once per fact. (GH #981)
 
 ### Fixed

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -17,42 +17,13 @@ except (locale.Error, ValueError):
     # This shouldn't happen on most systems, but better safe than sorry
     pass
 
-from typing import Any
-
+# We used to monkeypatch HttpxThrottleCache._get_httpx_transport_params below this
+# import, because it dropped the 'verify' parameter on the floor and users behind
+# SSL-inspecting corporate proxies could not turn verification off. httpxthrottlecache
+# now extracts 'verify' itself, so the patch was redundant — and worse than redundant,
+# since shadowing an upstream method silently reverts any future fix to it.
+# test_verify_reaches_the_transport_params pins the behaviour the patch protected.
 from httpxthrottlecache import HttpxThrottleCache
-
-
-# =============================================================================
-# WORKAROUND for httpxthrottlecache bug: SSL verify parameter not passed to transport
-#
-# Bug: httpxthrottlecache v0.2.1 (and possibly earlier versions) fails to pass the
-# 'verify' parameter to the HTTP transport, causing SSL verification to remain enabled
-# even when configure_http(verify_ssl=False) is called.
-#
-# Impact: Users behind corporate VPNs/proxies with SSL inspection cannot disable
-# SSL verification, making edgartools unusable in those environments.
-#
-# Upstream issue: https://github.com/paultiq/httpxthrottlecache/issues/XXX (TODO: create)
-#
-# TODO: Remove this monkey patch once httpxthrottlecache releases a fix (check for v0.3.0+)
-# =============================================================================
-def _patched_get_httpx_transport_params(self, params: dict[str, Any]) -> dict[str, Any]:
-    """
-    Patched version that includes the 'verify' parameter for SSL configuration.
-
-    This fixes a bug where httpxthrottlecache._get_httpx_transport_params() only
-    extracts 'http2' and 'proxy' parameters, ignoring 'verify'.
-    """
-    http2 = params.get("http2", False)
-    proxy = self.proxy
-    verify = params.get("verify", True)  # Extract verify parameter (defaults to True for security)
-
-    return {"http2": http2, "proxy": proxy, "verify": verify}
-
-
-# Apply the monkey patch at module import time
-HttpxThrottleCache._get_httpx_transport_params = _patched_get_httpx_transport_params
-# =============================================================================
 
 from edgar.core import get_identity, strtobool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,12 @@ dependencies = [
   "nest-asyncio>=1.5.1",
   "jinja2>=3.1.0",
   "pyrate-limiter>=3.0.0",
-  # Cap below 0.5.0: that release migrated from httpx to the httpx2 fork, which
-  # breaks edgartools (we import plain httpx throughout httprequests.py and our
-  # tests mock httpx). 0.3.5 is the latest version still on plain httpx.
-  "httpxthrottlecache>=0.3.0,<0.5.0",
+  # The [httpx] extra is required, not decorative: from 0.6.0 httpxthrottlecache
+  # declares httpx and httpx2 as optional extras and installs neither by default.
+  # 0.5.0 briefly hard-required the httpx2 fork — which is why this was capped
+  # below it — and 0.6.0 reversed that, so the cap is no longer needed to stay on
+  # plain httpx. Migrating to httpx2 is tracked separately (edgartools-q2iz).
+  "httpxthrottlecache[httpx]>=0.6.0",
   "truststore>=0.9.0",
 ]
 dynamic = ["version"]

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -228,6 +228,27 @@ def test_ssl_verification_applied_to_http_manager(monkeypatch):
     assert isinstance(http_mgr.httpx_params["verify"], bool), "verify should be a boolean, not a function"
 
 
+def test_verify_reaches_the_transport_params():
+    """`verify` must survive the last hop, from httpx_params into the transport.
+
+    edgartools used to monkeypatch HttpxThrottleCache._get_httpx_transport_params
+    because it extracted only 'http2' and 'proxy', so configure_http(verify_ssl=False)
+    was silently ignored and users behind SSL-inspecting corporate proxies could not
+    reach EDGAR at all. httpxthrottlecache does this itself now and the patch was
+    removed; this pins the behaviour so an upstream regression fails here rather
+    than in the field. test_ssl_verification_applied_to_http_manager covers the
+    earlier hop (env var -> httpx_params) — this one covers params -> transport.
+    """
+    http_mgr = get_http_mgr()
+
+    assert http_mgr._get_httpx_transport_params({"verify": False})["verify"] is False
+    assert http_mgr._get_httpx_transport_params({"verify": True})["verify"] is True
+
+    # Absent means verify, not "silently off" — the safe default matters more than
+    # the passthrough, since getting it wrong disables TLS checking for everyone.
+    assert http_mgr._get_httpx_transport_params({})["verify"] is True
+
+
 def test_default_http_timeout_is_set(monkeypatch):
     """
     HTTP_MGR must have a non-None default timeout so a stalled upstream


### PR DESCRIPTION
Lifts the `httpxthrottlecache` cap without migrating to `httpx2`. Split out of `edgartools-q2iz` after validating that bead's premise — the migration it assumed was forced turns out not to be.

## Why the cap can go

The dependency was capped `>=0.3.0,<0.5.0` because 0.5.0 hard-required the `httpx2` fork. That requirement lasted exactly one release:

```
0.3.5  2026-03-11   httpx>=0.28.1                      <- where we are pinned
0.5.0  2026-06-08   httpx2>=2.3.0                      <- the reason for the cap
0.6.0  2026-07-28   httpx==0.28.1; extra=="httpx"      <- reversed: both optional
                    httpx2>=2.3.0; extra=="httpx2"
```

Upstream backed it out. So the cap is no longer needed to stay on plain `httpx`, and five months of upstream releases become reachable — with no `httpx2`, no vcrpy unpin, and none of the user-visible exception-type churn that a fork migration would bring.

The `[httpx]` extra is load-bearing rather than cosmetic: from 0.6.0 the package installs **neither** transport by default, so omitting it would leave no HTTP transport at all.

## Why the monkeypatch goes with it

`edgar/httpclient.py` monkeypatched `HttpxThrottleCache._get_httpx_transport_params` because upstream extracted only `http2` and `proxy`, silently ignoring `verify` — which meant `configure_http(verify_ssl=False)` did nothing and users behind SSL-inspecting corporate proxies could not reach EDGAR at all.

Upstream 0.6.0 now does this itself, identically:

```python
http2 = params.get("http2", False)
proxy = self.proxy
verify = params.get("verify", True)
return {"http2": http2, "proxy": proxy, "verify": verify}
```

The patch was therefore redundant — and worse than redundant, because shadowing an upstream method means any *future* fix to it gets silently reverted by us. Its own TODO said to remove it at v0.3.0+; we are going to 0.6.0.

## The test that should have existed

Removing a safety patch on an untested path is how regressions ship, and this path was untested. `test_ssl_verification_applied_to_http_manager` covers env var → `httpx_params`, but nothing covered the last hop, `params` → transport, which is precisely what the patch guaranteed.

`test_verify_reaches_the_transport_params` covers it, including that an absent `verify` defaults to **on** — getting that backwards would disable TLS checking for everyone. I confirmed it is not vacuous by reinstating the pre-fix upstream behaviour: it fails with `KeyError: 'verify'`.

## Verification

- `httpxthrottlecache[httpx]>=0.6.0` resolves to httpx 0.28.1 + httpcore 1.0.9, **no httpx2** present, and `_get_httpx_transport_params` is still there.
- `-m fast` — **4455 passed**.
- CI's network selection, `-m 'network and not slow and not regression'` — **2283 passed, 0 failed**.
- `ruff` — no new findings versus `main`.

### One thing reviewers should know

A full `pytest -m network` run shows 4 failures (`test_get_with_retry_for_redirect[301|302]` and the async variants). **These are pre-existing** — I ran the same selection against `main` and got the identical four:

```
main @ dfe46b41   -m network   ->  4 failed, 2993 passed
this branch       -m network   ->  4 failed, 2998 passed
```

They pass in isolation, pass within their own file, and pass under CI's selection, so it is cross-file state leakage. Filed separately as `edgartools-5y7v`, along with the more interesting half: **no CI job runs `-m network` as a whole**, while `hatch run test-network` does — so the documented local command is redder than the one gating merges, and this class of failure is invisible by construction.

## Not in scope

Adopting `httpx2`. That stays on `edgartools-q2iz`, now correctly framed as a 6.0 *candidate* rather than a forced move, and gated on https://github.com/kevin1024/vcrpy/issues/1028 — vcrpy only intercepts `httpx2` from 8.3.0, and 8.3.0 still carries the null-reason-phrase crash that breaks 38% of our cassettes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
