### PR TITLE
chore(release): 5.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.46.0] - 2026-08-07
+
 ### Changed
 
 - **On a multi-filer filing, `Filing.cik` and `Filing.company` now name the issuer rather than whichever filer the quarterly index listed first.** Accession lookups go through EDGAR full-text search before falling back to the quarterly index, and the two order a filing's filers differently. `find("0001918704-25-005439")` was `(70858, 'BANK OF AMERICA CORP /DE/')` and is now `(1682472, 'BofA Finance LLC')`. `all_ciks` and `all_entities` still return every filer; single-filer filings are unaffected.

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.45.1'
+__version__ = '5.46.0'


### PR DESCRIPTION
Version bump and changelog fold for 5.46.0. Two files, three lines.

**5.46.0 is already on PyPI** — the wheel and sdist were uploaded before this branch existed, because `git push origin main` is blocked by branch protection and that wasn't caught until after the upload. So this PR is the repo catching up with a release that is already in users' hands, not a proposal to release. Merging it restores the invariant that `edgar/__about__.py` and the changelog describe what PyPI serves.

Once it merges, `v5.46.0` gets tagged on the resulting commit — deliberately after the merge rather than before, since a squash would move the SHA out from under a pre-made tag.

## Contents

- `edgar/__about__.py`: `5.45.1` → `5.46.0`
- `CHANGELOG.md`: `[Unreleased]` folded into `## [5.46.0] - 2026-08-07`, fresh empty `[Unreleased]` left behind

22 entries across Changed, Fixed and Performance, covering 59 commits since 5.45.1 on 2026-08-03.

Minor rather than patch: 8 `feat`/`perf` commits, plus two behavioural changes callers may notice — `Filing.cik` and `Filing.company` now name the issuer on a multi-filer filing, and `FactQuery.to_dataframe()` returns a column set determined by the query rather than by which rows happened to match. Both are documented in the changelog.

## Verification

Done before the build, on this commit:

- `hatch run test-fast`: 4474 passed, 4 skipped, 1 xfailed
- wheel metadata: `Metadata-Version: 2.4`, Name and Version intact
- built wheel installed into a clean venv: reports `5.46.0`, and `get_ticker_from_cusip("G3421J106")` returns `FERG`, confirming the #978 fix is in the artifact rather than only in the repo
- wheel carries the corrected `ct.pq`, with no `.bak` and no `scripts/` — the new `.gitignore` rules cost the package nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
