### PR TITLE
test(regression): a regression test either runs or fails, enforced

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -90,6 +90,15 @@ jobs:
         python -m pip install -e ".[ai]"
         python -m pip install pytest pytest-cov pytest-env pytest-xdist pytest-asyncio pytest-retry pytest-mock pytest-vcr "vcrpy<8.2" freezegun==1.5.1 filelock tqdm responses
 
+    # A source scan, so it runs here rather than as its own job: this is the
+    # only context pull requests are required to report, and adding a second
+    # required one means updating branch protection in lockstep (see the header
+    # of this file). It is also why the check reads source instead of hooking
+    # pytest — half the regression tree is network-marked and runs post-merge,
+    # so a runtime hook would not see those tests on a pull request at all.
+    - name: Check no regression test skips itself
+      run: python scripts/check_regression_skips.py
+
     - name: Run fast tests
       run: |
         # Parallelize fast tests - safe, no SEC API calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ smoke-filings = "python scripts/batch/batch_filings.py {args}"
 # PyYAML's unsafe loader, so a contributed cassette executes code on your
 # machine the moment a test touches it. CI gates on this too.
 check-cassettes = "python scripts/check_cassettes.py {args}"
+check-regression-skips = "python scripts/check_regression_skips.py {args}"
 # Test categorization commands (sequential execution)
 test-fast = "pytest -m 'fast' {args}"
 test-slow = "pytest -m 'slow' {args}"

--- a/scripts/check_regression_skips.py
+++ b/scripts/check_regression_skips.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""Fail if a regression test skips itself at runtime.
+
+A regression test exists to catch one condition. When it calls ``pytest.skip()``
+because the data isn't shaped the way it expected, the condition it exists to
+catch is usually the condition that makes it skip — so the bug it guards walks
+straight past it and the run stays green. Two of these were live in
+``test_issue_669.py``: a fiscal-period suffix was added to DataFrame column
+names, the helper matching those columns stopped matching anything, and both
+tests skipped on "No period columns" in every run afterwards while the feature
+they guard went unverified (bead edgartools-07lk.24 finding 3).
+
+THE RULE: no ``pytest.skip()`` under ``tests/issues/regression/``. A regression
+test either runs or fails.
+
+Two things that look like exceptions and are not:
+
+* **A missing fixture file.** Every fixture guarded this way in this tree is
+  committed — abbv, aapl, nvda, c, wfc, ms, msft and ``data/sgml`` are all
+  tracked, verified with ``git ls-files``. In a valid checkout they are present,
+  so their absence means a broken checkout, and that belongs in the failure
+  report. ``assert path.exists()`` says so; a skip hides it. Anchor the path on
+  ``__file__`` rather than the working directory while you are there — two of
+  these resolved only under a repo-root invocation and skipped silently
+  anywhere else.
+
+* **A missing dependency.** ``@pytest.mark.skipif`` is the mechanism for that:
+  it is declarative, evaluated at collection, and reported as its own outcome
+  rather than as a test that ran. This gate deliberately does not touch it.
+
+Why a static scan and not a pytest hook: ``pytest.skip()`` fires at runtime, so
+a hook only catches a skip on a run that reaches it — and the network-marked
+half of this tree runs post-merge. Reading the source catches it on every pull
+request, including in tests nothing has executed yet.
+
+Why a per-file count and not per-line: line numbers drift with every edit above
+them. The count only ever goes down, so the list is a debt register that cannot
+silently grow.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
+
+DEFAULT_ROOT = Path(__file__).resolve().parent.parent / "tests" / "issues" / "regression"
+
+# file name -> number of pytest.skip() calls still to be converted.
+#
+# Each of these needs its data probed before its assertion can be written --
+# what AZN and AAPL got in #1001 -- so they are recorded as debt rather than
+# rewritten by pattern. Lower the number when you convert one; delete the entry
+# at zero. Raising a number, or adding an entry, needs a reason that survives
+# the docstring above, and there is not currently a known one.
+GRANDFATHERED: Dict[str, int] = {
+    "test_issue_581_mchp_income_statement.py": 2,
+    "test_issue_412_historical_periods.py": 1,
+    "test_issue_583_equity_labels.py": 6,
+    "test_issue_452_dnut_fiscal_year.py": 1,
+    "test_issue_762_html_in_dataframe.py": 2,
+    "test_issue_v3ec_two_up_maturity_rows.py": 1,
+    "test_issue_637_ifrs_concept_discovery.py": 1,
+    "test_issue_607_dimension_member_label_reopen.py": 4,
+    "test_issue_603_dimension_member_label.py": 3,
+    "test_issue_460_quarterly_period_labels.py": 1,
+    "test_issue_427_xbrl_data_cap.py": 1,
+}
+
+
+def _is_skip_call(node: ast.AST) -> bool:
+    """True for ``pytest.skip(...)`` and for a bare ``skip(...)`` imported from pytest.
+
+    ``pytest.importorskip`` and ``pytest.mark.skipif`` are deliberately not
+    matched: the first is a dependency guard, the second is the declarative
+    mechanism this gate is steering people towards.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == "skip" and isinstance(func.value, ast.Name) and func.value.id == "pytest"
+    return isinstance(func, ast.Name) and func.id == "skip"
+
+
+def find_skips(path: Path) -> List[Tuple[int, str]]:
+    """Return (line, source-ish reason) for every runtime skip in one file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:  # a file that cannot parse is a different problem
+        print(f"{path}: could not parse ({exc})", file=sys.stderr)
+        return []
+
+    found = []
+    for node in ast.walk(tree):
+        if _is_skip_call(node):
+            reason = ""
+            if node.args:
+                arg = node.args[0]
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    reason = arg.value
+                elif isinstance(arg, ast.JoinedStr):
+                    reason = "".join(
+                        v.value for v in arg.values
+                        if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                    )
+            found.append((node.lineno, reason))
+    return sorted(found)
+
+
+def iter_test_files(root: Path) -> Iterator[Path]:
+    yield from sorted(root.rglob("*.py"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_ROOT,
+                        help="regression test directory to scan")
+    args = parser.parse_args()
+
+    root: Path = args.root
+    if not root.is_dir():
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 2
+
+    violations: List[str] = []
+    stale: List[str] = []
+    scanned = 0
+    seen: Dict[str, int] = {}
+
+    for path in iter_test_files(root):
+        scanned += 1
+        skips = find_skips(path)
+        if not skips:
+            continue
+        name = path.name
+        seen[name] = len(skips)
+        allowed = GRANDFATHERED.get(name, 0)
+        if len(skips) > allowed:
+            for line, reason in skips[allowed:]:
+                violations.append(f"{path}:{line}: pytest.skip({reason!r})")
+
+    # An entry that no longer matches reality is its own failure: a stale
+    # allowance is how a debt register quietly stops registering the debt.
+    for name, allowed in sorted(GRANDFATHERED.items()):
+        actual = seen.get(name, 0)
+        if actual < allowed:
+            stale.append(
+                f"{name}: allows {allowed} skip(s) but has {actual} — "
+                f"lower it to {actual}" + (" and delete the entry" if actual == 0 else "")
+            )
+
+    for line in violations:
+        print(line, file=sys.stderr)
+    for line in stale:
+        print(f"stale allowance: {line}", file=sys.stderr)
+
+    if violations or stale:
+        print(
+            f"\nRefusing {scanned} scanned file(s). A regression test either runs "
+            f"or fails — it does not skip itself.\n"
+            f"Missing committed fixture: assert it, anchored on __file__.\n"
+            f"Missing dependency: @pytest.mark.skipif, which this gate ignores.\n"
+            f"Unexpected data shape: that is the bug — assert, and let it fail.\n"
+            f"See {Path(__file__).name} for why, and do not widen the list to "
+            f"get past this.",
+            file=sys.stderr,
+        )
+        return 1
+
+    outstanding = sum(GRANDFATHERED.values())
+    print(f"OK: {scanned} file(s) scanned, no new runtime skips "
+          f"({outstanding} grandfathered still to convert).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/issues/regression/test_issue_2vzk_exhibit_index.py
+++ b/tests/issues/regression/test_issue_2vzk_exhibit_index.py
@@ -45,8 +45,7 @@ FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "html" / "abbv"
 @pytest.fixture(scope="module")
 def abbv_document():
     fixtures = sorted(FIXTURE_DIR.glob("*.html"))
-    if not fixtures:
-        pytest.skip(f"ABBV 10-K fixture not present in {FIXTURE_DIR}")
+    assert fixtures, f"committed ABBV 10-K fixture is missing from {FIXTURE_DIR}"
     html = fixtures[0].read_text(errors="ignore")
     return HTMLParser(ParserConfig(form="10-K")).parse(html)
 

--- a/tests/issues/regression/test_issue_4agg_index_and_item_tables.py
+++ b/tests/issues/regression/test_issue_4agg_index_and_item_tables.py
@@ -60,8 +60,7 @@ pytestmark = pytest.mark.fast
 
 @pytest.fixture(scope="module")
 def citi_html():
-    if not CITI.exists():
-        pytest.skip("Citigroup 10-K fixture not available")
+    assert CITI.exists(), f"committed Citigroup 10-K fixture is missing: {CITI}"
     html = CITI.read_text(encoding="utf-8", errors="replace")
     yield html
     del html
@@ -70,8 +69,7 @@ def citi_html():
 
 @pytest.fixture(scope="module")
 def wfc_html():
-    if not WFC.exists():
-        pytest.skip("Wells Fargo 10-K fixture not available")
+    assert WFC.exists(), f"committed Wells Fargo 10-K fixture is missing: {WFC}"
     html = WFC.read_text(encoding="utf-8", errors="replace")
     yield html
     del html

--- a/tests/issues/regression/test_issue_4q74_document_order_boundaries.py
+++ b/tests/issues/regression/test_issue_4q74_document_order_boundaries.py
@@ -47,8 +47,7 @@ MS_10K = Path(__file__).parents[2] / "fixtures" / "html" / "ms" / "10k" / "ms-10
 
 @pytest.fixture(scope="module")
 def ms_doc():
-    if not MS_10K.exists():
-        pytest.skip("Morgan Stanley 10-K fixture not available")
+    assert MS_10K.exists(), f"committed Morgan Stanley 10-K fixture is missing: {MS_10K}"
     doc = parse_html(MS_10K.read_bytes().decode("utf-8", "replace"), ParserConfig(form="10-K"))
     yield doc
     del doc

--- a/tests/issues/regression/test_issue_879.py
+++ b/tests/issues/regression/test_issue_879.py
@@ -199,6 +199,13 @@ class TestSignaturesBoundaryInProcess:
 # VCR ground-truth tests — replay the real filing HTML without re-fetching
 # ---------------------------------------------------------------------------
 
+# vcrpy is a pinned test dependency, so this is gating for an environment that
+# should not occur -- but when it does, skipif says so at collection and marks
+# the tests skipped, where a pytest.skip() inside the helper marked them passed
+# on the strength of a dependency being absent (edgartools-07lk.24 finding 3).
+requires_vcr = pytest.mark.skipif(not _HAS_VCR, reason="vcrpy not installed")
+
+
 def _parse_filing_html(cassette_name: str, filing_html_uri: str, form: str):
     """Fetch the filing HTML from the VCR cassette and parse it.
 
@@ -207,8 +214,6 @@ def _parse_filing_html(cassette_name: str, filing_html_uri: str, form: str):
     to replay the recorded response. Uses httpx (the same transport edgar uses)
     so VCR intercepts the request correctly.
     """
-    if not _HAS_VCR:
-        pytest.skip("vcrpy not installed")
     import httpx
 
     with _my_vcr.use_cassette(cassette_name):
@@ -222,6 +227,7 @@ def _parse_filing_html(cassette_name: str, filing_html_uri: str, form: str):
 
 
 @pytest.mark.fast
+@requires_vcr
 class TestMetaSingleItemGroundTruth:
     """GH #879: Meta 8-K (0001628280-25-058337) — single item, Workiva rendering.
 
@@ -280,6 +286,7 @@ class TestMetaSingleItemGroundTruth:
 
 
 @pytest.mark.fast
+@requires_vcr
 class TestJPMMultiItemGroundTruth:
     """GH #879: JPMorgan 8-K (0000019617-26-000241) — two items.
 

--- a/tests/issues/regression/test_issue_880.py
+++ b/tests/issues/regression/test_issue_880.py
@@ -88,18 +88,18 @@ def tesla_2022_10k():
     was recorded, so what remains is a placeholder that keeps record_mode="none"
     satisfied.
     """
-    if _HAS_VCR:
-        # record_mode="once" will record on first run and replay thereafter.
-        with _my_vcr.use_cassette(_TESLA_2022_CASSETTE):
-            return offline_filing("0000950170-23-001409").obj()
-    else:
-        pytest.skip("vcrpy not installed — install it to run this test offline")
+    # record_mode="once" will record on first run and replay thereafter.
+    with _my_vcr.use_cassette(_TESLA_2022_CASSETTE):
+        return offline_filing("0000950170-23-001409").obj()
 
 
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
 
+# See test_issue_879.py: skipif reports these as skipped at collection, where
+# the fixture's pytest.skip() reported them as passed.
+@pytest.mark.skipif(not _HAS_VCR, reason="vcrpy not installed")
 class TestTesla2022PartIII:
     """GH #880: Part III items must be independently extractable."""
 

--- a/tests/issues/regression/test_issue_886_markdown_images.py
+++ b/tests/issues/regression/test_issue_886_markdown_images.py
@@ -57,8 +57,7 @@ MARKDOWN_IMAGE = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<src>[^)]*)\)")
 @pytest.fixture(scope="module")
 def nvda_markdown():
     """Render the fixture exactly as the rerouted ``Filing.markdown()`` does."""
-    if not FIXTURE.exists():
-        pytest.skip(f"NVDA 10-K fixture not present at {FIXTURE}")
+    assert FIXTURE.exists(), f"committed NVDA 10-K fixture is missing: {FIXTURE}"
     document = HTMLParser(ParserConfig(form="10-K")).parse(
         FIXTURE.read_text(errors="ignore"))
     document.metadata.url = NVDA_ARCHIVE_DIR
@@ -110,8 +109,7 @@ class TestImagesSurviveIntoMarkdown:
         correct absolute form. Keeping the raw ``src`` is honest; inventing an
         sec.gov prefix would produce links that 404.
         """
-        if not FIXTURE.exists():
-            pytest.skip(f"NVDA 10-K fixture not present at {FIXTURE}")
+        assert FIXTURE.exists(), f"committed NVDA 10-K fixture is missing: {FIXTURE}"
         document = HTMLParser(ParserConfig(form="10-K")).parse(
             FIXTURE.read_text(errors="ignore"))
         markdown = document.to_markdown()

--- a/tests/issues/regression/test_issue_llmp_6_1_boundary_overflow.py
+++ b/tests/issues/regression/test_issue_llmp_6_1_boundary_overflow.py
@@ -42,8 +42,7 @@ def _normalise(text):
 
 @pytest.fixture(scope="module")
 def wfc_sections():
-    if not WFC.exists():
-        pytest.skip("Wells Fargo 10-K fixture not available")
+    assert WFC.exists(), f"committed Wells Fargo 10-K fixture is missing: {WFC}"
     doc = parse_html(WFC.read_bytes().decode("utf-8", "replace"), ParserConfig(form="10-K"))
     sections = {name: _normalise(section.text()) for name, section in doc.sections.items()}
     items = {name: section.item for name, section in doc.sections.items()}

--- a/tests/issues/regression/test_issue_sfnr_filing_text_fidelity.py
+++ b/tests/issues/regression/test_issue_sfnr_filing_text_fidelity.py
@@ -56,15 +56,14 @@ def _parse(path: Path):
 
 @pytest.fixture(scope="module")
 def aapl_document():
-    if not AAPL_DIR.is_dir() or not os.listdir(AAPL_DIR):
-        pytest.skip(f"AAPL 10-K fixture not present in {AAPL_DIR}")
+    assert AAPL_DIR.is_dir() and os.listdir(AAPL_DIR), (
+        f"committed AAPL 10-K fixture is missing from {AAPL_DIR}")
     return _parse(sorted(AAPL_DIR.glob("*.html"))[0])
 
 
 @pytest.fixture(scope="module")
 def nvda_document():
-    if not NVDA.exists():
-        pytest.skip(f"NVDA 10-K fixture not present at {NVDA}")
+    assert NVDA.exists(), f"committed NVDA 10-K fixture is missing: {NVDA}"
     return _parse(NVDA)
 
 
@@ -119,8 +118,8 @@ class TestLongTableCellsSurvive:
         """
         from edgar.richtools import rich_to_text
 
-        if not AAPL_DIR.is_dir() or not os.listdir(AAPL_DIR):
-            pytest.skip(f"AAPL 10-K fixture not present in {AAPL_DIR}")
+        assert AAPL_DIR.is_dir() and os.listdir(AAPL_DIR), (
+            f"committed AAPL 10-K fixture is missing from {AAPL_DIR}")
         fixture = sorted(AAPL_DIR.glob("*.html"))[0]
 
         def collapsed(s):

--- a/tests/issues/regression/test_issue_v3ec_two_up_maturity_rows.py
+++ b/tests/issues/regression/test_issue_v3ec_two_up_maturity_rows.py
@@ -63,8 +63,7 @@ DEBT_ROW_RE = re.compile(r"\$(\d[\d,]*?)\s*(\d\.\d+)%,\s+(\w{3} \d{4})")
 
 @pytest.fixture(scope="module")
 def unh_document():
-    if not FIXTURE.exists():
-        pytest.skip(f"UNH 10-K fixture not present at {FIXTURE}")
+    assert FIXTURE.exists(), f"committed UNH 10-K fixture is missing: {FIXTURE}"
     return HTMLParser(ParserConfig(form="10-K")).parse(
         FIXTURE.read_text(errors="ignore"))
 


### PR DESCRIPTION
`edgartools-07lk.24` finding 3 — the guard. Picks the design, converts the 13
skips that needed no data probing, and registers the 23 that do.

## The rule

**No `pytest.skip()` under `tests/issues/regression/`.** A regression test
either runs or fails.

This is stricter than the bead proposed — it suggested allowing a skip whose
reason names a missing fixture file. That exception turns out to have **no valid
instances**: every fixture guarded that way is committed (abbv, aapl, nvda, c,
wfc, ms, msft and `data/sgml`, all confirmed with `git ls-files`). In a valid
checkout the file is present, so its absence means a broken checkout — which
belongs in the failure report, not behind a skip. Those 11 guards are now
asserts.

Dependency gating keeps a mechanism, just a better one: `@pytest.mark.skipif`
is declarative, evaluated at collection, and reported as its own outcome. The
two vcrpy guards move to it, applied to the three classes that actually need
vcr rather than to whole modules. The gate ignores `skipif` and `importorskip`
by design.

## Designs rejected, and why

**Keying on the reason string.** The only way to keep a fixture exception, and
it means matching prose: *"Citigroup 10-K fixture not available"* would be legal
while *"Income statement not available for DNUT"* is not, and they differ by
nothing a checker can see.

**Legal at setup, illegal at call.** This was the appealing one — it needs no
prose matching at all, and it would let fixtures guard while forcing test bodies
to assert. I tested it and it is **unsound**: bad skips live in fixtures too
(`test_issue_637`'s *"Could not load TSM company facts"*, `test_issue_581`'s
*"network issue"*), while a legitimate guard sat in a test body.

## Implementation notes

**A static scan, not a pytest hook.** `pytest.skip()` fires at runtime, and the
network half of this tree runs post-merge — a hook would never see those tests
on a pull request. Reading source catches them all, including tests nothing has
executed yet.

**A step in `test-fast`, not its own job.** That is the only context pull
requests are required to report; a second required context means updating branch
protection in lockstep, which this workflow's header warns about at length.

**Per-file counts, not per-line.** Line numbers drift with every edit above
them. Counts only go down, and a count that no longer matches its file fails
too — a stale allowance is how a debt register quietly stops registering.

## Verification

The gate was verified to bite in both directions, not just to pass:

- reintroducing one skip → **exit 1**, and it names the file, line and reason
- claiming 5 skips for a file that has 1 → **stale allowance** reported
- clean tree → exit 0

And nothing was lost in the conversion:

- the 9 converted files: **98 passed, 0 skipped**
- regression tree still collects **1902** tests — none dropped by a `skipif`
- `pytest -n auto -m fast`: **4522 passed**, 4 skipped, 1 xfailed

## What remains

23 data-shape skips across 11 files, listed in `GRANDFATHERED` with the reason
they are not converted here: each needs its data probed before its assertion can
be written — what AZN and AAPL got in #1001 — which is a judgement call per
file, not a batch edit. The list can only shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
