### PR TITLE
test: make an xfail that passes a failure (xfail_strict)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,6 +378,21 @@ retry_delay = 4
 cumulative_timing = false
 retry_outcome = "rerun"
 
+# An xfail that passes is a failure, not a quiet success.
+#
+# Without this, xfail-pass and xfail-fail are BOTH green, so an xfail-marked
+# test has no outcome that can fail and stops being a test. Three in
+# test_issue_583_equity_labels.py sat that way for months reporting XPASS in
+# every CI run: they were marked "not yet implemented" and the feature had
+# shipped, which the file's own docstring recorded (edgartools-07lk.24
+# finding 2). Strict mode turns the next one of those into a failure the day
+# the behaviour changes, which is the only moment the information is useful.
+#
+# The four remaining xfails are genuinely still failing and stay xfail --
+# strict does not touch those. If you mark a test xfail, it must actually fail;
+# when it starts passing, delete the marker rather than widen this setting.
+xfail_strict = true
+
 # Pytest markers for test categorization
 markers = [
     "fast: Fast tests that run quickly (< 0.1s each)",

--- a/tests/issues/regression/test_issue_583_equity_labels.py
+++ b/tests/issues/regression/test_issue_583_equity_labels.py
@@ -31,7 +31,6 @@ class TestIssue583EquityLabels:
         return filing.xbrl()
 
     @pytest.mark.network
-    @pytest.mark.xfail(reason="Beginning/ending balance label suffixes not yet implemented")
     def test_equity_labels_have_beginning_ending_suffix(self, aapl_10k_xbrl):
         """Test that labels have 'Beginning balance' / 'Ending balance' suffixes."""
         stmt = aapl_10k_xbrl.statements.statement_of_equity()
@@ -49,7 +48,6 @@ class TestIssue583EquityLabels:
             "Should have rows with 'Ending balance' in label"
 
     @pytest.mark.network
-    @pytest.mark.xfail(reason="Beginning/ending balance label suffixes not yet implemented")
     def test_stockholders_equity_has_distinct_beginning_ending_labels(self, aapl_10k_xbrl):
         """Test that StockholdersEquity rows have distinct beginning/ending labels."""
         stmt = aapl_10k_xbrl.statements.statement_of_equity()
@@ -108,7 +106,6 @@ class TestIssue583EquityLabels:
             f"Beginning ({begin_val}) and ending ({end_val}) values should differ"
 
     @pytest.mark.network
-    @pytest.mark.xfail(reason="Beginning/ending balance label suffixes not yet implemented")
     def test_dimensional_rows_have_beginning_ending_logic(self, aapl_10k_xbrl):
         """Test that dimensional rows also have beginning/ending balance distinction."""
         stmt = aapl_10k_xbrl.statements.statement_of_equity()


### PR DESCRIPTION
`edgartools-07lk.24` finding 2.

`xfail_strict` was unset, so xfail-pass and xfail-fail were **both green** — an
xfail-marked test had no outcome that could fail, and stopped being a test.

Three in `test_issue_583_equity_labels.py` sat that way for months, reporting
XPASS in every CI run checked. They are marked *"Beginning/ending balance label
suffixes not yet implemented"* and the suffixes had shipped — the file's own
docstring records the fix under `Fixes:`:

> Added "Beginning balance" / "Ending balance" suffixes to labels in `to_dataframe()`

Dropped those three markers, so the tests now pass for the ordinary reason and
fail if the labels regress. Turned on `xfail_strict` so the class is impossible
rather than merely absent.

## Blast radius, measured

Six files in the repo carry `xfail`, all in the regression tree. Measured
outcomes before changing anything:

| File | Outcome | Disposition |
|---|---|---|
| `test_issue_583_equity_labels.py` (x3) | **XPASS** | markers removed |
| `test_issue_440_currency_display.py` | XFAIL | unchanged |
| `test_issue_4agg_index_and_item_tables.py` | XFAIL | unchanged |
| `test_issue_j8bs_unterminated_comment.py` | XFAIL | unchanged |
| `test_issue_rck1_sgml_text_ownership_xml.py` | XFAIL | unchanged |
| `test_viewer_corpus.py` | dynamic | unaffected, see below |

The four remaining xfails are genuinely still failing and their reasons name the
constraint — two of them the `d216a934` revert. Strict mode does not touch a
test that fails as advertised.

`test_viewer_corpus.py` sets `strict=False` explicitly on its manifest-driven
marks, and a per-mark value overrides the ini setting, so it is unaffected.

## Verification

The setting was verified to bite rather than trusted from its semantics — an
xfail-marked test asserting `True` now reports `FAILED [XPASS(strict)]`, while
one asserting `False` still reports `xfailed`.

- the six xfail files: 60 passed, 4 xfailed, **0 xpassed** (was 57/4/3)
- `test_issue_583_equity_labels.py` alone: 9 passed
- `pytest -n auto -m fast`: 4505 passed, 4 skipped, 1 xfailed, 62s

## Note, not fixed here

`test_viewer_corpus.py`'s `strict=False` is the same silent-pass shape written
explicitly rather than inherited from config: a manifest entry marked
`xfail_until_fixed` that starts passing stays green forever, so nobody learns
the viewer bug was fixed. That is arguably deliberate for a corpus of open bugs
and it belongs to `edgartools-doup`, so I have left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
