### PR TITLE
fix(documents): render images in Filing.markdown() via edgar.documents (#886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`Filing.markdown()` and `Attachment.markdown()` now render through `edgar.documents`.** They were the last public rendering methods still on the legacy `edgar.files` pipeline, which has no image node at all — `MarkdownRenderer.render` handles text blocks, tables, headings and page breaks, and drops everything else. Every `<img>` in every filing vanished silently. NVIDIA's FY2026 10-K now renders both of its images, including the Item 5 stock performance graph whose five-year return comparison exists only as a chart. Relative `src` values are resolved against the filing's SEC archive directory, so the markdown carries working absolute links rather than bare sibling file names. Output also differs where the two renderers disagree on tables; a parity ratchet pins the numeric content of both. (GH #886)
+
+### Deprecated
+
+- **`include_page_breaks` and `start_page_number` on `Filing.markdown()` and `Attachment.markdown()`.** Page-break rendering exists only in the legacy renderer, so passing `include_page_breaks=True` routes the whole document through it and forfeits images and the newer table rendering — the flag selects a renderer, not a feature. It still works and now emits a `DeprecationWarning`; both parameters go in 6.0 alongside `edgar.files`. There is no replacement: the `edgar.documents` builder treats page-break `<hr>`s and page-number containers as print chrome and discards them.
+
 ### Fixed
 
 - **`Document.to_markdown()` dropped the exhibit index from 10-K filings.** Every exhibit row was classified as a header row — `_is_header_row` reads any date as evidence of a period column, and exhibit descriptions are full of them ("dated as of June 25, 2019") — leaving no data rows for the renderer to emit. On AbbVie's FY2024 10-K the index is back: 62 "incorporated by reference" rows, and the rendered document grows from 436,060 to 452,668 characters.

--- a/docs/api/filing.md
+++ b/docs/api/filing.md
@@ -598,13 +598,18 @@ for exhibit in filing.exhibits:
 ```python
 filing = company.get_filings(form="10-K").latest()
 
-# Export to markdown
-md = filing.markdown(include_page_breaks=True)
+# Export to markdown — tables, links and images all preserved
+md = filing.markdown()
 
 # Save for LLM processing
 with open("filing_for_analysis.md", "w") as f:
     f.write(md)
 ```
+
+!!! warning "`include_page_breaks` is deprecated"
+
+    It routes the document through the legacy renderer, which drops images.
+    Removed in 6.0.
 
 ## Error Handling
 

--- a/docs/guides/filing-attachments.md
+++ b/docs/guides/filing-attachments.md
@@ -60,9 +60,17 @@ if attachment.is_html():
     print(markdown_content)
 ```
 
-The `markdown()` method returns `None` for non-HTML attachments, so you can safely call it on any attachment.
+The `markdown()` method returns `None` for non-HTML attachments, so you can safely call it on any attachment. Images are rendered as Markdown image links with absolute SEC archive URLs, resolved against the attachment's own URL.
 
 #### Page Break Delimiter Support
+
+!!! warning "Deprecated — removed in 6.0"
+
+    Page-break rendering exists only in the legacy renderer, so
+    `include_page_breaks=True` routes the whole document through it. That
+    renderer drops every image and formats tables differently from the default
+    path, which is why the flag is going away rather than being carried
+    forward. Prefer `attachment.markdown()`.
 
 The `markdown()` method supports optional page break delimiters to help you understand document structure:
 

--- a/docs/guides/working-with-filing.md
+++ b/docs/guides/working-with-filing.md
@@ -166,11 +166,17 @@ with open("filing.md", "w") as f:
     f.write(md)
 ```
 
-With page breaks:
+Images are rendered as Markdown image links with absolute SEC archive URLs, so
+charts that exist only as images — a 10-K's stock performance graph, for example
+— survive into the export and stay viewable.
 
-```python
-md = filing.markdown(include_page_breaks=True, start_page_number=1)
-```
+!!! warning "`include_page_breaks` is deprecated"
+
+    `filing.markdown(include_page_breaks=True, start_page_number=1)` inserts
+    `{N}----` delimiters, but page-break rendering exists only in the legacy
+    renderer, so the flag routes the whole document through it — and that
+    renderer drops every image and formats tables differently. It will be
+    removed in 6.0. Prefer `filing.markdown()`.
 
 ### Get XML
 
@@ -489,8 +495,8 @@ for filing in filings:
 company = Company("NVDA")
 filing = company.get_filings(form="10-K").latest()
 
-# Export to markdown
-md = filing.markdown(include_page_breaks=True)
+# Export to markdown — tables, links and images all preserved
+md = filing.markdown()
 
 # Save for processing
 with open("nvidia_10k_for_analysis.md", "w") as f:

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -310,6 +310,7 @@ against these; each will get a section above when it lands.
 | Change | What to expect |
 |---|---|
 | `edgar.files` removal | The legacy parser package and `chunked_document` go. Use `edgar.documents`. |
+| `include_page_breaks` on `markdown()` | Already deprecated in 5.x: `Filing.markdown()` and `Attachment.markdown()` render through `edgar.documents`, but `include_page_breaks=True` still falls back to the legacy renderer — which drops images. Both it and `start_page_number` go with `edgar.files`. There is no replacement: the new builder treats page-break `<hr>`s and page-number containers as print chrome and discards them. |
 | `httpx` → `httpx2` | Exception namespace moves; code catching `httpx.*` will need updating. |
 | Public API definition | `__all__`, stable import paths, and internals made private — some currently-importable names will move. |
 | Unified error policy | Silent `None` returns become typed exceptions from an `edgar.exceptions` hierarchy. |

--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import pickle
 import re
+import warnings
 import webbrowser
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -54,6 +55,8 @@ from edgar.dates import InvalidDateException
 from edgar.display.formatting import accession_number_text, display_size
 from edgar.display.styles import print_info, print_warning
 from edgar.documents import HTMLParser, ParserConfig
+from edgar.documents.exceptions import ParsingError
+from edgar.files._deprecation import PAGE_BREAK_DEPRECATION as _PAGE_BREAK_DEPRECATION
 from edgar.files.html_documents import get_clean_html
 from edgar.files.htmltools import html_sections
 from edgar.files.markdown import to_markdown
@@ -1747,16 +1750,42 @@ class Filing:
         """
         Return the markdown version of this filing html
 
+        Rendered by ``edgar.documents``, so images survive into the markdown
+        (GH #886) and tables render through the same pipeline as ``text()``,
+        ``view()`` and the section extractors. Relative image ``src`` values are
+        resolved against the filing's SEC archive directory, so the markdown is
+        a self-contained document with working image links.
+
         Args:
-            include_page_breaks: If True, include page break delimiters in the markdown
-            start_page_number: Starting page number for page break markers (default: 0)
+            include_page_breaks: If True, include ``{N}----`` page break
+                delimiters in the markdown. **Deprecated.** Page breaks exist
+                only in the legacy ``edgar.files`` renderer, so passing True
+                routes the whole document through it and forfeits images and
+                the newer table rendering. Removed in 6.0.
+            start_page_number: Starting page number for page break markers
+                (default: 0). Only meaningful with ``include_page_breaks=True``.
         """
         html = self.html()
         if html:
-            clean_html = get_clean_html(html)
-            if clean_html:
-                markdown_result = to_markdown(clean_html, include_page_breaks=include_page_breaks,
-                                              start_page_number=start_page_number)
+            if include_page_breaks:
+                warnings.warn(_PAGE_BREAK_DEPRECATION.format(cls="Filing"),
+                              DeprecationWarning, stacklevel=2)
+                clean_html = get_clean_html(html)
+                if clean_html:
+                    markdown_result = to_markdown(clean_html, include_page_breaks=True,
+                                                  start_page_number=start_page_number)
+                    if markdown_result:
+                        return markdown_result
+            else:
+                try:
+                    document = HTMLParser(ParserConfig(form=self.form)).parse(html)
+                    # Base for resolving relative image src. Trailing slash matters:
+                    # urljoin() drops the last path segment without it. base_dir is a
+                    # pure string property, so this costs no request.
+                    document.metadata.url = f"{self.base_dir}/"
+                    markdown_result = document.to_markdown()
+                except ParsingError:
+                    markdown_result = None
                 if markdown_result:
                     return markdown_result
         text_content = self.text()

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -6,6 +6,7 @@ import signal
 import socketserver
 import tempfile
 import time
+import warnings
 import webbrowser
 import zipfile
 
@@ -30,6 +31,7 @@ from rich.text import Text
 
 from edgar.config import SEC_BASE_URL
 from edgar.core import binary_extensions, has_html_content, text_extensions
+from edgar.files._deprecation import PAGE_BREAK_DEPRECATION
 from edgar.files.html_documents import get_clean_html
 from edgar.files.markdown import to_markdown
 from edgar.httpclient import async_http_client
@@ -440,9 +442,17 @@ class Attachment:
         """
         Convert the attachment to markdown format if it's HTML content.
 
+        Rendered by ``edgar.documents``, the same pipeline as ``Filing.markdown()``,
+        so images survive (GH #886) with their ``src`` resolved against this
+        attachment's URL.
+
         Args:
-            include_page_breaks: If True, include page break delimiters in the markdown
-            start_page_number: Starting page number for page break markers (default: 0)
+            include_page_breaks: If True, include ``{N}----`` page break
+                delimiters in the markdown. **Deprecated** — routes the document
+                through the legacy ``edgar.files`` renderer and forfeits images.
+                Removed in 6.0.
+            start_page_number: Starting page number for page break markers
+                (default: 0). Only meaningful with ``include_page_breaks=True``.
 
         Returns:
             None if the attachment is not HTML or cannot be converted.
@@ -458,12 +468,25 @@ class Attachment:
         if not has_html_content(content):
             return None
 
-        # Use the same approach as Filing.markdown() but with page break support
-        clean_html = get_clean_html(content)
-        if clean_html:
-            return to_markdown(clean_html, include_page_breaks=include_page_breaks, start_page_number=start_page_number)
+        if include_page_breaks:
+            warnings.warn(PAGE_BREAK_DEPRECATION.format(cls="Attachment"),
+                          DeprecationWarning, stacklevel=2)
+            clean_html = get_clean_html(content)
+            if clean_html:
+                return to_markdown(clean_html, include_page_breaks=True,
+                                   start_page_number=start_page_number)
+            return None
 
-        return None
+        from edgar.documents import HTMLParser, ParserConfig
+        from edgar.documents.exceptions import ParsingError
+        try:
+            document = HTMLParser(ParserConfig()).parse(content)
+        except ParsingError:
+            return None
+        # Base for resolving relative image src. self.url ends in the document
+        # file name, so urljoin() resolves siblings in the same archive folder.
+        document.metadata.url = self.url
+        return document.to_markdown() or None
 
     def __rich__(self):
         icon = get_file_icon(self.document_type, self.sequence_number, self.document)
@@ -845,7 +868,9 @@ class Attachments:
         Convert all HTML attachments to markdown format.
 
         Args:
-            include_page_breaks: If True, include page break delimiters in the markdown
+            include_page_breaks: If True, include page break delimiters in the
+                markdown. **Deprecated** — see :meth:`Attachment.markdown`.
+                Removed in 6.0.
             start_page_number: Starting page number for page break markers (default: 0)
 
         Returns:

--- a/edgar/files/_deprecation.py
+++ b/edgar/files/_deprecation.py
@@ -15,6 +15,21 @@ notice is preserved where it matters.
 import inspect
 import warnings
 
+#: Emitted by ``Filing.markdown()`` and ``Attachment.markdown()`` when a caller
+#: asks for page breaks. ``{cls}`` is the class name of the call site. Page
+#: break rendering lives only in ``edgar.files.markdown``; the ``edgar.documents``
+#: builder treats page-break ``<hr>``s and page-number containers as print
+#: chrome and drops them (``strategies/document_builder.py``). So the flag does
+#: not select a feature, it selects a whole renderer — which is the reason it is
+#: going away rather than being ported.
+PAGE_BREAK_DEPRECATION = (
+    "{cls}.markdown(include_page_breaks=True) renders through the legacy "
+    "edgar.files pipeline, which drops images and formats tables differently "
+    "from the default path. It is deprecated and will be removed in "
+    "edgartools 6.0; call {cls}.markdown() without the flag for the supported "
+    "renderer."
+)
+
 # Modules that are transparent to the caller check: the deprecated
 # modules themselves and (for dataclass-generated __init__ trampolines)
 # the standard library's dataclasses module. The dataclass machinery

--- a/tests/issues/regression/test_issue_886_markdown_images.py
+++ b/tests/issues/regression/test_issue_886_markdown_images.py
@@ -1,0 +1,202 @@
+"""``Filing.markdown()`` renders images, with resolvable URLs (GH #886, edgartools-n45i).
+
+WHAT WAS BROKEN. ``Filing.markdown()`` was the last public rendering method still
+on the legacy ``edgar.files`` pipeline while ``text()``, ``view()`` and the
+section extractors had all moved to ``edgar.documents``. The legacy renderer has
+no image node at all: ``MarkdownRenderer.render`` in ``edgar/files/markdown.py``
+handles ``text_block``, ``table``, ``heading`` and ``page_break``, and anything
+else renders as nothing. Every ``<img>`` in every filing was dropped silently.
+
+The reporter's example is the one pinned here — NVIDIA's 10-K Item 5 "Stock
+Performance Graph", which is a chart image. The five-year total-return comparison
+against the S&P 500 and the Nasdaq 100 exists *only* as that image; there is no
+table beside it. So the legacy markdown of Item 5 asserted that a performance
+comparison was presented and then showed nothing, which is worse for a RAG
+pipeline than an outright gap.
+
+TWO THINGS ARE ASSERTED, AND THE SECOND IS THE EASY ONE TO LOSE. Rendering
+``![alt](src)`` is not sufficient, because the ``src`` in filing HTML is a bare
+sibling file name — ``nvda-20250126_g2.jpg``. Emitted verbatim it resolves
+against wherever the markdown ends up, which is nowhere. The reroute sets
+``document.metadata.url`` to the filing's archive directory so the renderer's
+``urljoin`` produces an absolute SEC URL. A refactor that keeps the image node
+but forgets the base URL passes a naive "are there images?" test and still ships
+markdown with dead links, so the absolute form is asserted explicitly.
+
+GROUND TRUTH. NVIDIA's FY2025 10-K (accession 0001045810-25-000023, filed
+2025-02-26) carries exactly two images: the corporate logo on the cover
+(``nvda-20250126_g1.jpg``) and the Item 5 stock performance graph
+(``nvda-20250126_g2.jpg``). Both file names were read off the fixture HTML, and
+the archive directory follows from the accession number. Verified against the
+live filing 2026-08-08: both URLs return HTTP 200 image/jpeg.
+"""
+import re
+import warnings
+from pathlib import Path
+from urllib.parse import urljoin
+
+import pytest
+
+from edgar.documents.config import ParserConfig
+from edgar.documents.parser import HTMLParser
+
+FIXTURE = (Path(__file__).parent.parent.parent
+           / "fixtures" / "html" / "nvda" / "10k" / "nvda-10-k-2025-02-26.html")
+
+# The archive directory for accession 0001045810-25-000023 under CIK 1045810.
+# Trailing slash is load-bearing: urljoin() discards the last path segment
+# without it, and the images would resolve one directory too high.
+NVDA_ARCHIVE_DIR = "https://www.sec.gov/Archives/edgar/data/1045810/000104581025000023/"
+
+COVER_LOGO = "nvda-20250126_g1.jpg"
+STOCK_PERFORMANCE_GRAPH = "nvda-20250126_g2.jpg"
+
+MARKDOWN_IMAGE = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<src>[^)]*)\)")
+
+
+@pytest.fixture(scope="module")
+def nvda_markdown():
+    """Render the fixture exactly as the rerouted ``Filing.markdown()`` does."""
+    if not FIXTURE.exists():
+        pytest.skip(f"NVDA 10-K fixture not present at {FIXTURE}")
+    document = HTMLParser(ParserConfig(form="10-K")).parse(
+        FIXTURE.read_text(errors="ignore"))
+    document.metadata.url = NVDA_ARCHIVE_DIR
+    return document.to_markdown()
+
+
+@pytest.mark.fast
+class TestImagesSurviveIntoMarkdown:
+
+    def test_both_images_are_rendered(self, nvda_markdown):
+        """GH #886: the legacy renderer emitted zero of these."""
+        sources = [m.group("src") for m in MARKDOWN_IMAGE.finditer(nvda_markdown)]
+        missing = [name for name in (COVER_LOGO, STOCK_PERFORMANCE_GRAPH)
+                   if not any(name in src for src in sources)]
+        assert not missing, (
+            f"images absent from rendered markdown: {missing}. Rendered image "
+            f"sources were: {sources}"
+        )
+
+    def test_the_stock_performance_graph_is_the_one_that_matters(self, nvda_markdown):
+        """Item 5's five-year return comparison exists only as this image."""
+        assert STOCK_PERFORMANCE_GRAPH in nvda_markdown, (
+            "the Item 5 stock performance graph is missing — this is the exact "
+            "content GH #886 was filed about"
+        )
+
+    def test_image_urls_are_absolute_and_point_at_the_sec_archive(self, nvda_markdown):
+        """A relative src in exported markdown is a dead link."""
+        sources = [m.group("src") for m in MARKDOWN_IMAGE.finditer(nvda_markdown)]
+        assert sources, "no images rendered at all"
+        relative = [src for src in sources if not src.startswith("https://")]
+        assert not relative, (
+            f"image sources left unresolved: {relative}. They must be joined "
+            f"against document.metadata.url ({NVDA_ARCHIVE_DIR})."
+        )
+        assert urljoin(NVDA_ARCHIVE_DIR, STOCK_PERFORMANCE_GRAPH) in sources
+
+    def test_alt_text_is_preserved(self, nvda_markdown):
+        """The alt attribute is the only text a reader gets for a chart image."""
+        alts = [m.group("alt") for m in MARKDOWN_IMAGE.finditer(nvda_markdown)]
+        assert any("nvidialogo" in alt for alt in alts), (
+            f"cover logo alt text lost; alts were: {alts}"
+        )
+
+    def test_a_document_without_a_base_url_keeps_the_raw_src(self):
+        """Parsing raw HTML must not fabricate a URL — silence check.
+
+        ``HTMLParser().parse(html)`` has no filing behind it, so there is no
+        correct absolute form. Keeping the raw ``src`` is honest; inventing an
+        sec.gov prefix would produce links that 404.
+        """
+        if not FIXTURE.exists():
+            pytest.skip(f"NVDA 10-K fixture not present at {FIXTURE}")
+        document = HTMLParser(ParserConfig(form="10-K")).parse(
+            FIXTURE.read_text(errors="ignore"))
+        markdown = document.to_markdown()
+        sources = [m.group("src") for m in MARKDOWN_IMAGE.finditer(markdown)]
+        assert STOCK_PERFORMANCE_GRAPH in sources, (
+            f"expected the bare src to be preserved, got: {sources}"
+        )
+
+
+@pytest.mark.fast
+class TestThePageBreakEscapeHatch:
+    """``include_page_breaks=True`` still works, and says it is going away.
+
+    The new pipeline has no page-break rendering — ``DocumentBuilder`` drops
+    page-break ``<hr>``s and page-number containers as print chrome — so the
+    flag keeps routing to the legacy renderer until 6.0. That is a deliberate
+    trade, and the warning is the part users actually see.
+    """
+
+    def test_the_flag_warns_about_removal(self):
+        from edgar.files._deprecation import PAGE_BREAK_DEPRECATION
+
+        message = PAGE_BREAK_DEPRECATION.format(cls="Filing")
+        assert "6.0" in message, "the warning must name the removal release"
+        assert "images" in message, (
+            "the warning must say what the caller gives up, not just that the "
+            "flag is deprecated"
+        )
+
+    def test_the_legacy_renderer_still_emits_page_break_markers(self):
+        """Guards the fallback itself, not just the warning."""
+        from edgar.files.markdown import to_markdown
+
+        html = (
+            "<html><body>"
+            "<div>Page one body text that is long enough to be a text block.</div>"
+            "<hr style='page-break-after:always'/>"
+            "<div>Page two body text that is long enough to be a text block.</div>"
+            "</body></html>"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            markdown = to_markdown(html, include_page_breaks=True, start_page_number=1)
+        assert markdown is not None
+        assert re.search(r"\{\d+\}-{10,}", markdown), (
+            f"no page break delimiter in legacy output:\n{markdown}"
+        )
+
+
+@pytest.mark.network
+class TestEndToEndThroughFilingMarkdown:
+    """The offline tests above cannot see ``Filing.markdown()``'s URL wiring.
+
+    ``base_dir`` is built from the CIK and accession number, and nothing offline
+    exercises that. This is the test that fails if the reroute renders images
+    but joins them against the wrong directory.
+    """
+
+    def test_filing_markdown_emits_absolute_sec_image_urls(self):
+        from edgar import Company
+
+        filing = Company("NVDA").get_filings(form="10-K").latest()
+        markdown = filing.markdown()
+
+        sources = [m.group("src") for m in MARKDOWN_IMAGE.finditer(markdown)]
+        assert sources, (
+            f"Filing.markdown() rendered no images for {filing.accession_no}; "
+            "GH #886 is not fixed"
+        )
+        assert all(src.startswith("https://www.sec.gov/Archives/") for src in sources), (
+            f"image sources are not absolute SEC archive URLs: {sources}"
+        )
+        assert all(filing.accession_no.replace("-", "") in src for src in sources), (
+            f"image URLs do not point at this filing's archive directory: {sources}"
+        )
+
+    def test_the_deprecated_path_warns_and_still_renders(self):
+        from edgar import Company
+
+        filing = Company("NVDA").get_filings(form="10-K").latest()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            markdown = filing.markdown(include_page_breaks=True, start_page_number=1)
+
+        assert re.search(r"\{\d+\}-{10,}", markdown), "page break markers missing"
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations, "include_page_breaks=True must emit a DeprecationWarning"
+        assert "6.0" in str(deprecations[0].message)


### PR DESCRIPTION
Fixes the **markdown half** of #886. Beads: `edgartools-n45i`.

Deliberately does *not* close the issue: #886 is "images dropped from markdown/**text** output", and the reporter asked for `[Image: ...]` placeholders in text as well. `Filing.text()` renders via `rich_to_text(document)` (`_filings.py:1682`), which never reaches `TextExtractor`, so the `include_images` flag added in a2093248 is not merely defaulted off on that path — it is not on that path. That half is still open.

## What was broken

`Filing.markdown()` and `Attachment.markdown()` were the last public rendering methods still on the legacy `edgar.files` pipeline, while `text()`, `view()` and the section extractors had all moved to `edgar.documents`. That renderer has no image node at all — `MarkdownRenderer.render` in `edgar/files/markdown.py` handles `text_block`, `table`, `heading` and `page_break`, and anything else renders as nothing. Every `<img>` in every filing was dropped silently.

The reporter's example is NVIDIA's 10-K Item 5 "Stock Performance Graph". The five-year total-return comparison against the S&P 500 and the Nasdaq 100 exists *only* as that chart image; there is no table beside it. So the legacy markdown announced a performance comparison and then showed nothing — for a RAG pipeline that is worse than an outright gap.

## The fix

Rendering the image is only half of it. The `src` in filing HTML is a bare sibling file name, so emitted verbatim it resolves against wherever the markdown ends up, which is nowhere. Both call sites set `document.metadata.url` before rendering:

- `Filing` → its archive directory (`base_dir`, a pure string property, so no extra request). The trailing slash is load-bearing: `urljoin` discards the last path segment without it and the images resolve one directory too high.
- `Attachment` → `self.url`, which already ends in the document file name.

`Attachments.markdown()` (plural, `attachments.py:843`) forwards to `Attachment.markdown()`, so it inherits both changes without a code change of its own.

Live on NVIDIA's FY2026 10-K:

```
![nvidialogoa10.jpg](https://www.sec.gov/Archives/edgar/data/1045810/000104581026000021/nvda-20260125_g1.jpg)
![562](https://www.sec.gov/Archives/edgar/data/1045810/000104581026000021/nvda-20260125_g2.jpg)
```

`g2.jpg` is the performance graph; both URLs return `200 image/jpeg`. Legacy rendered zero images on the same filing.

## Page breaks

`include_page_breaks=True` keeps routing to the legacy renderer and now emits a `DeprecationWarning` naming 6.0.

Page-break rendering exists only there — the `edgar.documents` builder treats page-break `<hr>`s and page-number containers as print chrome and discards them (`strategies/document_builder.py:147-156`). So the flag selects a whole *renderer*, not a feature, and a caller who sets it forfeits images and the newer table rendering. That is why it is being removed rather than ported; there is no equivalent to port it to.

The message lives in `edgar/files/_deprecation.py` so the two call sites cannot drift. It deliberately does **not** use that module's existing `warn_legacy_html_usage()` helper: that suppresses warnings from any `edgar.*` frame, and the immediate caller here is `edgar._filings`, so it would have silenced every warning. Plain `warnings.warn(..., stacklevel=2)` points at the user's own line.

`edgar/files/markdown.py` stays — `tests/test_page_breaks.py` still drives the legacy `Document.parse()` directly, and deletion belongs to `07lk.3`.

## Docs

`working-with-filing.md` and `api/filing.md` both recommended `include_page_breaks=True` **specifically for LLM analysis**, which is now the worst advice in either file — that is the flag that drops images. Both flipped to plain `filing.markdown()`, with deprecation notes there and in `filing-attachments.md`. CHANGELOG gets Changed + Deprecated entries; `docs/upgrade/6.0.md` gets a "Still to come" row for the parameter removal.

## Verification

| | |
|---|---|
| `test-fast` | **4487 passed**, 4 skipped, 1 xfailed, 0 failed (4480 before + 7 new) |
| Markdown + section parity ratchets | 13 passed |
| `test_page_breaks` / `test_markdown_page_breaks` / `test_attachments` / `test_form_upload` | 52 passed |
| ruff | zero new findings (compared line-number-insensitively against `main`) |

One caveat worth stating: the ratchets exercise the two renderers directly, not `Filing.markdown()`, so they show the reroute did not disturb the parser rather than proving the reroute itself.

That is what `tests/issues/regression/test_issue_886_markdown_images.py` is for — 7 offline tests on the NVDA fixture (which carries the same two images as the live filing), plus 2 network tests that are the only thing covering the `base_dir` wiring end to end. A refactor that keeps the image node but forgets the base URL would pass a naive "are there images?" check and still ship dead links, so the absolute form is asserted explicitly. There is also a silence check: parsing raw HTML with no filing behind it keeps the bare `src` rather than inventing an `sec.gov` prefix that would 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
