### PR TITLE
test(markdown): measure full-document new-vs-legacy markdown parity (zqjn)

### DIFF
--- a/tests/fixtures/parser_corpus/markdown_parity.py
+++ b/tests/fixtures/parser_corpus/markdown_parity.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python
+"""New-vs-legacy FULL-DOCUMENT markdown parity (edgartools-zqjn, GH #886).
+
+The companion to ``parity_benchmark.py``. That one asks whether the new parser
+finds the same *sections* as the legacy one; this one asks whether it renders
+the same *document*. They gate different deletions and cannot answer for each
+other — a parser can locate every item and still lose half the prose inside them.
+
+WHAT IT GATES. ``Filing.markdown()`` is the last public rendering method still on
+the legacy parser: ``_filings.py:1746`` goes ``html() -> get_clean_html ->
+edgar.files.markdown.to_markdown``, while ``text()``/``view()``/``parse()`` moved
+to ``edgar.documents`` long ago. Two things follow from that split:
+
+  1. Images are silently dropped from ``Filing.markdown()`` (GH #886, ``n45i``).
+     The new parser renders them — fixed on main in ``a2093248`` — so rerouting
+     fixes it for free.
+  2. Rerouting is a visible behaviour change, not a drop-in. A spot measurement
+     on NVDA's FY2026 10-K had legacy at 429,312 chars and new at 343,760, about
+     20% shorter, with table pipes falling 7,849 -> 5,123 and headings rising
+     185 -> 233.
+
+Shorter is the whole problem. It is either compaction (whitespace, padding and
+redundant table scaffolding the new renderer does not emit) or content loss, and
+**a character count cannot tell you which**. Neither can a diff: the two
+renderers disagree about formatting on almost every line, so a diff of a real
+10-K is 100% noise. So this harness does not measure size. It measures what
+survives:
+
+    number_recall   fraction of legacy's DISTINCT numeric values also in new
+                    <-- THE GATE. Compaction cannot move it: no reformatting
+                        makes a figure disappear.
+    word_recall     fraction of legacy's word OCCURRENCES also in new, as a
+                    multiset. ADVISORY ONLY — see below.
+
+WHY NUMBERS GATE AND WORDS DO NOT. Numbers are high-cardinality and barely
+repeat, so a dropped table takes its figures out of the document entirely and
+the metric moves. The exhibit index is the worked example: losing it removes
+10.11-10.26, which appear nowhere else, and number_recall drops immediately.
+
+Words fail in both available flavours, which is worth stating so nobody
+"fixes" this by switching them:
+
+  * As a MULTISET they are too noisy. Legacy repeats ``Three Months Ended
+    June 30`` above every chunk of a split table; the new renderer emits it
+    once. That is compaction, and it shows up as hundreds of missing
+    occurrences of ``ended``/``months``/``three``. It dominates the residual on
+    every 10-Q in the corpus.
+  * As a SET they are too blunt. Losing ABBV's entire exhibit index does not
+    change the word set at all, because ``exhibit``, ``incorporated`` and
+    ``reference`` all occur elsewhere in the filing.
+
+So word_recall is reported, and a shortfall is worth reading, but it is not
+allowed to fail the gate on its own. Its real job is covering the one thing
+numbers cannot see: prose dropped from a passage that contained no figures.
+Treat a word-only shortfall as "go and look", not as "not ready".
+
+Structure counts (headings, table rows, images) are reported alongside but are
+NOT part of the gate: they are expected to differ, and differ in the new
+parser's favour. They are there to explain the size delta, not to score it.
+
+READING THE NUMBERS — three traps this harness is built to avoid.
+
+1. *The legacy fallback is not markdown.* When ``get_clean_html`` cannot root the
+   HTML, ``Filing.markdown()`` falls back to ``text_to_markdown``, which wraps
+   raw text in a ``<pre>`` block (``_markdown.py:107``). Scoring that against
+   real markdown would manufacture a huge fake delta in whichever direction the
+   fallback happens to run. Those filings are reported as ``legacy_degraded`` and
+   excluded from the rates — and they are a finding in their own right, because
+   they are filings where the thing we are trying to keep already produces
+   nothing worth keeping.
+
+2. *Formatting is not content* — and this trap is not hypothetical, it was the
+   entire first result. Both renderers have habits that a naive token scan reads
+   as content loss: the new one escapes markdown punctuation (``$0\\.24``), and
+   the legacy one leaks raw ``<div align='center'>`` tags into its output. On
+   AAPL's FY2024 10-K that alone produced 63 phantom missing numbers and a
+   phantom 3.4% word shortfall, in a filing with no real loss at all. A third
+   showed up across the corpus: legacy runs words together across tag boundaries
+   (``endedmarch``, ``thethreemonthsendedjune``), which reads as prose the new
+   renderer dropped when it is prose legacy invented. ``comparable`` and
+   ``glued`` below neutralise all three, and the unadjusted word rate stays in
+   the report beside the adjusted one so the correction can be audited rather
+   than trusted. Read both docstrings before changing a recall number.
+
+3. *A recall number alone is not actionable.* 0.97 is meaningless until you know
+   whether the missing 3% is page numbers from a table of contents or line items
+   from a balance sheet. Every shortfall therefore carries a sample of the
+   actually-missing tokens, so the report can be adjudicated by eye rather than
+   believed.
+
+USAGE
+    python tests/fixtures/parser_corpus/markdown_parity.py
+    python tests/fixtures/parser_corpus/markdown_parity.py --form 10-K --limit 5
+    python tests/fixtures/parser_corpus/markdown_parity.py --json out.json
+
+The corpus is shared with ``parity_benchmark.py`` (``build_corpus``), so the same
+caveat applies: ``text_boundary_corpus`` is gitignored, a CI run therefore
+measures fewer fixtures than a local one, and a filing that is not present is
+UNMEASURED, never passing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import warnings
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+_CORPUS_DIR = Path(__file__).resolve().parent
+FIXTURES = _CORPUS_DIR.parent
+_REPO_ROOT = FIXTURES.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_CORPUS_DIR))
+
+# The legacy parser warns on every construction by design.
+warnings.filterwarnings("ignore")
+
+from parity_benchmark import GATE_FORMS, build_corpus  # noqa: E402
+
+from edgar.documents.config import ParserConfig  # noqa: E402
+from edgar.documents.parser import HTMLParser  # noqa: E402
+from edgar.files.html_documents import get_clean_html  # noqa: E402
+from edgar.files.markdown import to_markdown  # noqa: E402
+
+# The gate. Numbers only — see the module docstring for why words are advisory.
+NUMBER_RECALL_GATE = 1.00
+# Not a gate. The threshold below which a word shortfall is worth reading, which
+# is a different thing from a threshold that blocks the reroute.
+WORD_REVIEW_THRESHOLD = 0.98
+
+
+# ---------------------------------------------------------------------------
+# Rendering — each pipeline exactly as Filing.markdown() would reach it.
+# ---------------------------------------------------------------------------
+
+def render_legacy(html: str) -> Tuple[Optional[str], bool, Optional[str]]:
+    """Render via the legacy pipeline. Returns (markdown, degraded, error).
+
+    Mirrors ``Filing.markdown()`` (``_filings.py:1756-1766``) rather than calling
+    it, because that method needs a live ``Filing`` and this harness is offline.
+    ``degraded`` marks the ``<pre>``-wrapped fallback, which is not markdown and
+    must not be scored — see trap 1 in the module docstring.
+    """
+    try:
+        clean = get_clean_html(html)
+        if not clean:
+            return None, True, None
+        md = to_markdown(clean)
+        if not md:
+            return None, True, None
+        return md, False, None
+    except Exception as exc:  # noqa: BLE001 — a crash is a result, not a stop
+        return None, False, f"{type(exc).__name__}: {exc}"[:200]
+
+
+def render_new(html: str, form: str) -> Tuple[Optional[str], Optional[str]]:
+    """Render via the new pipeline: ``HTMLParser.parse(...).to_markdown()``."""
+    try:
+        doc = HTMLParser(ParserConfig(form=form)).parse(html)
+        return doc.to_markdown(), None
+    except Exception as exc:  # noqa: BLE001
+        return None, f"{type(exc).__name__}: {exc}"[:200]
+
+
+# ---------------------------------------------------------------------------
+# Normalisation — the part that decides whether the numbers mean anything.
+# ---------------------------------------------------------------------------
+
+_NUMBER_RE = re.compile(r"\d[\d,]*(?:\.\d+)?")
+_WORD_RE = re.compile(r"[a-z]{2,}")
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+\S", re.MULTILINE)
+_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$", re.MULTILINE)
+
+_ESCAPE_RE = re.compile(r"\\([^\w\s])")
+_HTML_TAG_RE = re.compile(r"<[^>]{1,200}>")
+
+
+def comparable(md: str) -> str:
+    """Strip each renderer's formatting habits so only content is compared.
+
+    Both sides need this, and for opposite reasons — see trap 2. Measured on
+    AAPL's FY2024 10-K, where the raw texts disagree on 63 numbers and neither
+    disagreement is real:
+
+    *The new renderer escapes markdown punctuation.* It emits ``$0\\.24``,
+    ``2024\\.`` and ``10\\-K``. A naive number scan reads ``0\\.24`` as the two
+    tokens ``0`` and ``24`` and reports the dividend as missing, when the
+    sentence is rendered in full. Every one of those 63 was this.
+
+    *The legacy renderer leaks raw HTML.* It emits literal
+    ``<div align='center'>`` into its markdown, 146 times in that one filing,
+    so ``div``/``align``/``center`` look like words the new parser dropped. It
+    is the new parser that is right, and scoring it down for that would invert
+    the finding.
+
+    Neither transformation can hide a genuine loss: unescaping only rejoins
+    tokens the new side already has, and tag-stripping only removes text the
+    legacy side should never have emitted.
+    """
+    return _HTML_TAG_RE.sub(" ", _ESCAPE_RE.sub(r"\1", md))
+
+
+def _canonical_number(token: str) -> str:
+    """``3.050`` and ``3.05`` are the same rate; ``1,234`` and ``1234`` the same total.
+
+    Compared by value rather than spelling, because the new renderer drops
+    trailing zeros — it writes AAPL's ``3.050% Notes due 2029`` as ``3.05%``.
+    That is a formatting choice with no effect on meaning, and comparing the
+    strings scored every such coupon as a lost figure.
+
+    Done by trimming rather than via ``float``, so a 20-digit share count is not
+    quietly rounded by the very check meant to detect lost digits.
+    """
+    t = token.replace(",", "")
+    if "." in t:
+        t = t.rstrip("0").rstrip(".")
+    return t or "0"
+
+
+def numbers(md: str) -> set:
+    """Distinct numeric values.
+
+    A set, not a multiset: the same figure legitimately repeats (a total restated
+    in a note, a year in every header), and renderers differ on how often
+    boilerplate is emitted. Presence is the question — whether the document still
+    contains the figure at all.
+    """
+    return {_canonical_number(m.group(0)) for m in _NUMBER_RE.finditer(md)}
+
+
+def words(md: str) -> Counter:
+    """Bare alphabetic tokens as a multiset.
+
+    A multiset here precisely because prose does not legitimately vanish: if
+    legacy renders a paragraph twice and new renders it once, that is a real
+    difference and a set would hide it.
+    """
+    return Counter(_WORD_RE.findall(md.lower()))
+
+
+def structure(md: str) -> Dict[str, int]:
+    """Counts that explain a size delta without being part of the gate."""
+    rows = _TABLE_ROW_RE.findall(md)
+    return {
+        "chars": len(md),
+        "headings": len(_HEADING_RE.findall(md)),
+        "table_rows": len(rows),
+        "table_cells": sum(r.count("|") - 1 for r in rows),
+        "images": len(_IMAGE_RE.findall(md)),
+    }
+
+
+def glued(token: str, vocabulary: frozenset) -> bool:
+    """Is this legacy token two or more new-side words run together?
+
+    The third contaminant, found the same way as the other two — by reading the
+    shortfall samples instead of the totals. Legacy loses whitespace across tag
+    boundaries and emits ``endedmarch``, ``percentagechange``,
+    ``thethreemonthsendedjune``. The new renderer spaces them correctly, so every
+    one of those reads as a word it dropped, when it is a word legacy invented.
+
+    Note the direction: this is the *legacy* half of the word-boundary bug family
+    (``edgartools-vfwp``), not the new parser's. Both parsers have had it.
+
+    Split greedily against words the new side actually has, requiring at least
+    two pieces of 3+ characters. Kept deliberately narrow: it only excuses a
+    token that is fully explained by words already present, so genuinely lost
+    prose cannot hide here — and the unadjusted rate stays in the report next to
+    the adjusted one so the adjustment itself can be audited.
+    """
+    if len(token) < 6:
+        return False
+    pieces, i, n = 0, 0, len(token)
+    while i < n:
+        for j in range(n, i + 2, -1):
+            if token[i:j] in vocabulary:
+                pieces += 1
+                i = j
+                break
+        else:
+            return False
+    return pieces >= 2
+
+
+def _recall(legacy, new) -> float:
+    """Fraction of legacy retained in new. Vacuously 1.0 if legacy had none."""
+    if isinstance(legacy, Counter):
+        total = sum(legacy.values())
+        if not total:
+            return 1.0
+        return sum(min(c, new[t]) for t, c in legacy.items()) / total
+    if not legacy:
+        return 1.0
+    return len(legacy & new) / len(legacy)
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+def measure_markdown(entry: dict) -> dict:
+    """Render one fixture both ways and return the content differential."""
+    form = entry["form"]
+    html = entry["path"].read_text(errors="ignore")
+
+    legacy_md, degraded, legacy_error = render_legacy(html)
+    new_md, new_error = render_new(html, form)
+
+    row = {
+        "form": form,
+        "era": entry["era"],
+        "label": entry["label"],
+        "size": len(html),
+        "legacy_degraded": degraded,
+        "legacy_error": legacy_error,
+        "new_error": new_error,
+        "scored": bool(legacy_md and new_md),
+    }
+
+    if not row["scored"]:
+        row.update({
+            "legacy": structure(legacy_md) if legacy_md else None,
+            "new": structure(new_md) if new_md else None,
+            "number_recall": None,
+            "word_recall": None,
+            "word_recall_raw": None,
+            "glued_tokens": 0,
+            "missing_numbers": [],
+            "missing_words": [],
+            "missing_number_total": 0,
+            "missing_word_total": 0,
+        })
+        return row
+
+    legacy_cmp, new_cmp = comparable(legacy_md), comparable(new_md)
+    legacy_nums, new_nums = numbers(legacy_cmp), numbers(new_cmp)
+    legacy_words, new_words = words(legacy_cmp), words(new_cmp)
+    missing_nums = legacy_nums - new_nums
+    missing_words = {w: c - new_words[w] for w, c in legacy_words.items()
+                     if c > new_words[w]}
+
+    # Discount legacy's own glued tokens, and report both rates so the size of
+    # the adjustment is visible rather than assumed.
+    vocabulary = frozenset(new_words)
+    glue = {w: c for w, c in missing_words.items() if glued(w, vocabulary)}
+    real_missing = {w: c for w, c in missing_words.items() if w not in glue}
+    legacy_total = sum(legacy_words.values())
+    word_recall = _recall(legacy_words, new_words)
+    word_recall_adj = (
+        1.0 if not legacy_total
+        else 1.0 - sum(real_missing.values()) / legacy_total
+    )
+
+    row.update({
+        "legacy": structure(legacy_md),
+        "new": structure(new_md),
+        "number_recall": _recall(legacy_nums, new_nums),
+        "word_recall_raw": word_recall,
+        "word_recall": word_recall_adj,
+        "glued_tokens": sum(glue.values()),
+        # Samples, not the full sets: this is adjudication material (trap 3),
+        # and a 10-K can drop thousands of tokens when it drops anything.
+        "missing_numbers": sorted(missing_nums)[:15],
+        "missing_words": [w for w, _ in Counter(real_missing).most_common(15)],
+        "missing_number_total": len(missing_nums),
+        "missing_word_total": sum(real_missing.values()),
+    })
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def _pct(x: Optional[float]) -> str:
+    return "—" if x is None else f"{x:.1%}"
+
+
+def report(results: List[dict]) -> None:
+    by_form: Dict[str, List[dict]] = defaultdict(list)
+    for r in results:
+        by_form[r["form"]].append(r)
+
+    print("\n" + "=" * 78)
+    print("FULL-DOCUMENT MARKDOWN PARITY — new HTMLParser vs legacy to_markdown")
+    print("=" * 78)
+
+    print("\n## Content recall (the reroute gate)\n")
+    print("Compaction leaves both columns at 100%. Anything below is content the")
+    print("legacy renderer emits and the new one does not.\n")
+    hdr = (f"{'form':7}{'scored':>8}{'numbers':>10}{'words':>9}{'(raw)':>9}"
+           f"{'clean':>8}{'degraded':>10}{'errors':>8}")
+    print(hdr)
+    print("-" * len(hdr))
+    for form in GATE_FORMS:
+        rs = by_form.get(form)
+        if not rs:
+            continue
+        scored = [r for r in rs if r["scored"]]
+        clean = sum(1 for r in scored
+                    if r["number_recall"] >= NUMBER_RECALL_GATE)
+        degraded = sum(1 for r in rs if r["legacy_degraded"])
+        errors = sum(1 for r in rs if r["new_error"] or r["legacy_error"])
+        n_rec = (min(r["number_recall"] for r in scored) if scored else None)
+        w_rec = (min(r["word_recall"] for r in scored) if scored else None)
+        w_raw = (min(r["word_recall_raw"] for r in scored) if scored else None)
+        print(f"{form:7}{len(scored):>8}{_pct(n_rec):>10}{_pct(w_rec):>9}"
+              f"{_pct(w_raw):>9}{clean:>8}{degraded:>10}{errors:>8}")
+    print("\n(numbers/words columns are the WORST filing in the form, not the mean —")
+    print(" a mean over a corpus hides the one filing that would regress a user.)")
+    glue_total = sum(r.get("glued_tokens", 0) for r in results if r["scored"])
+    print(f"\n(words vs (raw): (raw) is before discounting {glue_total} tokens that")
+    print(" LEGACY glued together — 'endedmarch', 'thethreemonthsendedjune'. The new")
+    print(" renderer spaces them correctly and was being charged for it. See glued().)")
+
+    print("\n## Size delta — descriptive only, NOT the gate\n")
+    hdr2 = (f"{'form':7}{'chars new/legacy':>19}{'rows':>10}"
+            f"{'headings':>11}{'images':>16}")
+    print(hdr2)
+    print("-" * len(hdr2))
+    for form in GATE_FORMS:
+        scored = [r for r in by_form.get(form, []) if r["scored"]]
+        if not scored:
+            continue
+        lc = sum(r["legacy"]["chars"] for r in scored)
+        nc = sum(r["new"]["chars"] for r in scored)
+        lr = sum(r["legacy"]["table_rows"] for r in scored)
+        nr = sum(r["new"]["table_rows"] for r in scored)
+        lh = sum(r["legacy"]["headings"] for r in scored)
+        nh = sum(r["new"]["headings"] for r in scored)
+        li = sum(r["legacy"]["images"] for r in scored)
+        ni = sum(r["new"]["images"] for r in scored)
+        ratio = f"{nc / lc:.2f}x" if lc else "—"
+        print(f"{form:7}{ratio:>19}{f'{nr}/{lr}':>10}"
+              f"{f'{nh}/{lh}':>11}{f'{ni}/{li}':>16}")
+    print("\n(images: legacy renders none at all — that is GH #886, and it is the")
+    print(" reason this reroute is worth doing rather than merely tidy.)")
+
+    print("\n## Shortfalls — the work list\n")
+    print("Each line is a filing where rerouting Filing.markdown() would today")
+    print("lose content. The sample says WHAT was lost, so you can tell a table")
+    print("of contents' page numbers from a balance sheet's line items.\n")
+    any_gap = False
+    for form in GATE_FORMS:
+        rs = [r for r in by_form.get(form, [])
+              if r["scored"] and (r["number_recall"] < NUMBER_RECALL_GATE
+                                  or r["word_recall"] < WORD_REVIEW_THRESHOLD)]
+        if not rs:
+            continue
+        any_gap = True
+        print(f"  {form} — {len(rs)} filings below gate")
+        for r in sorted(rs, key=lambda x: x["number_recall"]):
+            print(f"      [{r['era']}] {r['label']:<34} "
+                  f"num {r['number_recall']:.1%} ({r['missing_number_total']} lost)  "
+                  f"word {r['word_recall']:.1%} ({r['missing_word_total']} lost)")
+            if r["missing_numbers"]:
+                print(f"          numbers: {', '.join(r['missing_numbers'][:10])}")
+            if r["missing_words"]:
+                print(f"          words:   {', '.join(r['missing_words'][:10])}")
+    if not any_gap:
+        print("  (none — every filing clears both gates)")
+
+    degraded = [r for r in results if r["legacy_degraded"]]
+    print("\n## Legacy-degraded filings\n")
+    if degraded:
+        print(f"  {len(degraded)} filings where the LEGACY pipeline produced no")
+        print("  markdown at all and Filing.markdown() would fall back to a <pre>")
+        print("  block of raw text. Excluded from the rates. These are an argument")
+        print("  FOR the reroute, not against it — check whether the new parser")
+        print("  rendered them properly:\n")
+        for r in degraded:
+            new_chars = r["new"]["chars"] if r["new"] else 0
+            verdict = "new OK" if new_chars > 1000 else "new ALSO empty"
+            print(f"      [{r['form']} {r['era']}] {r['label']:<34} "
+                  f"new={new_chars} chars  ({verdict})")
+    else:
+        print("  (none)")
+
+    errors = [r for r in results if r["new_error"] or r["legacy_error"]]
+    print("\n## Renderer errors\n")
+    if errors:
+        for r in errors:
+            who = "new" if r["new_error"] else "legacy"
+            print(f"  [{r['form']} {r['label']}] {who}: "
+                  f"{r['new_error'] or r['legacy_error']}")
+    else:
+        print("  (none)")
+
+    scored_all = [r for r in results if r["scored"]]
+    if scored_all:
+        clean = sum(1 for r in scored_all
+                    if r["number_recall"] >= NUMBER_RECALL_GATE)
+        print("\n## Verdict\n")
+        print(f"  {clean}/{len(scored_all)} scored filings retain every number "
+              f"legacy renders.")
+        if clean == len(scored_all):
+            print("  Filing.markdown() can be rerouted: the size delta is compaction.")
+        else:
+            print("  NOT ready to reroute — see the work list above.")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--form", action="append", choices=GATE_FORMS,
+                    help="limit to one or more forms (repeatable)")
+    ap.add_argument("--limit", type=int,
+                    help="measure at most N fixtures per form (for a quick look)")
+    ap.add_argument("--json", type=Path, help="write the per-filing results here")
+    args = ap.parse_args()
+
+    forms = args.form or GATE_FORMS
+    corpus = build_corpus(forms)
+    if args.limit:
+        per_form: Dict[str, int] = defaultdict(int)
+        kept = []
+        for entry in corpus:
+            if per_form[entry["form"]] < args.limit:
+                per_form[entry["form"]] += 1
+                kept.append(entry)
+        corpus = kept
+    if not corpus:
+        print("No fixtures found — is the fixture corpus present?", file=sys.stderr)
+        return 1
+
+    print(f"Rendering {len(corpus)} fixtures twice each (offline)...",
+          file=sys.stderr)
+    results = []
+    started = time.perf_counter()
+    for i, entry in enumerate(corpus, 1):
+        print(f"  [{i}/{len(corpus)}] {entry['form']:<5} {entry['label']}",
+              file=sys.stderr)
+        results.append(measure_markdown(entry))
+    elapsed = time.perf_counter() - started
+
+    report(results)
+    print(f"\n({len(corpus)} fixtures in {elapsed:.1f}s)")
+
+    if args.json:
+        args.json.write_text(json.dumps(results, indent=2))
+        print(f"Per-filing results written to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_markdown_parity_ratchet.py
+++ b/tests/test_markdown_parity_ratchet.py
@@ -1,0 +1,262 @@
+"""New-vs-legacy full-document markdown parity ratchet (edgartools-zqjn, GH #886).
+
+The sibling of ``test_section_parity_ratchet.py``, and it exists for the same
+reason: a measurement nobody re-runs is a measurement that gets lost. The
+section half of ``zqjn`` lost its original benchmark and five months of progress
+with it. This pins the markdown half from the day it was first measured.
+
+WHAT IT GUARDS. ``Filing.markdown()`` is the last public rendering method still
+on the legacy parser (``_filings.py:1746``). Rerouting it to ``edgar.documents``
+fixes GH #886 — images are dropped today and the new parser renders them, 252 of
+them across this corpus — but the new renderer's output is also ~26% shorter on a
+10-K, and shorter is either compaction or content loss.
+
+``BASELINE_NUMBER_LOSS`` is how much of legacy's numeric content each tracked
+filing currently loses, measured 2026-08-07. The assertion is one-directional,
+mirroring the section ratchet: the loss may shrink freely, and any *increase*
+fails. So work on the exhibit-index bug (``edgartools-2vzk``) needs no change
+here until a filing reaches zero, while a change that starts dropping a table
+somewhere else turns this red.
+
+Numbers, not words or characters — ``markdown_parity.py``'s module docstring
+explains why at length, and it is worth reading before touching a threshold
+here. Briefly: characters cannot distinguish compaction from loss, word counts
+are dominated by legacy's repeated table headers, and numbers are the only
+signal a reformat cannot move.
+
+WHAT IS AND IS NOT MEASURED IN CI. Same split as the section ratchet.
+``tests/fixtures/html`` and ``tests/fixtures/parity_gate`` are tracked (61 of the
+115 fixtures); ``tests/fixtures/text_boundary_corpus`` is gitignored, so the
+era-stratified filings exist on developer machines only. Only tracked fixtures
+are pinned here, so the baseline means the same thing in both places — and
+``test_the_tracked_corpus_is_present`` fails if the tracked half goes missing,
+because "measured nothing" must never read as "nothing wrong".
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "fixtures" / "parser_corpus"))
+import markdown_parity  # noqa: E402
+import parity_benchmark  # noqa: E402
+
+# Offline, but renders the whole corpus through two markdown pipelines. ~220s for
+# all 115 fixtures locally, less in CI where the era corpus is absent. Slow lane.
+pytestmark = pytest.mark.slow
+
+
+# Distinct numeric values each filing renders in legacy markdown and NOT in new,
+# measured 2026-08-07 on main (4bb2c3e0). Tracked fixtures only.
+#
+# The shape of this list is one finding, not fifty-seven. The dominant cluster is
+# the exhibit index — missing values run 4.1, 10.11, 10.12 ... 99.1, i.e. exhibit
+# numbers, and they come with 'exhibit', 'incorporated', 'reference' and 'herein'
+# in the word shortfall. The parser captures those tables (ABBV: 4 TableNodes,
+# 6.5-9.5 KB each); both renderers then lose them. That is edgartools-2vzk, and
+# closing it should empty most of this dict at once.
+#
+# unh/10k at 232 is the extreme of the same thing, not a separate problem.
+BASELINE_NUMBER_LOSS = {
+    ("8-K", "0000887919-21-000012"): 2,
+    ("20-F", "0001062993-16-008650"): 42,
+    ("20-F", "0001062993-21-003193"): 34,
+    ("10-Q", "aapl/10q"): 10,
+    ("10-Q", "ba/10q"): 5,
+    ("10-Q", "gbdc/10q"): 24,
+    ("10-Q", "gs/10q"): 6,
+    ("10-Q", "hubs/10q"): 18,
+    ("10-Q", "ibm/10q"): 6,
+    ("10-Q", "jnj/10q"): 1,
+    ("10-Q", "jpm/10q"): 6,
+    ("10-Q", "ko/10q"): 47,
+    ("10-Q", "msft/10q"): 68,
+    ("10-Q", "nflx/10q"): 6,
+    ("10-Q", "nvda/10q"): 4,
+    ("10-Q", "pg/10q"): 29,
+    ("10-Q", "tsla/10q"): 4,
+    ("10-Q", "unp/10q"): 2,
+    ("10-Q", "xom/10q"): 1,
+    ("10-K", "915358/10k"): 55,
+    ("10-K", "aapl/10k"): 1,
+    ("10-K", "abbv/10k"): 38,
+    ("10-K", "adbe/10k"): 16,
+    ("10-K", "amzn/10k"): 66,
+    ("10-K", "axp/10k"): 36,
+    ("10-K", "ba/10k"): 51,
+    ("10-K", "bac/10k"): 5,
+    ("10-K", "c/10k"): 6,
+    ("10-K", "cat/10k"): 62,
+    ("10-K", "crm/10k"): 30,
+    ("10-K", "cvx/10k"): 28,
+    ("10-K", "gbdc/10k"): 72,
+    ("10-K", "googl/10k"): 2,
+    ("10-K", "gs/10k"): 9,
+    ("10-K", "hd/10k"): 32,
+    ("10-K", "hubs/10k"): 24,
+    ("10-K", "ibm/10k"): 27,
+    ("10-K", "jnj/10k"): 12,
+    ("10-K", "jpm/10k"): 6,
+    ("10-K", "ko/10k"): 86,
+    ("10-K", "ma/10k"): 20,
+    ("10-K", "meta/10k"): 53,
+    ("10-K", "ms/10k"): 16,
+    ("10-K", "msft/10k"): 57,
+    ("10-K", "nflx/10k"): 40,
+    ("10-K", "nke/10k"): 26,
+    ("10-K", "nvda/10k"): 18,
+    ("10-K", "orcl/10k"): 9,
+    ("10-K", "pfe/10k"): 33,
+    ("10-K", "rf/10k"): 44,
+    ("10-K", "tsla/10k"): 30,
+    ("10-K", "unh/10k"): 232,
+    ("10-K", "unp/10k"): 12,
+    ("10-K", "v/10k"): 29,
+    ("10-K", "wfc/10k"): 15,
+    ("10-K", "wmt/10k"): 23,
+    ("10-K", "xom/10k"): 2,
+}
+
+# Tracked filings that already lose nothing. Kept as a separate set rather than
+# as zero-valued entries above, because "already correct" and "known broken by
+# this much" are different claims and only one of them is a work item.
+CLEAN_FILINGS = {
+    ("8-K", "0001104659-03-004925"),
+    ("8-K", "0001437749-16-028287"),
+    ("20-F", "0000928385-01-500187"),
+    ("10-K", "pg/10k"),
+}
+
+TRACKED = set(BASELINE_NUMBER_LOSS) | CLEAN_FILINGS
+
+# Legacy renders no images at all — that is GH #886 in one number. Pinned as a
+# floor so a renderer change that silently stops emitting them is caught here
+# rather than after the reroute ships.
+BASELINE_NEW_IMAGES = 252
+
+
+@pytest.fixture(scope="module")
+def measured():
+    """Render whatever corpus this environment actually has, both ways.
+
+    Returns results keyed by (form, label) plus the set of labels present, since
+    every assertion below has to tell "no loss" apart from "never looked".
+    """
+    corpus = parity_benchmark.build_corpus(parity_benchmark.GATE_FORMS)
+    assert corpus, "fixture corpus is missing entirely — nothing was measured"
+    results = {}
+    for entry in corpus:
+        row = markdown_parity.measure_markdown(entry)
+        results[(row["form"], row["label"])] = row
+    return results, set(results)
+
+
+class TestRerouteLosesNoMoreThanRecorded:
+    """The reroute gate: no filing may start losing numbers it was not already."""
+
+    def test_no_filing_loses_more_numbers(self, measured):
+        results, _present = measured
+        regressions = {}
+        for key, row in results.items():
+            if key not in TRACKED or not row["scored"]:
+                continue
+            allowed = BASELINE_NUMBER_LOSS.get(key, 0)
+            if row["missing_number_total"] > allowed:
+                regressions[key] = (
+                    f"{row['missing_number_total']} lost, baseline {allowed}; "
+                    f"e.g. {row['missing_numbers'][:6]}"
+                )
+        assert not regressions, (
+            "the new renderer now drops numbers the legacy one renders, on "
+            f"filings where that was not previously true (or not this badly): "
+            f"{regressions}"
+        )
+
+    def test_clean_filings_stay_clean(self, measured):
+        results, present = measured
+        dirty = {
+            key: results[key]["missing_numbers"][:6]
+            for key in CLEAN_FILINGS
+            if key in present and results[key]["scored"]
+            and results[key]["missing_number_total"] > 0
+        }
+        assert not dirty, (
+            f"these filings previously retained every number and no longer do: {dirty}"
+        )
+
+    def test_a_repaired_filing_is_banked(self, measured):
+        """The ratchet's other half: move a filing to CLEAN_FILINGS when it is fixed.
+
+        Not a parser failure — a failure to bank the win. Left unbanked, the
+        baseline keeps permitting a loss that no longer exists and the guard
+        quietly loosens. Only filings this environment could measure count; an
+        absent fixture has not been repaired.
+
+        Deliberately triggers only at zero, not on any decrease. Counts drift by
+        one or two whenever the renderer changes at all, and a ratchet that has
+        to be re-banked on every unrelated commit gets disabled instead of read.
+        """
+        results, present = measured
+        repaired = {
+            key: baseline
+            for key, baseline in BASELINE_NUMBER_LOSS.items()
+            if key in present and results[key]["scored"]
+            and results[key]["missing_number_total"] == 0
+        }
+        assert not repaired, (
+            "these filings now lose nothing — move them from BASELINE_NUMBER_LOSS "
+            f"to CLEAN_FILINGS in the same commit that fixed them: {repaired}"
+        )
+
+
+class TestTheRerouteStillBuysWhatItIsFor:
+
+    def test_the_new_renderer_still_emits_images(self, measured):
+        """GH #886 is the reason to reroute; guard the thing being bought."""
+        results, _present = measured
+        scored = [r for r in results.values() if r["scored"]]
+        new_images = sum(r["new"]["images"] for r in scored)
+        legacy_images = sum(r["legacy"]["images"] for r in scored)
+        assert legacy_images == 0, (
+            f"legacy markdown rendered {legacy_images} images — if that is now "
+            "true, GH #886's premise has changed and this file needs revisiting"
+        )
+        # Floor, not equality: the corpus in CI is smaller than the local one.
+        expected = BASELINE_NEW_IMAGES if len(scored) >= 115 else 1
+        assert new_images >= expected, (
+            f"the new renderer emitted {new_images} images, expected at least "
+            f"{expected}. Rerouting Filing.markdown() is supposed to FIX image "
+            "loss; if this drops, it no longer does."
+        )
+
+
+class TestTheCorpusItselfIsIntact:
+    """Guards against the measurement quietly shrinking to nothing."""
+
+    def test_the_tracked_corpus_is_present(self, measured):
+        _results, present = measured
+        missing = sorted(TRACKED - present)
+        assert not missing, (
+            f"tracked fixtures absent from the corpus: {missing}. The parity "
+            "assertions cannot mean anything without them."
+        )
+
+    def test_neither_renderer_crashes(self, measured):
+        results, _present = measured
+        errors = [(k, r["new_error"] or r["legacy_error"])
+                  for k, r in results.items()
+                  if r["new_error"] or r["legacy_error"]]
+        assert not errors, f"renderer raised on: {errors}"
+
+    def test_the_legacy_pipeline_still_produces_markdown(self, measured):
+        """No fixture may newly fall back to the ``<pre>`` escape hatch.
+
+        Zero today. A filing joining this set is not a parity finding — it means
+        ``get_clean_html`` stopped rooting HTML it used to handle, which would
+        silently remove that filing from every rate above.
+        """
+        results, _present = measured
+        degraded = sorted(k for k, r in results.items() if r["legacy_degraded"])
+        assert not degraded, (
+            f"legacy markdown degraded to a <pre> block on: {degraded}"
+        )

--- a/tests/test_markdown_parity_ratchet.py
+++ b/tests/test_markdown_parity_ratchet.py
@@ -134,6 +134,12 @@ TRACKED = set(BASELINE_NUMBER_LOSS) | CLEAN_FILINGS
 # rather than after the reroute ships.
 BASELINE_NEW_IMAGES = 252
 
+# Fixtures available when the gitignored era corpus IS present, i.e. on a
+# developer machine. The image floor above was counted over all of them, so it
+# only applies to a run that measured all of them; CI sees 61 and gets the weaker
+# assertion. Named rather than inlined so the two numbers stay legibly related.
+FULL_CORPUS_SIZE = 115
+
 
 @pytest.fixture(scope="module")
 def measured():
@@ -222,7 +228,8 @@ class TestTheRerouteStillBuysWhatItIsFor:
             "true, GH #886's premise has changed and this file needs revisiting"
         )
         # Floor, not equality: the corpus in CI is smaller than the local one.
-        expected = BASELINE_NEW_IMAGES if len(scored) >= 115 else 1
+        full_run = len(scored) >= FULL_CORPUS_SIZE
+        expected = BASELINE_NEW_IMAGES if full_run else 1
         assert new_images >= expected, (
             f"the new renderer emitted {new_images} images, expected at least "
             f"{expected}. Rerouting Filing.markdown() is supposed to FIX image "


### PR DESCRIPTION
Completes `edgartools-zqjn`. `parity_benchmark.py` (#980) asks whether the new parser finds the same **sections**; this asks whether it renders the same **document** — the gate for rerouting `Filing.markdown()` off the legacy parser and closing GH #886 (`edgartools-n45i`).

## Why a new harness rather than a diff

`Filing.markdown()` (`_filings.py:1746`) is the last public rendering method still on `edgar.files`. Rerouting it is blocked on one question: the new renderer's output is ~26% shorter on a 10-K, and that is either compaction or content loss. A character count cannot tell you which, and neither can a diff — the two renderers disagree about formatting on nearly every line, so a diff of a real 10-K is 100% noise.

So the harness measures what *survives*, and gates on **numeric recall** — the one signal no reformat can move.

## Three contaminants, all found by reading samples rather than totals

The first run said AAPL's 10-K lost 63 numbers and 3.4% of its words. It lost nothing. What was actually happening:

| | |
|---|---|
| new renderer escapes markdown punctuation | `$0\.24` splits into `0` and `24` |
| legacy renderer leaks raw HTML | literal `<div align='center'>`, 146× in that one filing |
| legacy renderer glues words across tags | `endedmarch`, `thethreemonthsendedjune` |

Two of the three are *legacy* defects that were scoring the new parser down for being correct. `comparable()` and `glued()` neutralise all three, and the unadjusted word rate stays in the report beside the adjusted one so the correction can be audited instead of trusted.

Words are reported but deliberately **not** part of the gate — as a multiset they're dominated by legacy repeating `Three Months Ended June 30` above every chunk of a split table; as a set they're too blunt to notice ABBV losing its entire exhibit index. The module docstring works through both.

## Results — 115 fixtures, 219s, offline, 0 degraded, 0 errors

| form | scored | worst number recall | retain every number |
|------|-------:|--------------------:|--------------------:|
| 8-K  | 15 | 94.9% | 13/15 |
| 20-F | 15 | 95.7% | 5/15 |
| 10-Q | 31 | 93.4% | 10/31 |
| 10-K | 54 | 85.7% | 9/54 |

**The loss is one finding, not fifty-seven.** It is overwhelmingly the exhibit index — missing values run `4.1, 10.11 … 99.1` alongside missing words `exhibit, incorporated, reference, herein`. The parser captures those tables (ABBV: 4 `TableNode`s, 6.5–9.5 KB each); both renderers then lose them, and `doc.text()` drops the exhibit-number column too. Filed as **`edgartools-2vzk`**, now blocking `n45i`. Closing it should empty most of the baseline at once.

Also quantified: the new renderer emits **252 images** across the corpus and legacy emits **0**. That is GH #886 in one number, and it is the reason the reroute is worth doing rather than merely tidy.

## The ratchet

`tests/test_markdown_parity_ratchet.py` pins per-filing loss for the 61 tracked fixtures, so this measurement cannot be lost the way the original benchmark was. Increases fail; decreases are free until a filing reaches zero, at which point it must be banked — deliberately triggering only at zero, because counts drift by one or two on any renderer change and a ratchet that needs re-banking every commit gets disabled instead of read.

It also guards the thing being bought: if legacy starts rendering images, or the new renderer stops, the test says so.

## Verification

- 7 tests pass locally (220s) and again in a **detached worktree** with `text_boundary_corpus` genuinely absent (178s), confirming all 61 tracked fixtures are still measured under CI's view rather than silently skipped — the failure mode that bit #983.
- Slow lane, confirmed deselected from `test-fast`.
- No production code touched; this is measurement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)