### PR TITLE
test(regression): convert the last 23 self-skips to assertions

### DIFF
--- a/scripts/check_regression_skips.py
+++ b/scripts/check_regression_skips.py
@@ -49,24 +49,15 @@ DEFAULT_ROOT = Path(__file__).resolve().parent.parent / "tests" / "issues" / "re
 
 # file name -> number of pytest.skip() calls still to be converted.
 #
-# Each of these needs its data probed before its assertion can be written --
-# what AZN and AAPL got in #1001 -- so they are recorded as debt rather than
-# rewritten by pattern. Lower the number when you convert one; delete the entry
-# at zero. Raising a number, or adding an entry, needs a reason that survives
-# the docstring above, and there is not currently a known one.
-GRANDFATHERED: Dict[str, int] = {
-    "test_issue_581_mchp_income_statement.py": 2,
-    "test_issue_412_historical_periods.py": 1,
-    "test_issue_583_equity_labels.py": 6,
-    "test_issue_452_dnut_fiscal_year.py": 1,
-    "test_issue_762_html_in_dataframe.py": 2,
-    "test_issue_v3ec_two_up_maturity_rows.py": 1,
-    "test_issue_637_ifrs_concept_discovery.py": 1,
-    "test_issue_607_dimension_member_label_reopen.py": 4,
-    "test_issue_603_dimension_member_label.py": 3,
-    "test_issue_460_quarterly_period_labels.py": 1,
-    "test_issue_427_xbrl_data_cap.py": 1,
-}
+# EMPTY, and meant to stay that way. It held 23 while each one's data was being
+# probed -- the condition every skip was hiding had to be checked against a real
+# filing before its assertion could be written -- and all 23 are now assertions.
+#
+# Adding an entry needs a reason that survives the docstring above, and there is
+# not currently a known one. The two shapes that look like reasons are answered
+# there: a missing committed fixture is a broken checkout, and a missing
+# dependency is what @pytest.mark.skipif is for.
+GRANDFATHERED: Dict[str, int] = {}
 
 
 def _is_skip_call(node: ast.AST) -> bool:
@@ -170,8 +161,8 @@ def main() -> int:
         return 1
 
     outstanding = sum(GRANDFATHERED.values())
-    print(f"OK: {scanned} file(s) scanned, no new runtime skips "
-          f"({outstanding} grandfathered still to convert).")
+    tail = f" ({outstanding} grandfathered still to convert)" if outstanding else ""
+    print(f"OK: {scanned} file(s) scanned, no regression test skips itself{tail}.")
     return 0
 
 

--- a/tests/issues/regression/test_issue_412_historical_periods.py
+++ b/tests/issues/regression/test_issue_412_historical_periods.py
@@ -14,8 +14,10 @@ def test_historical_periods_have_comprehensive_data():
     """Historical periods (3rd, 4th) should have >35% completeness and key balance sheet items."""
     company = Company("TSLA")
     balance_sheet = company.balance_sheet(annual=True, periods=6)
-    if balance_sheet is None:
-        pytest.skip("Balance sheet not available for TSLA")
+    assert balance_sheet is not None, (
+        "TSLA should have an annual balance sheet; None here is the retrieval "
+        "path failing, which is the condition this test exists to catch"
+    )
     df = balance_sheet.to_dataframe()
 
     periods = balance_sheet.periods

--- a/tests/issues/regression/test_issue_427_xbrl_data_cap.py
+++ b/tests/issues/regression/test_issue_427_xbrl_data_cap.py
@@ -59,9 +59,9 @@ class TestIssue427XBRLDataCap:
         # Get XBRL 10-K filings
         tenk_filings = company.get_filings(form='10-K', is_xbrl=True)
         
-        # Skip if no XBRL filings available
-        if len(tenk_filings) == 0:
-            pytest.skip(f"No XBRL 10-K filings found for {ticker}")
+        # AAPL has 18 and MSFT 17 at the time of writing; zero means the
+        # is_xbrl filter stopped matching, not that the filings went away.
+        assert len(tenk_filings), f"{ticker} should have XBRL 10-K filings"
         
         # Get head filings and create XBRLS
         head_filings = tenk_filings.head(3)  # Use fewer filings for performance

--- a/tests/issues/regression/test_issue_452_dnut_fiscal_year.py
+++ b/tests/issues/regression/test_issue_452_dnut_fiscal_year.py
@@ -45,9 +45,12 @@ def test_dnut_fy2023_revenue_issue_452():
     # Get 5 annual periods to ensure we have FY 2023
     income_stmt = company.income_statement(periods=5, annual=True)
 
-    # Skip if income statement not available (company facts may not be loaded)
-    if income_stmt is None:
-        pytest.skip("Income statement not available for DNUT - company facts may be unavailable")
+    # None here is company facts failing to load, not a reason to pass: this
+    # test exists because DNUT's fiscal year was mis-assigned, and it cannot
+    # see that with no statement.
+    assert income_stmt is not None, (
+        "DNUT should have an annual income statement covering FY2023"
+    )
 
     # Convert to DataFrame for easier analysis
     df = income_stmt.to_dataframe()

--- a/tests/issues/regression/test_issue_460_quarterly_period_labels.py
+++ b/tests/issues/regression/test_issue_460_quarterly_period_labels.py
@@ -109,9 +109,10 @@ class TestQuarterlyPeriodLabels:
         company = Company("WMT")
         stmt = company.income_statement(periods=4, annual=False)
 
-        # Skip if statement not available
-        if stmt is None:
-            pytest.skip("Income statement not available for WMT - company facts may be unavailable")
+        assert stmt is not None, (
+            "WMT should have a quarterly income statement; without one the "
+            "period labelling this test checks cannot be wrong or right"
+        )
 
         # Verify we got periods
         assert len(stmt.periods) > 0, "Should have quarterly periods"

--- a/tests/issues/regression/test_issue_581_mchp_income_statement.py
+++ b/tests/issues/regression/test_issue_581_mchp_income_statement.py
@@ -31,13 +31,18 @@ class TestIssue581MCHPIncomeStatement:
         filings = company.get_filings(form="10-K")
         filing_2016 = filings.filter(date="2016-01-01:2016-12-31").latest()
 
-        # Skip test if filing couldn't be retrieved (network issues, rate limiting)
-        if filing_2016 is None:
-            pytest.skip("Could not retrieve MCHP 2016 10-K filing (network issue)")
+        # MCHP's FY2016 10-K is a filed historical document (0000827054-16-000344,
+        # 2016-05-24) and does not stop existing. An empty filter result or an
+        # unparseable XBRL is a defect in the filter or the parser, which is
+        # what this test is for -- skipping on it hid both.
+        assert filing_2016 is not None, (
+            "MCHP 10-K filed 2016-05-24 should be reachable by date filter"
+        )
 
         xbrl = filing_2016.xbrl()
-        if xbrl is None:
-            pytest.skip("Could not parse XBRL from MCHP 2016 10-K filing")
+        assert xbrl is not None, (
+            f"MCHP 2016 10-K ({filing_2016.accession_no}) should parse to XBRL"
+        )
 
         return xbrl
 

--- a/tests/issues/regression/test_issue_583_equity_labels.py
+++ b/tests/issues/regression/test_issue_583_equity_labels.py
@@ -83,8 +83,9 @@ class TestIssue583EquityLabels:
                      'standard_concept']
         value_cols = [c for c in df.columns if c not in meta_cols]
 
-        if not value_cols:
-            pytest.skip("No value columns found")
+        assert value_cols, (
+            f"statement_of_equity() should expose period columns; got {list(df.columns)}"
+        )
 
         # Get non-dimensional StockholdersEquity rows
         se_df = df[(df['concept'] == 'us-gaap_StockholdersEquity') & (df['dimension'] == False)]
@@ -93,8 +94,11 @@ class TestIssue583EquityLabels:
         ending_rows = se_df[se_df['label'].str.contains('Ending balance', na=False) &
                             ~se_df['label'].str.contains('Beginning', na=False)]
 
-        if len(beginning_rows) == 0 or len(ending_rows) == 0:
-            pytest.skip("Could not find both beginning and ending balance rows")
+        assert len(beginning_rows) and len(ending_rows), (
+            f"AAPL equity should carry both beginning and ending StockholdersEquity "
+            f"rows; got {len(beginning_rows)} beginning, {len(ending_rows)} ending "
+            f"from labels {se_df['label'].tolist()}"
+        )
 
         # Compare values in first value column
         value_col = value_cols[0]
@@ -114,8 +118,10 @@ class TestIssue583EquityLabels:
         # Get dimensional StockholdersEquity rows
         se_df = df[(df['concept'] == 'us-gaap_StockholdersEquity') & (df['dimension'] == True)]
 
-        if len(se_df) == 0:
-            pytest.skip("No dimensional StockholdersEquity rows found")
+        assert len(se_df), (
+            "AAPL equity should carry dimensional StockholdersEquity rows "
+            "(equity components are the statement's columns)"
+        )
 
         # Group by base label (without Beginning/Ending suffix)
         # Each unique dimensional label should appear twice (beginning + ending)
@@ -142,8 +148,9 @@ class TestIssue583EquityLabels:
                      'standard_concept']
         value_cols = [c for c in df.columns if c not in meta_cols]
 
-        if not value_cols:
-            pytest.skip("No value columns found")
+        assert value_cols, (
+            f"statement_of_equity() should expose period columns; got {list(df.columns)}"
+        )
 
         # Find a dimensional concept that appears twice
         dim_df = df[(df['concept'] == 'us-gaap_StockholdersEquity') & (df['dimension'] == True)]
@@ -155,8 +162,11 @@ class TestIssue583EquityLabels:
                             dim_df['label'].str.contains('Ending balance', na=False) &
                             ~dim_df['label'].str.contains('Beginning', na=False)]
 
-        if len(beginning_dim) == 0 or len(ending_dim) == 0:
-            pytest.skip("Could not find both beginning and ending dimensional rows")
+        assert len(beginning_dim) and len(ending_dim), (
+            f"Common stock should have both beginning and ending dimensional rows; "
+            f"got {len(beginning_dim)} beginning, {len(ending_dim)} ending from "
+            f"labels {dim_df['label'].tolist()}"
+        )
 
         # Compare values
         value_col = value_cols[0]
@@ -250,8 +260,9 @@ class TestIssue583IsBreakdownFlag:
             (df['dimension_axis'].str.contains('StatementEquityComponentsAxis', na=False))
         ]
 
-        if len(equity_dims) == 0:
-            pytest.skip("No equity component dimensional rows found")
+        assert len(equity_dims), (
+            "AAPL equity should carry rows on StatementEquityComponentsAxis"
+        )
 
         # All equity component dimensions should have is_breakdown=False
         # because they are STRUCTURAL (define column headers), not BREAKDOWN (notes detail)

--- a/tests/issues/regression/test_issue_603_dimension_member_label.py
+++ b/tests/issues/regression/test_issue_603_dimension_member_label.py
@@ -50,8 +50,11 @@ def test_issue_603_googl_dimension_member_label():
     # Filter to dimensional rows only
     dimensional_rows = df[df['dimension'] == True]
 
-    if len(dimensional_rows) == 0:
-        pytest.skip("No dimensional rows in GOOGL income statement")
+    assert len(dimensional_rows), (
+        "GOOGL 2023 10-K income statement should have dimensional rows "
+        "(33 at the time of writing); none means the dimensional data this "
+        "test inspects never arrived"
+    )
 
     # Check that dimension_member_label matches dimension_member's label portion
     # The bug was that dimension_member_label came from a different dimension than dimension_member
@@ -91,8 +94,10 @@ def test_issue_603_dimension_consistency():
         (df['dimension_member_label'].notna())
     ]
 
-    if len(dimensional_rows) == 0:
-        pytest.skip("No fully-populated dimensional rows")
+    assert len(dimensional_rows), (
+        "GOOGL 2023 10-K should have dimensional rows carrying axis, member and "
+        "member label together (33 at the time of writing)"
+    )
 
     # The dimension_member_label should NOT be "Google Services" for non-segment axes
     for _, row in dimensional_rows.iterrows():
@@ -129,8 +134,10 @@ def test_issue_603_query_by_dimension():
         # Try alternative revenue concept names
         revenue_by_product = xbrl.facts.query().by_concept("Revenues").by_dimension("ProductOrServiceAxis").to_dataframe()
 
-    if len(revenue_by_product) == 0:
-        pytest.skip("No Revenue facts with ProductOrServiceAxis dimension")
+    assert len(revenue_by_product), (
+        "GOOGL 2023 10-K should have Revenue facts on ProductOrServiceAxis "
+        "(15 at the time of writing, under the 'Revenue' concept)"
+    )
 
     print(f"Found {len(revenue_by_product)} revenue facts with ProductOrServiceAxis")
 

--- a/tests/issues/regression/test_issue_607_dimension_member_label_reopen.py
+++ b/tests/issues/regression/test_issue_607_dimension_member_label_reopen.py
@@ -46,8 +46,11 @@ def test_issue_607_multi_dimension_correct_label():
     # Some facts have both this axis AND srt:RangeAxis
     df = xbrl.facts.query().by_dimension("PropertyPlantAndEquipmentByTypeAxis").to_dataframe()
 
-    if len(df) == 0:
-        pytest.skip("No facts found with PropertyPlantAndEquipmentByTypeAxis dimension")
+    assert len(df), (
+        "GOOGL 2024 10-K should have facts on PropertyPlantAndEquipmentByTypeAxis "
+        "(18 at the time of writing) -- an empty result is the query breaking, "
+        "which is what this test exists to catch"
+    )
 
     print(f"Found {len(df)} facts with PropertyPlantAndEquipmentByTypeAxis dimension")
 
@@ -87,8 +90,9 @@ def test_issue_607_dimension_field_consistency():
     # Query by a known dimension
     df = xbrl.facts.query().by_dimension("PropertyPlantAndEquipmentByTypeAxis").to_dataframe()
 
-    if len(df) == 0:
-        pytest.skip("No facts found")
+    assert len(df), (
+        "GOOGL 2024 10-K should have facts on PropertyPlantAndEquipmentByTypeAxis"
+    )
 
     # Check that the dimension field reflects the requested dimension
     if 'dimension' in df.columns:
@@ -133,8 +137,10 @@ def test_issue_607_aapl_segment_dimension():
     # Query by StatementBusinessSegmentsAxis
     df = xbrl.facts.query().by_dimension("StatementBusinessSegmentsAxis").to_dataframe()
 
-    if len(df) == 0:
-        pytest.skip("No facts found with StatementBusinessSegmentsAxis dimension")
+    assert len(df), (
+        "GOOGL 2024 10-K should have facts on StatementBusinessSegmentsAxis "
+        "(54 at the time of writing)"
+    )
 
     print(f"Found {len(df)} facts with StatementBusinessSegmentsAxis dimension")
 
@@ -175,8 +181,7 @@ def test_issue_607_no_dimension_query_unchanged():
         lambda f: any(key.startswith('dim_') for key in f.keys())
     ).limit(20).to_dataframe()
 
-    if len(df) == 0:
-        pytest.skip("No dimensional facts found")
+    assert len(df), "GOOGL 2024 10-K should have dimensional facts"
 
     # By default, dimensions are excluded unless by_dimension() is called
     # So dimension columns might not be present, which is expected

--- a/tests/issues/regression/test_issue_637_ifrs_concept_discovery.py
+++ b/tests/issues/regression/test_issue_637_ifrs_concept_discovery.py
@@ -22,8 +22,10 @@ class TestIFRSConceptDiscovery:
         """TSM (Taiwan Semiconductor) - IFRS filer with ifrs-full: prefixed tags."""
         company = Company("TSM")
         facts = company.get_facts()
-        if facts is None:
-            pytest.skip("Could not load TSM company facts (network/cassette issue)")
+        assert facts is not None, (
+            "TSM company facts should load; None is the IFRS filer path failing, "
+            "which is exactly what this class verifies"
+        )
         return facts
 
     def test_discover_concept_tags_finds_ifrs_revenue(self, tsm_facts):

--- a/tests/issues/regression/test_issue_762_html_in_dataframe.py
+++ b/tests/issues/regression/test_issue_762_html_in_dataframe.py
@@ -65,8 +65,11 @@ class TestDataFrameNoHtml:
     def test_segment_disclosure_dataframe_has_no_html(self, msft_xbrl):
         """The segment disclosure table DataFrame must not contain HTML."""
         stmt = msft_xbrl.statements.get('Role_DisclosureSEGMENTINFORMATIONANDGEOGRAPHICDATATables')
-        if stmt is None:
-            pytest.skip("Segment disclosure statement not found")
+        assert stmt is not None, (
+            "the committed MSFT fixture carries "
+            "Role_DisclosureSEGMENTINFORMATIONANDGEOGRAPHICDATATables; its "
+            "absence means role lookup broke, not that the data moved"
+        )
 
         df = stmt.to_dataframe()
         assert not df.empty
@@ -79,8 +82,11 @@ class TestDataFrameNoHtml:
     def test_segment_disclosure_has_readable_text(self, msft_xbrl):
         """Sanitized TextBlock values should contain readable financial content."""
         stmt = msft_xbrl.statements.get('Role_DisclosureSEGMENTINFORMATIONANDGEOGRAPHICDATATables')
-        if stmt is None:
-            pytest.skip("Segment disclosure statement not found")
+        assert stmt is not None, (
+            "the committed MSFT fixture carries "
+            "Role_DisclosureSEGMENTINFORMATIONANDGEOGRAPHICDATATables; its "
+            "absence means role lookup broke, not that the data moved"
+        )
 
         df = stmt.to_dataframe()
         text_cells = []

--- a/tests/issues/regression/test_issue_v3ec_two_up_maturity_rows.py
+++ b/tests/issues/regression/test_issue_v3ec_two_up_maturity_rows.py
@@ -78,7 +78,11 @@ def debt_table(unh_document):
     for node in unh_document.root.walk():
         if isinstance(node, TableNode) and "Carrying Value as of" in (node.text() or ""):
             return node
-    pytest.skip("long-term debt schedule not found in the parsed document")
+    raise AssertionError(
+        "UNH's long-term debt schedule (the table headed 'Carrying Value as of') "
+        "is absent from the parsed document. That table not being found IS the "
+        "v3ec bug's territory, so it fails here rather than skipping."
+    )
 
 
 @pytest.mark.fast


### PR DESCRIPTION
`edgartools-07lk.24` finding 3, finished. The regression tree now contains
**zero** `pytest.skip()` calls and the gate's allowance list is **empty**.

## Every conversion was made against real data

The point of a skip is that it hides a condition. So each one was probed against
the filing the test actually loads before its assertion was written — none of
this was pattern-matched. Every condition holds:

| File | What the skip was hiding, measured |
|---|---|
| `583` AAPL equity | 3 period columns; 2 non-dim SE rows (1 beginning, 1 ending — 56.95bn vs 73.73bn); 6 dimensional SE rows (3+3); Common stock pair 83.28bn vs 93.57bn; 14 rows on `StatementEquityComponentsAxis`, 0 with `is_breakdown=True` |
| `607` GOOGL 2024 10-K | 18 facts on `PropertyPlantAndEquipmentByTypeAxis`, 54 on `StatementBusinessSegmentsAxis`, 20 dimensional |
| `603` GOOGL 2023 10-K | 33 dimensional income rows, 33 fully populated, 15 Revenue facts on `ProductOrServiceAxis` |
| `581` MCHP | FY2016 10-K resolves (`0000827054-16-000344`, 2016-05-24) and parses to XBRL |
| `762` MSFT fixture | the segment disclosure role is present |
| `412`/`452`/`460`/`427` | TSLA balance sheet, DNUT and WMT income statements, TSM facts all load; AAPL has 18 XBRL 10-Ks, MSFT 17 |
| `v3ec` UNH | the `"Carrying Value as of"` debt schedule is found |

## The sharpest case for the rule

`test_issue_v3ec_two_up_maturity_rows.py`'s fixture skipped when UNH's long-term
debt schedule was not found in the parsed document — and **that table going
missing is the v3ec bug**. The test would have gone silent at precisely the
moment it had something to say. It raises now.

`test_issue_452`'s was the same shape: it exists because DNUT's fiscal year was
mis-assigned, and it cannot see that with no statement.

## One thing worth knowing before merging

Several of these tests read a *latest* filing rather than a pinned accession —
`Company("AAPL").get_filings(form="10-K").latest()` and similar. An assertion
can now fail when a future filing changes shape, where a skip stayed quiet.

That is the trade this finding asks for: a shape change is news, and silence was
the defect. But it does mean the next AAPL or GOOGL 10-K could turn one of these
red, and the honest fix for that is pinning the fixtures to accessions
(`tests/_offline_filings.py` exists for it), which is a separate change. Recorded
on the bead rather than smuggled in here.

## Verification

- **67 passed** across the 11 converted files, **zero skipped**
- regression tree still collects **1902** tests — nothing lost
- `pytest -n auto -m fast`: **4522 passed**, 4 skipped, 1 xfailed
- `check_regression_skips.py`: clean tree, empty allowance list

Two `pytest.skip(` strings survive a grep, in comments I wrote explaining the
conversion. The gate parses with `ast` rather than grepping, so it correctly
ignores them — which is why it was written that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
