### PR TITLE
test(regression): un-blind the two skips that were actually firing

### DIFF
--- a/tests/issues/regression/test_issue_412_regression.py
+++ b/tests/issues/regression/test_issue_412_regression.py
@@ -22,12 +22,15 @@ def test_sgml_parsing_with_multiple_angle_brackets():
     due to XBRL inline content with multiple '>' characters.
     """
     # Read the TSLA SGML file that was previously failing (minimal version for testing)
-    sgml_file = Path("data/sgml/0001564590-20-004475-minimal.txt")
-    
-    # Skip test if file doesn't exist (for CI environments without test data)
-    if not sgml_file.exists():
-        pytest.skip("SGML test data file not available")
-    
+    #
+    # Anchored on __file__, not the process working directory. As a cwd-relative
+    # path this resolved only when pytest was invoked from the repo root, and
+    # anywhere else the test skipped itself and reported success. The file is
+    # committed, so its absence is a broken checkout and belongs in the failure
+    # report rather than behind a skip (edgartools-07lk.24 finding 3).
+    sgml_file = Path(__file__).parents[3] / "data" / "sgml" / "0001564590-20-004475-minimal.txt"
+    assert sgml_file.exists(), f"committed SGML fixture is missing: {sgml_file}"
+
     content = sgml_file.read_text()
     
     # This should not raise "ValueError: too many values to unpack"

--- a/tests/issues/regression/test_issue_669.py
+++ b/tests/issues/regression/test_issue_669.py
@@ -20,10 +20,20 @@ import pytest
 from edgar import Company
 
 
+# Period columns are "2023-12-31 (FY)" -- a date followed by the fiscal period.
+#
+# This used to anchor on `^\d{4}-\d{2}-\d{2}$`, an exact match against the bare
+# date. When the " (FY)" suffix was added the pattern stopped matching anything,
+# get_period_columns() returned [], and the two tests below skipped on "No
+# period columns" in every run from then on. Nothing was verified and nothing
+# said so (edgartools-07lk.24 finding 3). Match the date as a prefix so a later
+# change to the suffix cannot silence these again.
+PERIOD_COLUMN = re.compile(r'^\d{4}-\d{2}-\d{2}(\s|$)')
+
+
 def get_period_columns(df):
-    """Get period columns (date format YYYY-MM-DD) from DataFrame."""
-    date_pattern = re.compile(r'^\d{4}-\d{2}-\d{2}$')
-    return [col for col in df.columns if date_pattern.match(str(col))]
+    """Get period columns (a YYYY-MM-DD date, optionally suffixed) from DataFrame."""
+    return [col for col in df.columns if PERIOD_COLUMN.match(str(col))]
 
 
 @pytest.mark.network
@@ -39,65 +49,71 @@ class TestIssue669PreferredSignInDataFrame:
         """Default to_dataframe() should apply preferred_sign (negate raw values)."""
         xbrl = azn_filing.xbrl()
         cf = xbrl.statements.cashflow_statement()
-        if cf is None:
-            pytest.skip("Cash flow statement not found")
+        assert cf is not None, "AZN 20-F should have a cash flow statement"
         df_pres = cf.to_dataframe()  # presentation=True is default
         df_raw = cf.to_dataframe(presentation=False)
 
-        if 'preferred_sign' not in df_pres.columns:
-            pytest.skip("No preferred_sign column")
+        assert 'preferred_sign' in df_pres.columns, (
+            f"to_dataframe() should carry preferred_sign; got {list(df_pres.columns)}"
+        )
 
         period_cols = get_period_columns(df_pres)
-        if not period_cols:
-            pytest.skip("No period columns")
+        assert period_cols, (
+            f"no period column matched {PERIOD_COLUMN.pattern} in {list(df_pres.columns)}"
+        )
 
-        # For rows with preferred_sign=-1, presentation values should be negated vs raw
         neg_mask = df_pres['preferred_sign'] == -1
-        if not neg_mask.any():
-            pytest.skip("No rows with preferred_sign=-1")
+        assert neg_mask.any(), "AZN's cash flow has rows with preferred_sign=-1"
 
         col = period_cols[0]
         pres_val = df_pres.loc[neg_mask, col].dropna()
         raw_val = df_raw.loc[neg_mask, col].dropna()
-        if pres_val.empty or raw_val.empty:
-            pytest.skip("No non-null values to compare")
+        assert not pres_val.empty and not raw_val.empty, (
+            f"column {col} has no non-null values on preferred_sign=-1 rows"
+        )
 
-        # The key invariant: presentation flips the sign relative to raw
-        assert pres_val.iloc[0] == -raw_val.iloc[0], (
+        # The key invariant: presentation flips the sign relative to raw, on
+        # EVERY such row rather than just the first one the frame happens to
+        # order first. 18 rows qualify on this filing.
+        mismatched = [(p, r) for p, r in zip(pres_val, raw_val) if p != -r]
+        assert not mismatched, (
             f"presentation=True should negate raw values for preferred_sign=-1. "
-            f"pres={pres_val.iloc[0]}, raw={raw_val.iloc[0]}"
+            f"{len(mismatched)} of {len(pres_val)} rows disagree, e.g. {mismatched[:3]}"
         )
 
     def test_presentation_false_returns_raw(self, azn_filing):
         """presentation=False should return unmodified XBRL instance values."""
         xbrl = azn_filing.xbrl()
         cf = xbrl.statements.cashflow_statement()
-        if cf is None:
-            pytest.skip("Cash flow statement not found")
+        assert cf is not None, "AZN 20-F should have a cash flow statement"
         df_pres = cf.to_dataframe(presentation=True)
         df_raw = cf.to_dataframe(presentation=False)
 
-        if 'preferred_sign' not in df_pres.columns:
-            pytest.skip("No preferred_sign column")
+        assert 'preferred_sign' in df_pres.columns, (
+            f"to_dataframe() should carry preferred_sign; got {list(df_pres.columns)}"
+        )
 
         period_cols = get_period_columns(df_pres)
-        if not period_cols:
-            pytest.skip("No period columns")
+        assert period_cols, (
+            f"no period column matched {PERIOD_COLUMN.pattern} in {list(df_pres.columns)}"
+        )
 
         neg_mask = df_pres['preferred_sign'] == -1
-        if not neg_mask.any():
-            pytest.skip("No rows with preferred_sign=-1")
+        assert neg_mask.any(), "AZN's cash flow has rows with preferred_sign=-1"
 
         col = period_cols[0]
         pres_val = df_pres.loc[neg_mask, col].dropna()
         raw_val = df_raw.loc[neg_mask, col].dropna()
-        if pres_val.empty or raw_val.empty:
-            pytest.skip("No non-null values to compare")
+        assert not pres_val.empty and not raw_val.empty, (
+            f"column {col} has no non-null values on preferred_sign=-1 rows"
+        )
 
-        # Raw and presentation should differ (sign flip)
-        assert pres_val.iloc[0] != raw_val.iloc[0], (
+        # Raw and presentation differ on every qualifying row. A zero would be
+        # its own negation and break this, but none of AZN's 18 are zero.
+        same = [(p, r) for p, r in zip(pres_val, raw_val) if p == r]
+        assert not same, (
             f"presentation=True and False should produce different values. "
-            f"Both returned {pres_val.iloc[0]}"
+            f"{len(same)} of {len(pres_val)} rows are identical, e.g. {same[:3]}"
         )
 
 
@@ -109,11 +125,9 @@ class TestIssue669StitchedPreferredSign:
         """StitchedStatement.to_dataframe() should include preferred_sign column."""
         company = Company("AAPL")
         financials = company.get_financials()
-        if financials is None:
-            pytest.skip("Financials not available")
+        assert financials is not None, "AAPL should have financials"
         cf = financials.cashflow_statement()
-        if cf is None:
-            pytest.skip("Cash flow statement not available")
+        assert cf is not None, "AAPL financials should have a cash flow statement"
         df = cf.to_dataframe()
         assert 'preferred_sign' in df.columns, "Stitched DataFrame should include preferred_sign column"
 
@@ -121,29 +135,38 @@ class TestIssue669StitchedPreferredSign:
         """StitchedStatement.to_dataframe() should apply preferred_sign by default."""
         company = Company("AAPL")
         financials = company.get_financials()
-        if financials is None:
-            pytest.skip("Financials not available")
+        assert financials is not None, "AAPL should have financials"
         cf = financials.cashflow_statement()
-        if cf is None:
-            pytest.skip("Cash flow statement not available")
+        assert cf is not None, "AAPL financials should have a cash flow statement"
 
         df_pres = cf.to_dataframe(presentation=True)
         df_raw = cf.to_dataframe(presentation=False)
 
-        # Find rows with preferred_sign=-1
-        if 'preferred_sign' in df_pres.columns:
-            neg_mask = df_pres['preferred_sign'] == -1
-            period_cols = get_period_columns(df_pres)
-            if neg_mask.any() and period_cols:
-                col = period_cols[0]
-                # For rows with preferred_sign=-1, presentation values should be negated vs raw
-                pres_val = df_pres.loc[neg_mask, col].dropna().iloc[0] if not df_pres.loc[neg_mask, col].dropna().empty else None
-                raw_val = df_raw.loc[neg_mask, col].dropna().iloc[0] if not df_raw.loc[neg_mask, col].dropna().empty else None
-                if pres_val is not None and raw_val is not None and raw_val != 0:
-                    assert pres_val == -raw_val, (
-                        f"Stitched presentation values should be negated vs raw. "
-                        f"pres={pres_val}, raw={raw_val}"
-                    )
+        # The whole comparison used to sit inside `if` guards, so any unmet
+        # condition passed the test having asserted nothing at all -- not even a
+        # skip to say so. Each condition is now its own assertion.
+        assert 'preferred_sign' in df_pres.columns, (
+            f"stitched to_dataframe() should carry preferred_sign; got {list(df_pres.columns)}"
+        )
+        period_cols = get_period_columns(df_pres)
+        assert period_cols, (
+            f"no period column matched {PERIOD_COLUMN.pattern} in {list(df_pres.columns)}"
+        )
+        neg_mask = df_pres['preferred_sign'] == -1
+        assert neg_mask.any(), "AAPL's stitched cash flow has rows with preferred_sign=-1"
+
+        col = period_cols[0]
+        pres_val = df_pres.loc[neg_mask, col].dropna()
+        raw_val = df_raw.loc[neg_mask, col].dropna()
+        assert not pres_val.empty and not raw_val.empty, (
+            f"column {col} has no non-null values on preferred_sign=-1 rows"
+        )
+
+        mismatched = [(p, r) for p, r in zip(pres_val, raw_val) if p != -r]
+        assert not mismatched, (
+            f"Stitched presentation values should be negated vs raw. "
+            f"{len(mismatched)} of {len(pres_val)} rows disagree, e.g. {mismatched[:3]}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/issues/regression/test_issue_762_html_in_dataframe.py
+++ b/tests/issues/regression/test_issue_762_html_in_dataframe.py
@@ -52,9 +52,14 @@ class TestDataFrameNoHtml:
     def msft_xbrl(self):
         from pathlib import Path
         from edgar.xbrl.xbrl import XBRL
-        fixture_dir = Path("tests/fixtures/xbrl/msft/10k_2024")
-        if not fixture_dir.exists() or not any(fixture_dir.iterdir()):
-            pytest.skip("MSFT 10-K fixture not available")
+        # Anchored on __file__, not the process working directory -- as a
+        # cwd-relative path this resolved only under a repo-root invocation and
+        # skipped itself anywhere else. The five fixture files are committed, so
+        # their absence is a broken checkout, not a reason to pass quietly.
+        fixture_dir = Path(__file__).parents[2] / "fixtures" / "xbrl" / "msft" / "10k_2024"
+        assert fixture_dir.exists() and any(fixture_dir.iterdir()), (
+            f"committed MSFT 10-K XBRL fixture is missing: {fixture_dir}"
+        )
         return XBRL.from_directory(fixture_dir)
 
     def test_segment_disclosure_dataframe_has_no_html(self, msft_xbrl):


### PR DESCRIPTION
`edgartools-07lk.24` finding 3 — the live half.

Of the 52 `pytest.skip()` calls in the regression tree, I measured which
actually fire. Exactly **two**: `test_issue_669.py`'s *"No period columns"*, in
both `TestIssue669PreferredSignInDataFrame` tests.

## Root cause

`get_period_columns()` anchored on `^\d{4}-\d{2}-\d{2}$` — an exact match
against a bare date. Period columns are now `"2023-12-31 (FY)"`; a
fiscal-period suffix was added at some point and the pattern stopped matching
anything at all. The helper returned `[]`, both tests skipped, and neither has
verified anything since.

The data was there the whole time — AZN's cash flow has 21 rows with
`preferred_sign=-1`, 18 non-null in the first period column.

**This un-blinds a working feature rather than uncovering a regression.** All 18
rows satisfy `pres == -raw`, and 13 of 13 on the stitched AAPL path. Matching
the date as a *prefix* means a later change to the suffix cannot silence these
again.

## What changed

- **All 14 skips in `test_issue_669.py`** are gone, not just the two that fired.
  Each is now the assertion it should have been, and the comparison runs over
  every qualifying row rather than whichever one the frame ordered first.
- **`test_stitched_dataframe_applies_signs` was worse than a skip** — its entire
  comparison sat inside `if` guards, so an unmet condition passed the test
  having asserted nothing and said nothing. Each condition is now its own
  assertion.
- **Two cwd-relative fixture paths** (`test_issue_412_regression.py`,
  `test_issue_762_html_in_dataframe.py`). Both resolved only under a repo-root
  invocation and skipped themselves anywhere else. Verified: from `/tmp` the old
  paths resolve to `/private/tmp/data/...` and `/private/tmp/tests/...`, neither
  of which exists. Both are now anchored on `__file__` and assert instead of
  skipping — the fixtures are committed (`git ls-files` confirms), so their
  absence is a broken checkout, not a reason to pass quietly.

## Verification

- the 21 skip-bearing files: **163 passed, 0 skipped** (was 164 passed, 2 skipped)
- `test_issue_669.py`: 4 passed, 0 skips remaining in the file
- the two path fixes **run from `/tmp`**: 11 passed — the exact cwd that used to
  skip them
- `pytest -n auto -m fast`: 4522 passed, 4 skipped, 1 xfailed

## Not in this PR

36 skips remain across 19 files, **none firing today**. Two things stand between
them and a fix, and both want a decision rather than a guess:

1. **The guard's design.** The bead proposed rejecting `pytest.skip()` under
   `tests/issues/regression/` unless the reason names a missing fixture file. I
   checked whether a cleaner rule works — legal at setup, illegal at call — and
   it does not: bad skips live in fixtures too (`test_issue_637`'s *"Could not
   load TSM company facts"*, `test_issue_581`'s *"network issue"*), while one
   legitimate one sits in a test body. So the rule has to key on the reason,
   which means regex-on-prose, or else legitimate skips move to a dedicated
   helper (`skip_if_fixture_missing(path)`) and bare `pytest.skip()` is banned
   outright. The helper is cleaner and mechanically checkable; it is also a
   15-site migration that only pays off once the other 23 are converted.
2. **Per-file data verification.** Each of the remaining 23 data-shape skips
   needs its data probed before its assertion can be written, the way AZN and
   AAPL were probed here. That is a judgement call per file, not a batch edit.

I also verified something worth recording: every fixture guarded by a "missing
fixture" skip **is committed** — abbv, aapl, nvda, c, wfc, ms, msft and the SGML
file are all tracked. So those guards cannot fire in CI today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
