### PR TITLE
fix(documents): restore the exhibit index to rendered markdown and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Document.to_markdown()` dropped the exhibit index from 10-K filings.** Every exhibit row was classified as a header row — `_is_header_row` reads any date as evidence of a period column, and exhibit descriptions are full of them ("dated as of June 25, 2019") — leaving no data rows for the renderer to emit. On AbbVie's FY2024 10-K the index is back: 62 "incorporated by reference" rows, and the rendered document grows from 436,060 to 452,668 characters.
+
+- **Table cell text gained a space wherever inline markup split a value.** `_extract_text` inserted one between any two adjacent text fragments, so AbbVie's FY2024 10-K, which writes each exhibit number across two `<a>` tags, rendered `10.10` as `10.1 0` — present but unfindable. Separation now derives from block boundaries only, so `<div>Exhibit</div><div>Number</div>` still reads as two words.
+
 ## [5.46.0] - 2026-08-07
 
 ### Changed

--- a/edgar/documents/strategies/table_processing.py
+++ b/edgar/documents/strategies/table_processing.py
@@ -379,37 +379,69 @@ class TableProcessor:
 
         return text
 
+    # Elements that start a new line of text. Everything else (a, span, b, i,
+    # font, sup, ...) is inline and contributes no separator.
+    _BLOCK_TAGS = frozenset({
+        'address', 'article', 'aside', 'blockquote', 'br', 'caption', 'div',
+        'dd', 'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav',
+        'ol', 'p', 'pre', 'section', 'table', 'td', 'th', 'tr', 'ul',
+    })
+
+    @classmethod
+    def _fragments_with_block_breaks(cls, elem: HtmlElement) -> List[str]:
+        """Text fragments, with a newline marker at every block boundary.
+
+        Downstream normalisation collapses runs of whitespace, so emitting a
+        marker on both entering and leaving a block is safe and keeps the rule
+        simple: separation comes from the document structure, never from
+        guessing at a fragment boundary.
+        """
+        parts: List[str] = []
+
+        def walk(node) -> None:
+            tag = node.tag
+            is_block = isinstance(tag, str) and tag.lower() in cls._BLOCK_TAGS
+            if is_block:
+                parts.append('\n')
+            if node.text:
+                parts.append(node.text)
+            for child in node:
+                walk(child)
+                if child.tail:
+                    parts.append(child.tail)
+            if is_block:
+                parts.append('\n')
+
+        walk(elem)
+        return [p for p in parts if p]
+
     def _extract_text(self, elem: HtmlElement) -> str:
         """Extract and clean text from element."""
-        # Use itertext() to get all text fragments
-        # This preserves spaces better than text_content()
-        text_parts = []
-        for text in elem.itertext():
-            if text:
-                text_parts.append(text)
+        # Fragments, with a marker wherever a BLOCK boundary separates them.
+        #
+        # The rule that matters is which boundaries imply whitespace. A block
+        # boundary does: <div>Exhibit</div><div>Number</div> is two words. An
+        # inline one does not: markup inside a run of text is invisible to the
+        # reader, so <a>10.1</a><a>0</a> is the single token 10.10 -- which is
+        # exactly how ABBV's exhibit index numbers its exhibits, each split
+        # across two <a> tags with no whitespace between them.
+        #
+        # This used to insert a space between ANY two adjacent fragments unless
+        # one already carried whitespace, which fabricated "10.1 0" and made
+        # every such exhibit number unfindable (edgartools-2vzk). Separating on
+        # block boundaries only fixes that without regressing the word-gluing
+        # this function was written to avoid -- the opposite failure, and the one
+        # a bare text_content() would reintroduce.
+        text_parts = self._fragments_with_block_breaks(elem)
 
-        # Join parts, ensuring we don't lose spaces
-        # If a part doesn't end with whitespace and the next doesn't start with whitespace,
-        # we need to add a space between them
         if not text_parts:
             return ''
 
-        result = []
-        for i, part in enumerate(text_parts):
-            if i == 0:
-                result.append(part)
-            else:
-                prev_part = text_parts[i-1]
-                # Check if we need to add a space between parts
-                # Don't add space if previous ends with space or current starts with space
-                if prev_part and part:
-                    if not prev_part[-1].isspace() and not part[0].isspace():
-                        # Check for punctuation that shouldn't have space before it
-                        if part[0] not in ',.;:!?%)]':
-                            result.append(' ')
-                result.append(part)
-
-        text = ''.join(result)
+        # Concatenated verbatim: the separators are already in text_parts, as
+        # newline markers at block boundaries. Nothing is inserted here, so an
+        # inline split cannot invent whitespace that the source did not have.
+        text = ''.join(text_parts)
 
         # Replace entities
         for entity, replacement in self.ENTITY_REPLACEMENTS.items():
@@ -470,6 +502,40 @@ class TableProcessor:
         pattern = '|'.join(f'(?:{p})' for p in patterns)
         return re.compile(pattern, re.IGNORECASE)
 
+    # A column header is a label, not a sentence. Genuine header cells in the
+    # fixture corpus sit well under this: median 24 characters, 75th percentile
+    # 54, and even a wide "Three Months Ended June 30, 2025 and 2024" is ~42.
+    # Prose cells are an order of magnitude longer, so the threshold sits in an
+    # empty band rather than near either population.
+    PROSE_CELL_CHARS = 100
+
+    @staticmethod
+    def _has_prose_cell(cells: List[HtmlElement]) -> bool:
+        """Does any cell hold a sentence rather than a label?
+
+        Used to veto ONE header signal: a bare date appearing anywhere in the
+        row. That signal exists to catch period columns like "Three Months Ended
+        June 30, 2025", but the pattern also matches a date buried in ordinary
+        prose — and SEC exhibit indexes are full of it ("...dated as of June 25,
+        2019, between AbbVie Inc. and ..."). Every row of ABBV's exhibit index
+        matched, so the whole table was classified as header rows, `rows` came
+        back nearly empty, and the markdown renderer combined 30 "header" rows
+        into a single line: the exhibit index vanished from the rendered output
+        (edgartools-2vzk).
+
+        Deliberately scoped to that one branch. A row with real ``<th>`` tags,
+        units notation, or genuine multi-year columns is still a header no matter
+        how long its cells are; length only breaks the tie when the sole evidence
+        was an incidental date.
+
+        Per-cell rather than per-row, because a wide table's header row is long
+        in total while each individual label stays short.
+        """
+        return any(
+            len(_text_content(cell).strip()) > TableProcessor.PROSE_CELL_CHARS
+            for cell in cells
+        )
+
     def _is_header_row(self, tr: HtmlElement) -> bool:
         """Detect if row is likely a header row in SEC filings."""
         own_cells = self._own_cells(tr)
@@ -485,6 +551,11 @@ class TableProcessor:
         # Get row text for analysis
         row_text = _text_content(tr)
         row_text_lower = row_text.lower()
+
+        # Every date- and year-derived signal below is evidence only when the row
+        # reads as labels. In prose those dates are incidental — see
+        # _has_prose_cell — so compute the veto once and apply it to each.
+        has_prose = self._has_prose_cell(cells)
 
         # Check for date ranges with financial data (Oracle Table 6 pattern)
         # Date ranges like "March 1, 2024—March 31, 2024" should be data rows, not headers
@@ -514,7 +585,7 @@ class TableProcessor:
                 # Not a multi-year comparison header
                 pass  # Don't return True
             # Multiple different years suggest multi-year comparison header
-            elif 'total' not in row_text_lower[:20]:  # Check first 20 chars
+            elif 'total' not in row_text_lower[:20] and not has_prose:
                 return True
 
         # Enhanced year detection - check individual cells for year patterns
@@ -533,7 +604,7 @@ class TableProcessor:
 
         # If we have multiple year cells or year + date phrases, likely a header
         if year_cells >= 2 or (year_cells >= 1 and date_phrases >= 1):
-            if 'total' not in row_text_lower[:20]:
+            if 'total' not in row_text_lower[:20] and not has_prose:
                 return True
 
         # Check for comprehensive financial period patterns (from old parser)
@@ -542,7 +613,7 @@ class TableProcessor:
             # Additional validation: ensure it's not a data row with period text
             # Check for absence of strong data indicators
             data_pattern = r'(?:\$\s*\d|\d+(?:,\d{3})+|\d+\s*[+\-*/]\s*\d+|\(\s*\d+(?:,\d{3})*\s*\))'
-            if not re.search(data_pattern, row_text):
+            if not re.search(data_pattern, row_text) and not has_prose:
                 return True
 
         # Check for units notation (in millions, thousands, billions)

--- a/tests/issues/regression/test_issue_2vzk_exhibit_index.py
+++ b/tests/issues/regression/test_issue_2vzk_exhibit_index.py
@@ -1,0 +1,135 @@
+"""The exhibit index survives into rendered markdown and text (edgartools-2vzk).
+
+Found by the markdown-parity harness (``edgartools-zqjn``), which measured the
+new renderer losing numeric content that the legacy one kept. Almost all of it
+was this: SEC exhibit indexes vanishing from ``Document.to_markdown()``.
+
+TWO DEFECTS, ONE SYMPTOM. Both are asserted here because either alone leaves the
+exhibit index unusable.
+
+1. *Every row classified as a header.* ``_is_header_row`` treats a date anywhere
+   in a row as evidence of a period column ("Three Months Ended June 30, 2025").
+   Exhibit descriptions are full of incidental dates — "...dated as of June 25,
+   2019, between AbbVie Inc. and ..." — so every row matched, ``TableNode.rows``
+   came back nearly empty, and the markdown renderer combined 30-odd "header"
+   rows into a single line. The table disappeared.
+
+2. *Fabricated whitespace inside exhibit numbers.* ABBV splits each number across
+   two anchors — ``<a>10.1</a><a>0</a>`` with nothing between them — and
+   ``_extract_text`` inserted a space between any two adjacent text fragments.
+   ``10.10`` came out as ``10.1 0``, which is worse than missing: the figure is
+   present but wrong, so neither a reader nor a search finds it.
+
+WHY IT MATTERS. The exhibit index is the route from a 10-K to its material
+contracts, and "incorporated by reference" rows are the only place some
+agreements are named at all. Dropping it silently from markdown means every RAG
+pipeline built on that output is blind to a filing's exhibits.
+
+Ground truth is read off the filing itself: ABBV's FY2024 10-K exhibit index runs
+2.1 through 32.1, and the values asserted here were confirmed by hand against the
+rendered document, not copied from parser output.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from edgar.documents.config import ParserConfig
+from edgar.documents.parser import HTMLParser
+
+pytestmark = pytest.mark.fast
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "html" / "abbv" / "10k"
+
+
+@pytest.fixture(scope="module")
+def abbv_document():
+    fixtures = sorted(FIXTURE_DIR.glob("*.html"))
+    if not fixtures:
+        pytest.skip(f"ABBV 10-K fixture not present in {FIXTURE_DIR}")
+    html = fixtures[0].read_text(errors="ignore")
+    return HTMLParser(ParserConfig(form="10-K")).parse(html)
+
+
+class TestTheExhibitIndexReachesTheOutput:
+
+    def test_exhibit_numbers_render_in_markdown(self, abbv_document):
+        """The whole point: you can find an exhibit by its number."""
+        markdown = abbv_document.to_markdown()
+        missing = [n for n in ("2.1", "4.8", "10.10", "10.11", "10.19", "32.1")
+                   if n not in markdown]
+        assert not missing, (
+            f"exhibit numbers absent from rendered markdown: {missing}. The "
+            "exhibit index is how a 10-K points at its material contracts."
+        )
+
+    def test_exhibit_descriptions_render_in_markdown(self, abbv_document):
+        markdown = abbv_document.to_markdown()
+        assert "Exhibit Description" in markdown
+        assert "Transaction Agreement" in markdown
+        assert "incorporated by reference" in markdown.lower()
+
+    def test_exhibit_numbers_render_in_text(self, abbv_document):
+        """``text()`` lost the exhibit-NUMBER column while keeping descriptions.
+
+        Asserted separately from markdown because the two renderers failed
+        differently — markdown dropped the table, text kept it but dropped a
+        column — and a fix for one need not fix the other.
+        """
+        text = abbv_document.text()
+        assert "10.10" in text
+        assert "10.11" in text
+        assert "Exhibit Description" in text
+
+
+class TestTheExhibitTableIsStructuredNotSquashed:
+
+    def test_exhibit_tables_have_data_rows(self, abbv_document):
+        """Header/data split, the mechanism behind defect 1.
+
+        Before the fix the first exhibit table reported 30+ header rows and 2
+        data rows. Asserting the shape rather than only the rendered string
+        means a renderer that papered over the misclassification would not make
+        this pass.
+        """
+        exhibit_tables = [t for t in abbv_document.tables
+                          if "Exhibit Description" in (t.text() or "")]
+        assert exhibit_tables, "no exhibit table found in the parsed document"
+
+        for table in exhibit_tables:
+            headers = table.headers or []
+            rows = table.rows or []
+            assert len(rows) > len(headers), (
+                f"exhibit table has {len(headers)} header rows and {len(rows)} "
+                "data rows — its data rows are being classified as headers"
+            )
+
+
+class TestNumbersAreNotSplitByFabricatedWhitespace:
+
+    def test_no_space_is_inserted_inside_an_exhibit_number(self, abbv_document):
+        """Defect 2, asserted as the corruption rather than the absence.
+
+        ``10.1 0`` would satisfy a naive "is 10.1 present" check, so the
+        assertion has to name the broken form.
+        """
+        markdown = abbv_document.to_markdown()
+        split = re.findall(r"\b\d{1,2}\.\d\s+\d\b", markdown)
+        assert not split, (
+            f"whitespace fabricated inside numbers: {sorted(set(split))[:10]}. "
+            "Adjacent inline elements must not be separated by a space."
+        )
+
+    def test_block_boundaries_still_separate_words(self, abbv_document):
+        """The converse, so the fix cannot be 'never insert whitespace'.
+
+        Word-gluing is the opposite failure and the reason the original
+        fragment-joining code existed. The header cell is built from two
+        separate block elements and must not collapse to 'ExhibitNumber'.
+        """
+        markdown = abbv_document.to_markdown()
+        assert "ExhibitNumber" not in markdown
+        assert "ExhibitDescription" not in markdown
+        assert re.search(r"Exhibit\s+Number", markdown), (
+            "the two-block header cell lost its separator entirely"
+        )

--- a/tests/test_markdown_parity_ratchet.py
+++ b/tests/test_markdown_parity_ratchet.py
@@ -49,72 +49,76 @@ pytestmark = pytest.mark.slow
 # Distinct numeric values each filing renders in legacy markdown and NOT in new,
 # measured 2026-08-07 on main (4bb2c3e0). Tracked fixtures only.
 #
-# The shape of this list is one finding, not fifty-seven. The dominant cluster is
-# the exhibit index — missing values run 4.1, 10.11, 10.12 ... 99.1, i.e. exhibit
-# numbers, and they come with 'exhibit', 'incorporated', 'reference' and 'herein'
-# in the word shortfall. The parser captures those tables (ABBV: 4 TableNodes,
-# 6.5-9.5 KB each); both renderers then lose them. That is edgartools-2vzk, and
-# closing it should empty most of this dict at once.
+# REBASELINED 2026-08-07 after edgartools-2vzk. Fixing the exhibit index took the
+# corpus-wide total from 1965 to 1191 distinct values (-39%) with zero filings
+# regressing, and six tracked filings now lose nothing at all.
 #
-# unh/10k at 232 is the extreme of the same thing, not a separate problem.
+# It did NOT empty this dict, which the pre-fix note predicted it would. What is
+# left is a different and more mixed population, and the largest part of it looks
+# like it is not our bug: unh/10k's residual is values such as 10000.55 and
+# 10001.15, i.e. LEGACY running two numbers together, the numeric counterpart of
+# the word-gluing that glued() already discounts. Extending that discount to
+# numbers is the next refinement to the harness, and would likely drop this
+# baseline again without any parser change.
+#
+# The real remaining signal is the executive-officers table ('executive',
+# 'officer', 'president' in the word shortfalls, e.g. adbe/10k).
 BASELINE_NUMBER_LOSS = {
     ("8-K", "0000887919-21-000012"): 2,
     ("20-F", "0001062993-16-008650"): 42,
-    ("20-F", "0001062993-21-003193"): 34,
+    ("20-F", "0001062993-21-003193"): 24,
     ("10-Q", "aapl/10q"): 10,
-    ("10-Q", "ba/10q"): 5,
+    ("10-Q", "ba/10q"): 1,
     ("10-Q", "gbdc/10q"): 24,
     ("10-Q", "gs/10q"): 6,
     ("10-Q", "hubs/10q"): 18,
     ("10-Q", "ibm/10q"): 6,
     ("10-Q", "jnj/10q"): 1,
     ("10-Q", "jpm/10q"): 6,
-    ("10-Q", "ko/10q"): 47,
+    ("10-Q", "ko/10q"): 2,
     ("10-Q", "msft/10q"): 68,
     ("10-Q", "nflx/10q"): 6,
-    ("10-Q", "nvda/10q"): 4,
-    ("10-Q", "pg/10q"): 29,
+    ("10-Q", "nvda/10q"): 2,
+    ("10-Q", "pg/10q"): 24,
     ("10-Q", "tsla/10q"): 4,
     ("10-Q", "unp/10q"): 2,
-    ("10-Q", "xom/10q"): 1,
-    ("10-K", "915358/10k"): 55,
+    ("10-K", "915358/10k"): 30,
     ("10-K", "aapl/10k"): 1,
-    ("10-K", "abbv/10k"): 38,
+    ("10-K", "abbv/10k"): 4,
     ("10-K", "adbe/10k"): 16,
-    ("10-K", "amzn/10k"): 66,
-    ("10-K", "axp/10k"): 36,
-    ("10-K", "ba/10k"): 51,
+    ("10-K", "amzn/10k"): 34,
+    ("10-K", "axp/10k"): 18,
+    ("10-K", "ba/10k"): 14,
     ("10-K", "bac/10k"): 5,
-    ("10-K", "c/10k"): 6,
-    ("10-K", "cat/10k"): 62,
-    ("10-K", "crm/10k"): 30,
-    ("10-K", "cvx/10k"): 28,
-    ("10-K", "gbdc/10k"): 72,
+    ("10-K", "c/10k"): 2,
+    ("10-K", "cat/10k"): 17,
+    ("10-K", "crm/10k"): 27,
+    ("10-K", "cvx/10k"): 4,
+    ("10-K", "gbdc/10k"): 67,
     ("10-K", "googl/10k"): 2,
     ("10-K", "gs/10k"): 9,
     ("10-K", "hd/10k"): 32,
     ("10-K", "hubs/10k"): 24,
-    ("10-K", "ibm/10k"): 27,
-    ("10-K", "jnj/10k"): 12,
-    ("10-K", "jpm/10k"): 6,
-    ("10-K", "ko/10k"): 86,
-    ("10-K", "ma/10k"): 20,
+    ("10-K", "jnj/10k"): 7,
+    ("10-K", "jpm/10k"): 1,
+    ("10-K", "ko/10k"): 3,
+    ("10-K", "ma/10k"): 3,
     ("10-K", "meta/10k"): 53,
-    ("10-K", "ms/10k"): 16,
+    ("10-K", "ms/10k"): 6,
     ("10-K", "msft/10k"): 57,
-    ("10-K", "nflx/10k"): 40,
-    ("10-K", "nke/10k"): 26,
-    ("10-K", "nvda/10k"): 18,
+    ("10-K", "nflx/10k"): 21,
+    ("10-K", "nke/10k"): 8,
+    ("10-K", "nvda/10k"): 16,
     ("10-K", "orcl/10k"): 9,
-    ("10-K", "pfe/10k"): 33,
-    ("10-K", "rf/10k"): 44,
-    ("10-K", "tsla/10k"): 30,
-    ("10-K", "unh/10k"): 232,
+    ("10-K", "pfe/10k"): 3,
+    ("10-K", "rf/10k"): 4,
+    ("10-K", "tsla/10k"): 22,
+    ("10-K", "unh/10k"): 186,
     ("10-K", "unp/10k"): 12,
-    ("10-K", "v/10k"): 29,
+    ("10-K", "v/10k"): 13,
     ("10-K", "wfc/10k"): 15,
-    ("10-K", "wmt/10k"): 23,
-    ("10-K", "xom/10k"): 2,
+    ("10-K", "wmt/10k"): 14,
+    ("10-K", "xom/10k"): 1,
 }
 
 # Tracked filings that already lose nothing. Kept as a separate set rather than
@@ -124,6 +128,8 @@ CLEAN_FILINGS = {
     ("8-K", "0001104659-03-004925"),
     ("8-K", "0001437749-16-028287"),
     ("20-F", "0000928385-01-500187"),
+    ("10-Q", "xom/10q"),
+    ("10-K", "ibm/10k"),
     ("10-K", "pg/10k"),
 }
 

--- a/tests/test_section_parity_ratchet.py
+++ b/tests/test_section_parity_ratchet.py
@@ -64,9 +64,18 @@ pytestmark = pytest.mark.slow
 #
 # Entries keyed on an accession number come from the untracked era corpus and
 # are unmeasurable in CI; the ticker-keyed ones are tracked and always run.
+#
+# Banked 2026-08-07: ("8-K", "0001437749-16-028287") Item 2 closed as a side
+# effect of edgartools-2vzk. That filing puts its heading — "Item 2.02 Results of
+# Operations and Financial Condition." — inside a <table> cell (verified), so it
+# was read through the same _extract_text that was fabricating a space between
+# adjacent inline elements. The new parser now resolves item_202.
+#
+# A markdown-rendering fix closing a section-extraction gap is not a coincidence:
+# both harnesses read cell text through that one extractor. Worth remembering
+# when triaging the remaining dt1f gaps — some may be extraction, not detection.
 BASELINE_GAPS = {
     ("8-K", "0001104659-03-004925"): ["9"],
-    ("8-K", "0001437749-16-028287"): ["2"],
     ("10-K", "0000927356-01-000369"): ["7"],
     ("10-K", "0000950153-99-001234"): ["1", "10", "11", "12", "13", "14", "2",
                                        "3", "4", "5", "6", "7", "7A", "8", "9"],


### PR DESCRIPTION
Closes `edgartools-2vzk`. Found by the markdown-parity harness from #992, which is also how the result is measured.

The exhibit index is how a 10-K points at its material contracts, and "incorporated by reference" rows are the only place some agreements are named at all. It was silently absent from `Document.to_markdown()`, so anything built on that output — RAG pipelines especially — was blind to a filing's exhibits.

## Two defects, one symptom

Either alone leaves the index unusable, so both are fixed here.

**1. Every exhibit row was classified as a header row.** `_is_header_row` treats a date anywhere in a row as evidence of a period column (`Three Months Ended June 30, 2025`). Exhibit descriptions are full of incidental dates — *"dated as of June 25, 2019, between AbbVie Inc. and …"* — so every row matched, `TableNode.rows` came back nearly empty, and the markdown renderer combined 30-odd "header" rows into one line.

ABBV's first exhibit table: **30+ headers / 2 rows → 1 header / 14 rows.**

The veto is scoped to the date- and year-derived signals only. A row with real `<th>` tags, units notation, or genuine multi-year columns is still a header however long its cells are — length only breaks the tie when the sole evidence was an incidental date. The threshold sits in an empty band: genuine header cells in the corpus have a median length of 24 characters and a 75th percentile of 54; prose cells run to hundreds.

**2. `_extract_text` fabricated whitespace inside values.** It inserted a space between any two adjacent text fragments unless one already carried whitespace. ABBV writes each exhibit number across two anchors — `<a>10.1</a><a>0</a>`, nothing between them — so `10.10` rendered as `10.1 0`. That is worse than missing: present but unfindable.

Separation now derives from block boundaries, which fixes it without reintroducing the word-gluing the fragment-joining existed to avoid — the opposite failure, and the one a bare `text_content()` would bring back. `<div>Exhibit</div><div>Number</div>` still reads as two words, and a test asserts that converse.

## Measured, over the full 115-fixture parity corpus

Distinct numeric values lost against the legacy renderer: **1965 → 1191 (−39%)**, with **zero filings regressing**. Six tracked filings now lose nothing at all.

| filing | before | after |
|---|---:|---:|
| ko/10k | 86 | 3 |
| cat/10k | 62 | 17 |
| ba/10k | 51 | 14 |
| rf/10k | 44 | 4 |
| abbv/10k | 38 | 4 |

**It does not empty the baseline, which the pre-fix note predicted it would.** What remains is a more mixed population, and the largest single piece looks like it isn't ours: `unh/10k`'s residual is values such as `10000.55` — *legacy* running two numbers together, the numeric counterpart of the word-gluing the harness already discounts. Extending that discount to numbers would likely drop the baseline again with no parser change. The real remaining signal is the executive-officers table.

Both ratchets are rebaselined in this PR.

## A section gap closed as a side effect

8-K `0001437749-16-028287` puts its heading — `Item 2.02 Results of Operations and Financial Condition.` — inside a `<table>` cell (verified), so it was read through the same extractor. The new parser now resolves `item_202`, and `test_section_parity_ratchet.py` demanded it be banked in the same commit, which it is.

Worth remembering when triaging the remaining `dt1f` gaps: both parity harnesses read cell text through that one extractor, so some may be extraction rather than detection.

## Verification

- `test-fast`: **4474 passed, 4 skipped, 1 xfailed** — identical to the 5.46.0 baseline, from a change touching every table cell.
- New `tests/issues/regression/test_issue_2vzk_exhibit_index.py`: 6 tests, **5 fail without the fix**. The sixth is the converse word-gluing guard, which correctly passes both ways.
- Markdown parity ratchet: 7 passed, rebaselined. Section parity ratchet: 6 passed, gap banked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)