### PR TITLE
ci: trigger the regression lane on the harness files that decide what it runs

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -33,6 +33,11 @@ on:
       - 'tests/issues/regression/**'
       - 'edgar/**'
       - '.github/workflows/regression-tests.yml'
+      - 'tests/conftest.py'
+      - 'tests/_offline_filings.py'
+      - 'tests/_offline_harness.py'
+      - 'tests/_vcr_safety.py'
+      - 'pyproject.toml'
 
   # Also run on main branch pushes that touch the library.
   #
@@ -42,12 +47,28 @@ on:
   # at all, and that is where the section-extraction defect cluster lives
   # (bead edgartools-07lk.21). `edgar/**` closes the hole as a class instead of
   # one package at a time; docs- and script-only merges still skip it.
+  #
+  # The four test-harness files are here because they decide what this lane
+  # RUNS, not just what it runs against. tests/conftest.py assigns every
+  # regression test its fast/network marker and fails collection on an
+  # unclassified file; _offline_filings.py backs the tests that resolve an
+  # accession without the quarterly index; _offline_harness.py is the offline
+  # measurement; _vcr_safety.py installs the safe YAML loader the cassette gate
+  # exists to protect. A pull request can break this suite by touching only
+  # those and never trigger the lane — PR #1013 was exactly that shape.
+  # pyproject.toml carries the marker registry and pytest options
+  # (xfail_strict among them), which change outcomes suite-wide.
   push:
     branches: [ "main" ]
     paths:
       - 'tests/issues/regression/**'
       - 'edgar/**'
       - '.github/workflows/regression-tests.yml'
+      - 'tests/conftest.py'
+      - 'tests/_offline_filings.py'
+      - 'tests/_offline_harness.py'
+      - 'tests/_vcr_safety.py'
+      - 'pyproject.toml'
 
 # Cancel superseded regression runs on the same ref.
 concurrency:


### PR DESCRIPTION
Follow-up to #1012, found by writing #1013.

## The gap

#1012 filtered the new advisory lane to `edgar/**`, `tests/issues/regression/**` and the workflow file. That covers what the suite runs *against*, but not what decides whether it runs at all — so a pull request can break the regression suite by touching only harness files and never trigger the lane.

**#1013 is exactly that shape.** It changes `tests/conftest.py`, which assigns every regression test its `fast`/`network` marker and fails collection on an unclassified file, and it triggers no regression run.

## Added to both triggers, kept identical

| path | why it changes what the lane runs |
|---|---|
| `tests/conftest.py` | assigns every regression test its fast/network marker; fails collection on an unclassified file |
| `tests/_offline_filings.py` | backs the tests that resolve an accession without fetching the quarterly index |
| `tests/_offline_harness.py` | the offline measurement harness |
| `tests/_vcr_safety.py` | installs the safe YAML loader the cassette gate exists to protect |
| `pyproject.toml` | marker registry and pytest options — `xfail_strict` among them, which changes outcomes suite-wide |

Verified all five exist at these paths, and that the `pull_request` and `push` path lists are byte-identical so the two triggers cannot drift.

Still paths-filtered, so still advisory, and still must never become a required check — the reasoning in the workflow header is unchanged.

## Verification

This PR touches `.github/workflows/regression-tests.yml`, which is already in the filter, so it triggers its own lane.

The new entries do not apply to #1013. For `pull_request` events GitHub reads the workflow — trigger and paths filter both — from the PR's own merge ref, not from the base branch; that is why #1012 was able to run the lane on itself in the same PR that introduced the trigger. #1013 branched from `main` at 67451372, whose copy of this workflow predates these path entries, so it keeps the old filter. Rebasing #1013 onto this change would give it the lane; that is not necessary, since #1013's own conftest change was verified locally against the full fast suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)