### PR TITLE
fix(funds): an outage is not a fund with no filings (edgartools-tg7y)

### DIFF
--- a/edgar/funds/core.py
+++ b/edgar/funds/core.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from rich.text import Text
 
 from edgar.entity.core import Entity
+from edgar.httprequests import TRANSPORT_ERRORS
 from edgar.richtools import repr_rich
 
 if TYPE_CHECKING:
@@ -594,7 +595,16 @@ class Fund:
                 series_filings = getattr(series, 'filings', None)
                 if series_filings is not None and len(series_filings) > 0:
                     filing_tables.append(series_filings.data)
-        except Exception as e:  # network / parse failure — do not fall back to the trust
+        except TRANSPORT_ERRORS:
+            # Let the caller see the outage. The `return None` below means "this
+            # series resolved to nothing", and get_filings turns it into an empty
+            # Filings — correct for a series with no matching filings, a lie for
+            # a failed fetch. There is deliberately no fallback on this path
+            # (GH #888: returning the unfiltered trust would hand back a sibling
+            # series' data), so nothing downstream can notice the difference and
+            # the user is simply told there are no filings.
+            raise
+        except Exception as e:  # parse failure — do not fall back to the trust
             log.debug("Series filing lookup failed for %s: %s", series_id, e)
             return None
 

--- a/edgar/funds/data.py
+++ b/edgar/funds/data.py
@@ -20,7 +20,7 @@ from edgar._filings import Filings
 from edgar.datatools import drop_duplicates_pyarrow
 from edgar.entity.data import EntityData
 from edgar.funds.core import FundClass, FundCompany, FundSeries
-from edgar.httprequests import download_text
+from edgar.httprequests import TRANSPORT_ERRORS, download_text
 
 log = logging.getLogger(__name__)
 
@@ -406,6 +406,17 @@ def direct_get_fund_with_filings(contract_or_series_id: str, filing_type: Option
             return _FundClass(company_info)
         else:
             return _FundSeries(company_info)
+    except TRANSPORT_ERRORS:
+        # "Could not reach SEC" is not "this fund does not exist". Returning None
+        # here made the two indistinguishable, and the caller in funds/core.py
+        # turns None into an EMPTY Filings with no fallback (GH #888 forbids
+        # falling back to the unfiltered trust) — so a network failure silently
+        # told the user the series had filed nothing.
+        #
+        # The genuine not-found signals stay None and are unaffected: an
+        # identifier that is not [CS]\d+, and a browse-edgar page containing
+        # "No matching". Those are answers. This is the absence of one.
+        raise
     except Exception as e:
         log.warning("Error retrieving fund information for %s: %s", contract_or_series_id, e)
         return None

--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -45,6 +45,9 @@ __all__ = [
     "download_datafile",
     "decompress_gzip_with_retry",
     "SSLVerificationError",
+    "TooManyRequestsError",
+    "IdentityNotSetException",
+    "TRANSPORT_ERRORS",
 ]
 
 attempts = 6
@@ -574,6 +577,35 @@ Details: https://github.com/dgunning/edgartools/blob/main/docs/guides/ssl_verifi
 
         message = f"{header}{cause}{diagnostic}{solution}{footer}"
         super().__init__(message)
+
+
+# The errors that mean "we could not ask SEC", as opposed to "we asked and the
+# answer is no". Every lookup that returns None for a missing record needs this
+# distinction, because a bare None collapses the two into one value and the
+# caller cannot tell an absent fund from an outage.
+#
+# It exists because they were being collapsed. `Fund.get_filings(series_only=True)`
+# returned an EMPTY Filings during a network failure — indistinguishable from a
+# series that has filed nothing, and with no fallback path to catch it, because
+# returning the unfiltered trust there would be wrong (GH #888). Found by running
+# the offline audit harness over the network-marked regression tests: six tests
+# failed on `assert None is not None` instead of a connection error, which is the
+# signature of a swallowed transport failure.
+#
+# Catch this tuple and re-raise BEFORE any `except Exception` that converts a
+# failure into None. Not a replacement for the exception hierarchy in bead
+# edgartools-07lk.10 — this is the vocabulary those call sites need today, and it
+# is deliberately a tuple of existing types so it introduces no new public class.
+#
+# IdentityNotSetException belongs here despite not being a transport error: it
+# means no request can be made at all, so reporting it as "not found" is the same
+# lie in a different costume.
+TRANSPORT_ERRORS = (
+    HTTPError,               # httpx base: connect, read, timeout, protocol, status
+    TooManyRequestsError,    # SEC rate limit, after retries are exhausted
+    SSLVerificationError,
+    IdentityNotSetException,
+)
 
 
 def is_redirect(response):

--- a/tests/issues/regression/test_issue_tg7y_fund_series_network_silence.py
+++ b/tests/issues/regression/test_issue_tg7y_fund_series_network_silence.py
@@ -1,0 +1,158 @@
+"""Regression test: a network failure must not look like a fund with no filings.
+
+Bead: edgartools-tg7y. Related: edgartools-07lk.10 (unified error policy).
+
+``Fund.get_filings(series_only=True)`` returned an EMPTY ``Filings`` when the SEC
+could not be reached. Two layers collaborated to produce it:
+
+  edgar/funds/data.py   direct_get_fund_with_filings caught Exception, logged a
+                        warning and returned None
+  edgar/funds/core.py   _get_series_filings saw None, returned None, and
+                        get_filings turned that into Filings([])
+
+Nothing downstream could notice, because this path deliberately has no fallback:
+returning the unfiltered trust would hand back a sibling series' data (GH #888).
+So an outage told the user the series had filed nothing, and the only trace was a
+log line.
+
+Found by running the offline audit harness over the network-marked regression
+tests. 626 of 631 failed with an explicit connection error; six failed on
+``assert None is not None`` instead, which is the signature of a transport error
+that something converted into a missing value.
+
+These tests inject the failure at the transport boundary (``download_text``)
+rather than by blocking sockets, for two reasons: it runs offline in the PR gate,
+and the socket-level harness raises a RuntimeError that httpx never wraps, so it
+would not exercise the httpx-keyed guard that the real failure goes through.
+"""
+
+import httpx
+import pytest
+
+from edgar.funds.core import Fund
+from edgar.httprequests import (
+    TRANSPORT_ERRORS,
+    IdentityNotSetException,
+    SSLVerificationError,
+    TooManyRequestsError,
+)
+
+# Vanguard Long-Term Corporate Bond ETF (VCLT). Any real series ID works; the
+# lookup never completes in these tests because the transport is made to fail.
+VCLT_SERIES = "S000026864"
+
+
+@pytest.fixture
+def fund_with_series():
+    """A Fund pinned to a series, without touching the network to build it."""
+    fund = Fund.__new__(Fund)
+    fund._target_series_id = VCLT_SERIES
+    fund._series = None
+    fund._company = None
+    fund._entity = None
+    fund._series_resolution = "test"
+    return fund
+
+
+def _fail_with(exc):
+    def _raise(*args, **kwargs):
+        raise exc
+    return _raise
+
+
+@pytest.mark.parametrize("exc", [
+    httpx.ConnectError("connection refused"),
+    httpx.ReadTimeout("timed out"),
+    TooManyRequestsError("https://www.sec.gov/cgi-bin/browse-edgar", retry_after=60),
+])
+def test_transport_failure_raises_instead_of_reporting_an_empty_series(
+    monkeypatch, fund_with_series, exc
+):
+    """The failure reaches the caller rather than becoming zero filings."""
+    monkeypatch.setattr("edgar.funds.data.download_text", _fail_with(exc))
+
+    with pytest.raises(type(exc)):
+        fund_with_series.get_filings(series_only=True)
+
+
+def test_the_old_behaviour_is_gone_specifically_an_empty_filings(
+    monkeypatch, fund_with_series
+):
+    """Pin the exact regression: not just 'raises', but 'does not return empty'.
+
+    Written separately from the parametrized test above because the bug was never
+    an exception of the wrong type — it was a perfectly well-formed empty result,
+    which no `pytest.raises` on its own distinguishes from a fix that returns
+    empty for a different reason.
+    """
+    monkeypatch.setattr(
+        "edgar.funds.data.download_text",
+        _fail_with(httpx.ConnectError("connection refused")),
+    )
+
+    try:
+        result = fund_with_series.get_filings(series_only=True)
+    except httpx.ConnectError:
+        return  # correct: the outage surfaced
+
+    pytest.fail(
+        "get_filings(series_only=True) returned "
+        f"{type(result).__name__} with len={len(result)} during a connection "
+        "failure. An empty result here is indistinguishable from a series that "
+        "has filed nothing, and this path has no fallback that could correct it."
+    )
+
+
+def test_a_genuine_miss_is_still_an_empty_result_not_an_error(
+    monkeypatch, fund_with_series
+):
+    """The fix must not turn 'no such series' into an exception.
+
+    browse-edgar answers an unknown identifier with a page containing
+    "No matching". That is an answer, and it must keep producing an empty
+    Filings — otherwise the guard has traded one wrong behaviour for another.
+    """
+    monkeypatch.setattr(
+        "edgar.funds.data.download_text",
+        lambda *a, **k: "<html><body>No matching Ticker Symbol.</body></html>",
+    )
+
+    result = fund_with_series.get_filings(series_only=True)
+    assert len(result) == 0, (
+        f"expected an empty Filings for an unresolvable series, got {len(result)}"
+    )
+
+
+def test_a_parse_failure_is_still_swallowed_to_empty(monkeypatch, fund_with_series):
+    """Scope check: only transport errors were promoted, not everything.
+
+    Schema drift in browse-edgar's HTML still degrades to an empty result rather
+    than raising. That is the pre-existing contract and this change deliberately
+    left it alone — widening it is a separate decision (edgartools-07lk.10).
+    """
+    monkeypatch.setattr(
+        "edgar.funds.data.download_text",
+        _fail_with(ValueError("unexpected table shape")),
+    )
+
+    result = fund_with_series.get_filings(series_only=True)
+    assert len(result) == 0
+
+
+def test_transport_errors_tuple_covers_what_the_http_layer_actually_raises():
+    """A guard keyed on the wrong types is not a guard.
+
+    httpx.HTTPError is the base of ConnectError/ReadTimeout/HTTPStatusError, so
+    naming it covers the transport family without enumerating it. The other three
+    are edgartools' own and are not httpx subclasses, so they have to be listed.
+    """
+    assert issubclass(httpx.ConnectError, TRANSPORT_ERRORS)
+    assert issubclass(httpx.ReadTimeout, TRANSPORT_ERRORS)
+    assert issubclass(httpx.HTTPStatusError, TRANSPORT_ERRORS)
+    assert issubclass(TooManyRequestsError, TRANSPORT_ERRORS)
+    assert issubclass(SSLVerificationError, TRANSPORT_ERRORS)
+    assert issubclass(IdentityNotSetException, TRANSPORT_ERRORS)
+
+    # And it must NOT swallow ordinary bugs into the transport bucket.
+    assert not issubclass(ValueError, TRANSPORT_ERRORS)
+    assert not issubclass(AttributeError, TRANSPORT_ERRORS)


### PR DESCRIPTION
`Fund.get_filings(series_only=True)` returned an **empty `Filings`** when the SEC could not be reached — indistinguishable from a series that has genuinely filed nothing.

## Why nothing caught it

Two layers collaborated:

| layer | behaviour |
|---|---|
| `edgar/funds/data.py` | `direct_get_fund_with_filings` caught `Exception`, logged a warning, returned `None` |
| `edgar/funds/core.py` | `_get_series_filings` saw `None` → returned `None` → `get_filings` turned it into `Filings([])` |

And nothing downstream could notice, because **this path deliberately has no fallback**: returning the unfiltered trust would hand back a sibling series' data (GH #888). So during an outage the user was told the series had filed nothing, with only a log line as evidence.

Note the ordering — `data.py` catches *first*, so `core.py:597` alone would have fixed nothing. Both needed the guard.

## The fix

Adds `edgar.httprequests.TRANSPORT_ERRORS`:

```python
TRANSPORT_ERRORS = (
    HTTPError,               # httpx base: connect, read, timeout, protocol, status
    TooManyRequestsError,    # SEC rate limit, after retries are exhausted
    SSLVerificationError,
    IdentityNotSetException,
)
```

The errors meaning *"we could not ask"* rather than *"the answer is no"*. Both sites re-raise it ahead of their `except Exception`. It is deliberately a tuple of **existing** types introducing no new public class, so it does not preempt the exception hierarchy in `edgartools-07lk.10` — it is the vocabulary those call sites needed today.

**Unchanged on purpose.** A genuine miss still returns an empty `Filings` (an identifier that isn't `[CS]\d+`, or browse-edgar answering "No matching"), and a parse failure still degrades to empty. Only transport errors were promoted; widening that is a separate decision.

## How it was found

Running the offline audit harness over the network-marked regression tests: **626 of 631** failed with an explicit connection error, **six** failed on `assert None is not None` instead.

That turns out to be a reusable technique — a test that fails offline *without* a network error is the signature of a swallowed transport failure. The harness is a silent-None detector, not just a marker checker.

## Verification

7 tests, offline, 0.04s. Faults are injected at `download_text` rather than by blocking sockets, deliberately: the socket harness raises a `RuntimeError` that httpx never wraps, so it would **not** exercise the httpx-keyed guard the real failure goes through.

Checked against the unfixed source rather than trusting a green run — 4 of the 7 fail, one reporting:

> `get_filings(series_only=True) returned Filings with len=0 during a connection failure.`

| suite | result |
|---|---|
| fast suite | 4,585 passed |
| funds suites (incl. network) | 88 passed |
| `test_issue_909_series_id_target_series.py` live | 10 passed |

## One thing I am deliberately not fixing

`edgar/search/efts.py:690` swallows identically, and I originally reported it as the second defect. It isn't one. Its caller falls back to the authoritative quarterly index, and that path (`_get_cached_filings` → `get_filings`) does not swallow, so a real outage still surfaces. It is documented as intentional at `_filings.py:2694`: *"a network failure is deliberately also a miss rather than an error."*

The general rule, which is the part worth keeping: **a swallow is only a defect if no layer above it re-establishes the truth.** Grepping for `except → return None` alone will produce mostly false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)