### PR TITLE
test(regression): every test names the bug it guards, and CI keeps it that way (07lk.24 finding 5)

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -99,6 +99,13 @@ jobs:
     - name: Check no regression test skips itself
       run: python scripts/check_regression_skips.py
 
+    # Same reasoning, different property: a regression test has to name the bug
+    # it guards, or nobody can answer "is this still reachable?" and the tree can
+    # never be pruned. Static like the check above, and for the same reason — it
+    # has to see the post-merge half of the tree on a pull request.
+    - name: Check every regression test names its bug
+      run: python scripts/check_regression_provenance.py
+
     - name: Run fast tests
       run: |
         # Parallelize fast tests - safe, no SEC API calls.

--- a/scripts/check_regression_provenance.py
+++ b/scripts/check_regression_provenance.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""Fail if a regression test cannot be traced back to the bug it guards.
+
+A regression test is a claim that some specific bug stays fixed. A year later
+the assertion is the only surviving record of what that bug was — and the only
+question that justifies ever deleting the test is "is this bug still
+reachable?", which nobody can answer without the report.
+
+THE RULE: every file under ``tests/issues/regression/`` names its origin in the
+module docstring, as one of
+
+    GitHub Issue: https://github.com/dgunning/edgartools/issues/<n>
+    GitHub PR:    https://github.com/dgunning/edgartools/pull/<n>
+    Bead:         edgartools-<id>
+
+A bare ``#819`` in prose does not count, and that is the whole point of the
+check rather than an oversight. 109 of these files named their issue in prose
+and nothing else (bead edgartools-07lk.24 finding 5): the number was there, but
+it was not a link, the form varied ("GH #812", "GitHub issue #488", "issue
+#762"), and no tool could follow it. Requiring one canonical shape is what makes
+"which of these bugs are still open?" answerable by a script instead of by
+reading 256 docstrings.
+
+WHY THE DOCSTRING AND NOT THE FILENAME. The filename usually carries the number
+too, and that is exactly why it is not enough: 67 files here are named after a
+beads slug and 9 are free-form, so the filename answers for some of the tree and
+silently not for the rest. The docstring answers for all of it, and it is where
+someone reading the test is already looking.
+
+WHAT THIS DELIBERATELY DOES NOT CHECK. Whether the issue exists, is open, or
+matches the test. That needs the network, and this runs in the pull-request
+gate. The one-time normalisation that seeded these lines did verify every number
+against the GitHub API — 103 of 103 resolved — but keeping that true is a
+periodic audit, not a per-commit gate.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REGRESSION_DIR = Path(__file__).resolve().parent.parent / "tests" / "issues" / "regression"
+
+# One canonical shape per source. Matched against the module docstring only.
+PROVENANCE = re.compile(
+    r"(?:https?://github\.com/[\w.-]+/[\w.-]+/(?:issues|pull)/\d+"
+    r"|\bedgartools-[a-z0-9]+(?:\.[0-9]+)*\b)",
+    re.IGNORECASE,
+)
+
+# A number mentioned in prose — real provenance that is merely not linkable.
+# Reported separately because the fix is mechanical and the message should say so.
+PROSE_ONLY = re.compile(
+    r"(?:GH[ -]?#?\s*|github\s+issue\s*#?\s*|issue\s*#\s*|#)(\d{2,4})\b",
+    re.IGNORECASE,
+)
+
+SKIP_NAMES = {"conftest.py", "__init__.py"}
+
+
+def main() -> int:
+    if not REGRESSION_DIR.is_dir():
+        print(f"not a directory: {REGRESSION_DIR}", file=sys.stderr)
+        return 1
+
+    missing: list[tuple[str, str]] = []
+    scanned = 0
+
+    for path in sorted(REGRESSION_DIR.rglob("*.py")):
+        if path.name in SKIP_NAMES:
+            continue
+        scanned += 1
+        source = path.read_text(encoding="utf-8", errors="replace")
+        try:
+            docstring = ast.get_docstring(ast.parse(source)) or ""
+        except SyntaxError as exc:
+            missing.append((path.name, f"does not parse: {exc}"))
+            continue
+
+        if PROVENANCE.search(docstring):
+            continue
+
+        prose = PROSE_ONLY.findall(docstring)
+        if prose:
+            n = prose[0]
+            missing.append((
+                path.name,
+                f"names #{n} in prose but not as a link — add "
+                f"'GitHub Issue: https://github.com/dgunning/edgartools/issues/{n}'",
+            ))
+        elif not docstring.strip():
+            missing.append((path.name, "has no module docstring at all"))
+        else:
+            missing.append((path.name, "names no issue, PR or bead"))
+
+    for name, why in missing:
+        print(f"{name}: {why}", file=sys.stderr)
+
+    if missing:
+        print(
+            f"\nRefusing {len(missing)} of {scanned} scanned file(s). A regression "
+            f"test has to say which bug it guards.\n"
+            f"Add ONE of these to the module docstring:\n"
+            f"    GitHub Issue: https://github.com/dgunning/edgartools/issues/<n>\n"
+            f"    GitHub PR:    https://github.com/dgunning/edgartools/pull/<n>\n"
+            f"    Bead:         edgartools-<id>\n"
+            f"If you cannot find the origin, `git log --reverse -- <file>` names the "
+            f"commit that added it, and its pull request or bead id is the answer "
+            f"— that is how the last four in this tree were traced.\n"
+            f"See {Path(__file__).name} for why prose does not count.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {scanned} regression file(s) scanned, every one traceable to its bug.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/issues/regression/README.md
+++ b/tests/issues/regression/README.md
@@ -69,8 +69,32 @@ test_issue_<issue_number>_<short_description>.py
 ```
 
 For bugs with no GitHub number, the beads ID stands in
-(`test_issue_v3ec_two_up_maturity_rows.py`). Put the issue URL in the module
-docstring — most files here predate that habit and are hard to trace back.
+(`test_issue_v3ec_two_up_maturity_rows.py`).
+
+## Provenance — enforced
+
+Every file here names its origin **in the module docstring**, as one of:
+
+```
+GitHub Issue: https://github.com/dgunning/edgartools/issues/<n>
+GitHub PR:    https://github.com/dgunning/edgartools/pull/<n>
+Bead:         edgartools-<id>
+```
+
+`scripts/check_regression_provenance.py` runs as a step in `test-fast` and fails
+the build otherwise. A bare `#819` in prose does **not** satisfy it, deliberately:
+109 files named their issue that way and nothing else, in four different shapes
+(`GH #812`, `GitHub issue #488`, `issue #762`, `#819`), which no tool could
+follow. One canonical form makes "which of these bugs are still open?" a script
+instead of a reading exercise.
+
+The filename is not accepted as the answer either. It usually carries the number,
+but 67 files here are named after a beads slug and 9 are free-form, so it answers
+for part of the tree and silently not the rest.
+
+If you cannot find the origin of an existing file, `git log --reverse -- <file>`
+names the commit that added it, and its pull request or bead ID is the answer —
+that is how the last four in this tree were traced.
 
 ## Writing one
 

--- a/tests/issues/regression/test_424b_parser.py
+++ b/tests/issues/regression/test_424b_parser.py
@@ -6,6 +6,8 @@ against ground-truth values from real SEC filings.
 
 Each test case uses a specific filing accession number and asserts specific
 values verified by hand against the SEC EDGAR filing.
+
+Bead: edgartools-fd3v.6
 """
 import pytest
 

--- a/tests/issues/regression/test_fee_table.py
+++ b/tests/issues/regression/test_fee_table.py
@@ -5,6 +5,8 @@ Tests extract_registration_fee_table() against ground-truth values from real S-3
 verified by hand from SEC EDGAR.
 
 See: docs-internal/research/sec-filings/forms/s-3/registration-fee-table-analysis.md
+
+Bead: edgartools-4jm1
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_215_ge_cross_reference_index.py
+++ b/tests/issues/regression/test_issue_215_ge_cross_reference_index.py
@@ -7,6 +7,8 @@ Item headings, causing extraction to fail.
 Solution: CrossReferenceIndex parser in edgar.documents.cross_reference_index
 
 This test ensures the parser continues to work for GE filings.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/215
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_251_citigroup_cross_reference.py
+++ b/tests/issues/regression/test_issue_251_citigroup_cross_reference.py
@@ -10,6 +10,8 @@ All three parsing strategies failed:
 
 Solution: Made CrossReferenceIndex detection case-insensitive and hyphen-tolerant,
 supported bare item numbers, en-dash page ranges, and continuation rows.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/251
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_282_xbrl_api_regression.py
+++ b/tests/issues/regression/test_issue_282_xbrl_api_regression.py
@@ -9,6 +9,8 @@ The test validates the key API patterns that users depend on:
 2. XBRL.from_filing() for parsing XBRL data
 3. facts.query().by_concept() for querying specific concepts
 4. Proper handling of period_start, period_end, and numeric_value fields
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/282
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_334_rd_expense_sign.py
+++ b/tests/issues/regression/test_issue_334_rd_expense_sign.py
@@ -31,6 +31,8 @@ figures match the income statements:
 
 Both companies are asserted, and Microsoft is the one that carried the bug —
 dropping it for being "the same as Apple now" would delete the regression.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/334
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_381_pr_493.py
+++ b/tests/issues/regression/test_issue_381_pr_493.py
@@ -17,6 +17,8 @@ This test verifies that:
     1. use_local_storage('/custom/path') sets EDGAR_LOCAL_DATA_DIR
     2. get_edgar_data_directory() returns the custom path
     3. download_bulk_data() would use the custom path (via mocking)
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/381
 """
 import os
 import pytest

--- a/tests/issues/regression/test_issue_408_cashflow_empty_periods.py
+++ b/tests/issues/regression/test_issue_408_cashflow_empty_periods.py
@@ -3,6 +3,8 @@ Regression test for Issue #408: Cash flow statement missing values
 
 Ensures that cash flow statements filter out periods containing only empty strings,
 showing only periods with meaningful financial data.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/408
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_412_historical_periods.py
+++ b/tests/issues/regression/test_issue_412_historical_periods.py
@@ -4,6 +4,8 @@ Historical periods in entity statements showed sparse data.
 
 Periods 3rd and 4th should have comprehensive balance sheet data,
 not just cash values.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/412
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_412_regression.py
+++ b/tests/issues/regression/test_issue_412_regression.py
@@ -7,6 +7,8 @@ characters in a single line can be parsed correctly.
 Fixed: SGML header parser was splitting on all '>' characters instead of just the first one,
 causing "ValueError: too many values to unpack" when encountering XBRL inline tags like:
 <ix:nonNumeric id="F_000001" name="dei:AmendmentFlag" contextRef="C_0001318605_20190101_20191231">false</ix:nonNumeric>
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/412
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_420_multi_year_income_statements.py
+++ b/tests/issues/regression/test_issue_420_multi_year_income_statements.py
@@ -5,6 +5,8 @@ Regression test for GitHub issue #420:
 
 This test ensures that users can successfully retrieve multi-year income statements
 using the correct APIs and that the error conditions are properly handled.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/420
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_427_xbrl_data_cap.py
+++ b/tests/issues/regression/test_issue_427_xbrl_data_cap.py
@@ -5,6 +5,8 @@ XBRLS cap out at 2018
 
 This test ensures that the .head() method on filings and XBRLS objects
 returns recent data (newer than 2018) for major companies.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/427
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_429_statement_period_regression.py
+++ b/tests/issues/regression/test_issue_429_statement_period_regression.py
@@ -7,6 +7,8 @@ This test ensures that the CurrentPeriodView correctly selects appropriate
 periods for different statement types:
 - Balance sheet: instant periods (point in time)
 - Income/Cash flow: duration periods (period of time)
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/429
 """
 
 import unittest

--- a/tests/issues/regression/test_issue_438_regression.py
+++ b/tests/issues/regression/test_issue_438_regression.py
@@ -3,6 +3,8 @@ Regression test for Issue #438 - Missing revenue facts in income statement
 
 This test ensures that revenue facts are properly classified and prevents
 future regressions of the us-gaap:Revenues classification issue.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/438
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_439_order_parsing.py
+++ b/tests/issues/regression/test_issue_439_order_parsing.py
@@ -8,6 +8,8 @@ The issue was that CalculationNode.order and PresentationNode.order were showing
 instead of the actual order values specified in the XBRL linkbase files.
 
 Fixed by properly setting the order attribute on child nodes when building the trees.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/439
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_441_current_filings_pagination.py
+++ b/tests/issues/regression/test_issue_441_current_filings_pagination.py
@@ -13,6 +13,8 @@ The fix involved:
 1. Replacing assertion with proper IndexError/KeyError exceptions in __getitem__
 2. Overriding __iter__ and __next__ to handle page-relative iteration correctly
 3. Using super().get_filing_at() directly with page-relative indices during iteration
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/441
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_443_corrupted_cache.py
+++ b/tests/issues/regression/test_issue_443_corrupted_cache.py
@@ -3,6 +3,8 @@ Regression test for GitHub issue #443: JSONDecodeError when fetching certain fil
 
 This test ensures that corrupted submissions cache files are handled gracefully
 by re-downloading the data automatically.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/443
 """
 
 import json

--- a/tests/issues/regression/test_issue_451_expense_sign_regression.py
+++ b/tests/issues/regression/test_issue_451_expense_sign_regression.py
@@ -16,6 +16,8 @@ Related Issues:
 - Issue #334: R&D expense sign inconsistency (resolved with same pattern)
 
 Reporter: @Velikolay
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/451
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_457_locale_cache_fix.py
+++ b/tests/issues/regression/test_issue_457_locale_cache_fix.py
@@ -19,6 +19,8 @@ Implement a one-time cache clearing function that:
 
 This ensures users upgrading from pre-4.19.0 have their old locale-corrupted cache files removed
 automatically on first import.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/457
 """
 
 import locale

--- a/tests/issues/regression/test_issue_460_quarterly_period_labels.py
+++ b/tests/issues/regression/test_issue_460_quarterly_period_labels.py
@@ -14,6 +14,8 @@ For NVIDIA/Autodesk (fiscal year ends in January):
 
 The fix implements `calculate_fiscal_year_for_label()` which derives the fiscal year
 from the period_end date and the company's fiscal year end month.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/460
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_464_10q_rendered_statements.py
+++ b/tests/issues/regression/test_issue_464_10q_rendered_statements.py
@@ -12,6 +12,8 @@ Fix Details:
 - Expanded duration period candidate pool from ~4 to 12 periods
 - Return max_periods * 3 candidates to let data quality filtering choose best ones
 - Mirrors successful Balance Sheet fix from v4.20.1
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/464
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_464_coin_verification.py
+++ b/tests/issues/regression/test_issue_464_coin_verification.py
@@ -12,6 +12,8 @@ filed 2024-10-30, period 2024-09-30). Prior to this pinning, the tests used
 new COIN 10-Qs were filed — a 2026 latest 10-Q has different completeness
 characteristics than the 2024 filing the issue was filed against, and the
 drift caused intermittent regression-test failures unrelated to the fix.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/464
 """
 import re
 

--- a/tests/issues/regression/test_issue_464_period_key.py
+++ b/tests/issues/regression/test_issue_464_period_key.py
@@ -3,6 +3,8 @@ Tests for Issue #464 - Missing period_key column in DataFrame exports
 
 This module tests that the period_key column is included in DataFrame exports
 to enable time series analysis across periods.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/464
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_486_comprehensive_income_zerodiv.py
+++ b/tests/issues/regression/test_issue_486_comprehensive_income_zerodiv.py
@@ -11,6 +11,8 @@ Root cause: total_weight > 0 but sum(weight_map.values()) == 0, causing
 ZeroDivisionError and blocking access to legitimate financial data.
 
 Affected ~9.5% of filings (~2,038 filings, 28+ companies).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/486
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_488_footnote_undefined_variable.py
+++ b/tests/issues/regression/test_issue_488_footnote_undefined_variable.py
@@ -7,6 +7,8 @@ footnoteLink elements correctly, without raising UnboundLocalError.
 The bug was in edgar/xbrl/parsers/instance.py where undefined_footnotes was
 declared inside the footnote_link loop but referenced outside it, causing
 UnboundLocalError when no footnoteLink elements existed.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/488
 """
 
 import xml.etree.ElementTree as ET

--- a/tests/issues/regression/test_issue_512_13f_manager_assignment.py
+++ b/tests/issues/regression/test_issue_512_13f_manager_assignment.py
@@ -7,6 +7,8 @@ Enhance 13F-HR parsing to support multi-manager institutional filings:
 
 Performance: Uses session-scoped fixtures from conftest.py to avoid
 parsing the same 13F filing multiple times (~10s savings per test).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/512
 """
 import pandas as pd
 import pytest

--- a/tests/issues/regression/test_issue_513_data_accuracy.py
+++ b/tests/issues/regression/test_issue_513_data_accuracy.py
@@ -14,6 +14,8 @@ Root causes:
 3. XBRL DocumentPeriodEndDate (2011-12-31) was wrong, SGML header had correct date (2012-12-31)
    - Fix: Added date discrepancy detection in XBRL.period_of_report to prefer SGML date when
      there's a mismatch and SGML year has annual data in the filing
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/513
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_514_parent_concept.py
+++ b/tests/issues/regression/test_issue_514_parent_concept.py
@@ -7,6 +7,8 @@ to enable programmatic analysis of XBRL concept relationships.
 Issue #514 refinement: Distinguish between calculation parent (metric) and presentation parent (abstract).
 - parent_concept: Calculation tree parent (always a metric concept for summation math)
 - parent_abstract_concept: Presentation tree parent (may be abstract, for display hierarchy)
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/514
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_518_income_statement_fallback.py
+++ b/tests/issues/regression/test_issue_518_income_statement_fallback.py
@@ -5,6 +5,8 @@ when IncomeStatement not found.
 This test ensures that when a filing has ComprehensiveIncome but no separate IncomeStatement,
 the system correctly returns ComprehensiveIncome as a fallback instead of returning a
 completely wrong statement type like CashFlowStatement.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/518
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_542_parent_concept_dimensional.py
+++ b/tests/issues/regression/test_issue_542_parent_concept_dimensional.py
@@ -12,6 +12,8 @@ overwriting the FIRST occurrence which has the correct parent information.
 Fix: Use first occurrence of each concept to preserve parent info.
 
 Reporter: Nikolay Ivanov (@Velikolay)
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/542
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_553_financials_type_error.py
+++ b/tests/issues/regression/test_issue_553_financials_type_error.py
@@ -14,6 +14,8 @@ Fix:
 
 Reporter: miruddfan
 Ticker: MSFT
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/553
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_574_structured_dimensions.py
+++ b/tests/issues/regression/test_issue_574_structured_dimensions.py
@@ -8,6 +8,8 @@ The fix adds these NEW columns to dimensional rows in statement DataFrames:
 
 The existing dimension_label is PRESERVED for backwards compatibility and contains
 the full combined format (e.g., 'srt:ProductOrServiceAxis: Products').
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/574
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_633_earnings_data_accuracy.py
+++ b/tests/issues/regression/test_issue_633_earnings_data_accuracy.py
@@ -11,6 +11,8 @@ Each test targets a specific bug from the issue:
   Bug 3: Income statement classification (tables classified UNKNOWN → None)
   Bug 4: Row-type metadata prevents share/EPS confusion
   Smoke: Full pipeline positive case (AMT, known-correct from reporter)
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/633
 """
 
 import pandas as pd

--- a/tests/issues/regression/test_issue_637_ifrs_concept_discovery.py
+++ b/tests/issues/regression/test_issue_637_ifrs_concept_discovery.py
@@ -9,6 +9,8 @@ foreign private issuers (20-F filers) invisible to the standardization layer.
 Fix: Added ifrs-full: to the variant search loop in all three methods,
 added IFRS-specific concept names to synonym groups, and expanded
 currency mappings so non-USD monetary values are recognized.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/637
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_643_duplicate_row_merging.py
+++ b/tests/issues/regression/test_issue_643_duplicate_row_merging.py
@@ -6,6 +6,8 @@ filings (e.g., label changed between years), stitching could produce
 duplicate rows for the same standard_concept. The merge logic consolidates
 these rows when they map to the same standard_concept and have no
 overlapping periods.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/643
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_644_debt_disambiguation.py
+++ b/tests/issues/regression/test_issue_644_debt_disambiguation.py
@@ -6,6 +6,8 @@ contain hints in their name ("Noncurrent", "Current") that should be used
 when section-based disambiguation isn't available.
 
 Fix: Added tag-name-based hints to _disambiguate_by_context() in reverse_index.py.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/644
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_646.py
+++ b/tests/issues/regression/test_issue_646.py
@@ -6,6 +6,8 @@ DIS (Disney) reports CostOfGoodsAndServicesSold with ONLY dimensional facts
 Before the fix, _generate_line_items picked just one dimensional fact via min(),
 losing the other member. The stitched income statement showed ~$52,677M instead
 of the correct ~$58,766M total (Service + Product).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/646
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_648_deck_income_before_tax.py
+++ b/tests/issues/regression/test_issue_648_deck_income_before_tax.py
@@ -6,6 +6,8 @@ IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLoss
 which was in the exclusions list, preventing it from being mapped to PretaxIncomeLoss.
 
 Fix: Removed the tag from exclusions.py and added it to gaap_mappings.json → PretaxIncomeLoss.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/648
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_649_standard_concept_propagation.py
+++ b/tests/issues/regression/test_issue_649_standard_concept_propagation.py
@@ -7,6 +7,8 @@ downstream filtering and cross-company analysis.
 
 Fix: Propagate standard_concept through concept_metadata, output dicts,
 DataFrame columns, and fact extraction.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/649
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_654_mcp_10q_sections.py
+++ b/tests/issues/regression/test_issue_654_mcp_10q_sections.py
@@ -8,6 +8,8 @@ objects that only expose content via __getitem__ with Part/Item keys such as
 
 Fix: _extract_section() now uses obj[key] via the SECTION_MAP_10K / SECTION_MAP_10Q
 lookup tables which contain the canonical key formats accepted by TenK/TenQ.__getitem__.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/654
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_672_empty_sgml_cache_bypass.py
+++ b/tests/issues/regression/test_issue_672_empty_sgml_cache_bypass.py
@@ -5,6 +5,8 @@ When the SEC returns an empty response for a filing's SGML content, the HTTP cac
 stores it forever (cache-forever rule for Archive data). The fix detects empty/truncated
 content immediately after fetch and retries with a direct HTTP request that bypasses
 the cache entirely.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/672
 """
 from unittest.mock import patch, call
 

--- a/tests/issues/regression/test_issue_673.py
+++ b/tests/issues/regression/test_issue_673.py
@@ -5,6 +5,8 @@ income_statement() and comprehensive_income() must resolve to different statemen
 Root cause: IFRS concepts were not classified in Phase 1, and
 ifrs-full_StatementOfComprehensiveIncomeAbstract was ambiguously listed as an
 alternative_concept for both IncomeStatement and ComprehensiveIncome.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/673
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_674_fallback_simulation.py
+++ b/tests/issues/regression/test_issue_674_fallback_simulation.py
@@ -8,6 +8,8 @@ Strategy:
   1. Load a filing normally (SGML path) and capture baseline values
   2. Force fallback by patching FilingSGML.from_filing to raise ValueError
   3. Verify that the fallback path produces equivalent or acceptable results
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/674
 """
 from unittest.mock import patch
 

--- a/tests/issues/regression/test_issue_674_homepage_fallback.py
+++ b/tests/issues/regression/test_issue_674_homepage_fallback.py
@@ -4,6 +4,8 @@ Regression test for GitHub Issue #674: Fallback to FilingHomepage when SGML unav
 When the SEC returns empty content for a filing's .txt file and the direct-fetch retry
 also fails, Filing.sgml() should fall back to constructing a minimal FilingSGML from
 the filing's homepage index page rather than raising an exception.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/674
 """
 from collections import defaultdict
 from unittest.mock import MagicMock, patch

--- a/tests/issues/regression/test_issue_703_balance_sheet_equity_components.py
+++ b/tests/issues/regression/test_issue_703_balance_sheet_equity_components.py
@@ -8,6 +8,8 @@ other concepts across all statement types.
 Fix: Removed the merge heuristic entirely.  No concepts are merged or dropped
 during statement rendering.  Duplicate-label rows (from XBRL concept switches)
 are preserved as-is — data correctness over cosmetics.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/703
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_706_missing_statements.py
+++ b/tests/issues/regression/test_issue_706_missing_statements.py
@@ -17,6 +17,8 @@ Confirmed affected cases:
 - TSLA 2018 Q2 10-Q (0001564590-18-019254): equity statement genuinely absent
 - IBM 2010 10-K (0001047469-10-001151): CI embedded in equity statement
 - GE 2010 10-K: CI embedded in roll-forward equity statement
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/706
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_710_combined_items_heading.py
+++ b/tests/issues/regression/test_issue_710_combined_items_heading.py
@@ -7,6 +7,8 @@ part_i_items_1_and_2._business_and_properties, but TenK.__getitem__ builds
 the key part_i_item_1 and never checks the combined-items variant.
 
 Fix: Add combined-items key scan in __getitem__ after standard part lookups.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/710
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_711_pg_concept_rename.py
+++ b/tests/issues/regression/test_issue_711_pg_concept_rename.py
@@ -11,6 +11,8 @@ them into a single row.
 Fix: Add concept-level equivalence pairs in _EQUIVALENT_CONCEPTS that the stitcher
 uses to merge rows with completely different concept names, guarded by value
 agreement on overlapping periods.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/711
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_712_xbrl_weight_sign.py
+++ b/tests/issues/regression/test_issue_712_xbrl_weight_sign.py
@@ -14,6 +14,8 @@ Affected concepts confirmed:
 - us-gaap:IncomeTaxExpenseBenefit (Income Statement) — weight was 1.0, should be -1.0
 - us-gaap:IncreaseDecreaseInInventories (Cash Flow) — already correct, regression guard
 - us-gaap:IncreaseDecreaseInOtherOperatingAssets (Cash Flow) — already correct, regression guard
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/712
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_743_dataframe_ytd_columns.py
+++ b/tests/issues/regression/test_issue_743_dataframe_ytd_columns.py
@@ -3,6 +3,8 @@
 Statement.to_dataframe() on 10-Q filings only showed YTD columns because
 quarterly and YTD periods shared the same end date, causing column name
 collisions. Now disambiguated with (Q2)/(YTD) suffixes.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/743
 """
 import re
 

--- a/tests/issues/regression/test_issue_745_find_ticker.py
+++ b/tests/issues/regression/test_issue_745_find_ticker.py
@@ -2,6 +2,8 @@
 
 find_ticker() returned 'EP' (Empire Petroleum) for CIK 1506307 (Kinder Morgan)
 because the heuristic stripped 'EP-PC' to 'EP' and picked it over 'KMI' by length.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/745
 """
 from edgar.reference.tickers import find_ticker
 

--- a/tests/issues/regression/test_issue_749_13f_value_units.py
+++ b/tests/issues/regression/test_issue_749_13f_value_units.py
@@ -2,6 +2,8 @@
 
 13F Value column was in thousands for pre-Q4 2022 filings and dollars for
 post-Q4 2022 filings. Values are now normalized to dollars for all periods.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/749
 """
 from datetime import datetime
 

--- a/tests/issues/regression/test_issue_752_fiscal_quarter_labels.py
+++ b/tests/issues/regression/test_issue_752_fiscal_quarter_labels.py
@@ -8,6 +8,8 @@ instead of Q3 for a June period).
 #753: to_dataframe() only added (Qn)/(YTD)/(FY) suffixes when end dates
 collided. Q1 filings (where quarterly = YTD) got no suffix at all.
 Now all duration periods consistently get period-type suffixes.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/752
 """
 import pytest
 from edgar import Filing

--- a/tests/issues/regression/test_issue_762_html_in_dataframe.py
+++ b/tests/issues/regression/test_issue_762_html_in_dataframe.py
@@ -5,6 +5,8 @@ XBRL TextBlock concepts (e.g., segment disclosure tables) contain HTML-encoded f
 The to_dataframe() path must sanitize these to plain text so DataFrame cells are usable.
 
 Uses the MSFT 10-K fixture which has disclosure tables with TextBlock concepts.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/762
 """
 
 import re

--- a/tests/issues/regression/test_issue_765_search_loc_displayed.py
+++ b/tests/issues/regression/test_issue_765_search_loc_displayed.py
@@ -4,6 +4,8 @@ the source section index (DocSection.loc), not the score-sorted display rank.
 Previously BM25 path sorted by score so `panel title "0"` meant
 "highest-scoring section" while regex path (no score) showed "0" for the
 first match in document order — same query, different meaning per method.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/765
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_778_entity_info_local_storage.py
+++ b/tests/issues/regression/test_issue_778_entity_info_local_storage.py
@@ -20,6 +20,8 @@ Fix:
    is allowed, fetch it from the filing homepage (single HTTP request).
 3. Add allow_network_fallback parameter to use_local_storage() so users
    can opt into strict offline mode.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/778
 """
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/issues/regression/test_issue_779_non_calendar_fye_quarterly.py
+++ b/tests/issues/regression/test_issue_779_non_calendar_fye_quarterly.py
@@ -14,6 +14,8 @@ Effect on `Company('ADSK').income_statement(periods=4, annual=False)`:
 
 This regression test exercises the validator at the unit level for all four
 FYE patterns, plus the original #781 schedule-fact rejection case.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/779
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_780.py
+++ b/tests/issues/regression/test_issue_780.py
@@ -10,6 +10,8 @@ silently dropped during stitching.
 The fix adds an opt-in ``include_quarterly`` parameter that surfaces both the
 discrete-quarter and YTD/annual periods from each filing. Default behavior is
 unchanged.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/780
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_791_download_submissions_export.py
+++ b/tests/issues/regression/test_issue_791_download_submissions_export.py
@@ -13,6 +13,8 @@ The error message therefore pointed users at an import that always failed
 with ImportError.
 
 This test verifies that the import path advertised in error messages works.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/791
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_792_time_series_period_start.py
+++ b/tests/issues/regression/test_issue_792_time_series_period_start.py
@@ -11,6 +11,8 @@ period_start=2025-01-01) collapsed onto rows that looked identical except
 for numeric_value.
 
 The fix surfaces period_start and a derived duration_days column.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/792
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_793_ttm_label_collision.py
+++ b/tests/issues/regression/test_issue_793_ttm_label_collision.py
@@ -15,6 +15,8 @@ dict-keyed mapping then collides, with the wrong window winning.
 
 The fix: derive the label fiscal_year from period_end + FYE month rather than
 trusting `as_of_fact.fiscal_year`.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/793
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_794_filing_date_tuple.py
+++ b/tests/issues/regression/test_issue_794_filing_date_tuple.py
@@ -10,6 +10,8 @@ form. Passing a tuple crashed with:
 This regression test asserts the tuple form is now accepted by extract_dates
 (and equivalently by filter_by_date, which delegates to it), preserving the
 public type-hint contract on get_filings.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/794
 """
 
 from datetime import datetime, date

--- a/tests/issues/regression/test_issue_795.py
+++ b/tests/issues/regression/test_issue_795.py
@@ -9,6 +9,8 @@ same reporting period.
 The fix uses exact=":" in concept so that:
 - Fully-qualified names (containing ':') get exact matching
 - Unqualified names (bare labels) retain fuzzy/label matching for discovery
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/795
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_796.py
+++ b/tests/issues/regression/test_issue_796.py
@@ -10,6 +10,8 @@ that won the dedup tiebreaker because the proxy was filed AFTER the 10-K.
 Fix has two layers:
 1. Skip facts with fiscal_period != expected value in derivation methods
 2. Prefer periodic-report sources (10-K, 10-Q) over non-periodic in dedup
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/796
 """
 from datetime import date
 

--- a/tests/issues/regression/test_issue_797.py
+++ b/tests/issues/regression/test_issue_797.py
@@ -9,6 +9,8 @@ that category, so the income statement was silently dropped.
 The fix in edgar/xbrl/viewer.py adds a MetaLinks.json fallback: any report
 whose groupType='statement' is also surfaced as a financial statement, even
 if FilingSummary.xml miscategorizes it.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/797
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_799.py
+++ b/tests/issues/regression/test_issue_799.py
@@ -14,6 +14,8 @@ the smallest depth observed in the report becomes 0.
 The lazy-on-access design avoids re-entering the (stateful) FilingSummary
 ``Reports`` iterator during construction, which previously truncated
 ``viewer.financial_statements``.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/799
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_802_schedule13_cusip_nested.py
+++ b/tests/issues/regression/test_issue_802_schedule13_cusip_nested.py
@@ -10,6 +10,8 @@ The fixtures here are the actual ``primary_doc.xml`` payloads from the
 two filings cited in the issue, so the test exercises the real wire
 format and will fire if the fallback is ever removed or if BeautifulSoup's
 recursive ``find()`` semantics are ever tightened.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/802
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_804_schedule13_event_date_alias.py
+++ b/tests/issues/regression/test_issue_804_schedule13_event_date_alias.py
@@ -4,6 +4,8 @@ Schedule13D exposed the triggering-event date as ``date_of_event`` while
 Schedule13G exposed it as ``event_date``, breaking duck-typing across a
 mixed list of 13D/13G filings. Both classes now accept either name as a
 read-only alias for the underlying attribute.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/804
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_807.py
+++ b/tests/issues/regression/test_issue_807.py
@@ -18,6 +18,8 @@ Acceptance criteria from the issue:
 1. ALGN balance sheet and income statement scaling agree
 2. ABNB scaling consistent across years
 3. Canary 5-ticker subset shows only ``{1, 1_000, 1_000_000}``
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/807
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_810.py
+++ b/tests/issues/regression/test_issue_810.py
@@ -17,6 +17,8 @@ ABT had no 2019 fact for that concept, so ``numeric_value`` returned ``34.0``
 The fix tracks ``primary_period`` on ``ConceptRow`` (populated from
 ``period_headers[0]`` by the parser) and resolves ``numeric_value`` against
 it explicitly, returning ``None`` when the primary period has no value.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/810
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_811.py
+++ b/tests/issues/regression/test_issue_811.py
@@ -16,6 +16,8 @@ The currency check passes but ``amount_*`` can still be ``None`` in valid
 N-PORT XBRL, and ``abs(None)`` raises. The fix adds a null guard to both
 assignments. The test constructs the failure mode deterministically by
 mutating a parsed Sample 7 forward — no SEC filing dependency.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/811
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_812.py
+++ b/tests/issues/regression/test_issue_812.py
@@ -24,6 +24,8 @@ colspan-2 cells (ADI's annual columns).
 The network test pins the ADI 2019 10-K; the offline tests guard the
 fix's contract with synthetic table HTML so the unit-level behavior
 can't quietly regress when SEC R*.htm rendering shifts.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/812
 """
 from __future__ import annotations
 

--- a/tests/issues/regression/test_issue_814.py
+++ b/tests/issues/regression/test_issue_814.py
@@ -21,6 +21,8 @@ Fix:
 The MU 10-Q (accession 0000723125-13-000042) is a structural canary —
 it has BOTH a net loss row AND a separate NCI row, exercising the full
 failure mode.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/814
 """
 import pytest
 from edgar import Company

--- a/tests/issues/regression/test_issue_816_fiscal_period_52_53_week.py
+++ b/tests/issues/regression/test_issue_816_fiscal_period_52_53_week.py
@@ -14,6 +14,8 @@ the period_end can drift into the first days of the following calendar month
 The fix treats end dates within the first 7 days of a month as belonging to
 the previous month for quarter classification, matching the ±15-day tolerance
 already used for fiscal-year-end matching elsewhere in the XBRL package.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/816
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_818_viewer_concept_rows.py
+++ b/tests/issues/regression/test_issue_818_viewer_concept_rows.py
@@ -21,6 +21,8 @@ Fixes (both in ``edgar/sgml/concept_extractor.py``):
   ``period_headers[0]`` behaviour.
 - B: ``class="th"`` cells are filtered out of ``value_cells`` before
   position assignment.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/818
 """
 
 from pathlib import Path

--- a/tests/issues/regression/test_issue_819_search_grep_on_text_filings.py
+++ b/tests/issues/regression/test_issue_819_search_grep_on_text_filings.py
@@ -1,4 +1,7 @@
-"""Regression test for #819 — search()/grep() failed on plain-text filings."""
+"""Regression test for #819 — search()/grep() failed on plain-text filings.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/819
+"""
 
 import pytest
 

--- a/tests/issues/regression/test_issue_821_gs_part_misclassification.py
+++ b/tests/issues/regression/test_issue_821_gs_part_misclassification.py
@@ -12,6 +12,8 @@ in its SEC-canonical Part. Item 1 is only checked in Part I; Item 7 is only
 checked in Part II; etc. If the canonical-Part key is missing, the lookup
 falls through to the legacy chunked_document parser rather than silently
 returning content from a wrong Part.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/821
 """
 
 from unittest.mock import MagicMock

--- a/tests/issues/regression/test_issue_824_13f_putcall_aggregation.py
+++ b/tests/issues/regression/test_issue_824_13f_putcall_aggregation.py
@@ -1,4 +1,7 @@
-"""Regression test for #824 — 13F-HR holdings merged Put/Call rows into equity."""
+"""Regression test for #824 — 13F-HR holdings merged Put/Call rows into equity.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/824
+"""
 
 import pytest
 

--- a/tests/issues/regression/test_issue_826.py
+++ b/tests/issues/regression/test_issue_826.py
@@ -23,6 +23,8 @@ The 20-F section is the high-multiplier (x24) case. It is NOT fully
 dup-free even after the fix — a *separate* anchor-boundary overlap bug
 leaves a small cross-section residual (worst x4) — so its assertion only
 guards that the nested-serialization explosion (this bug) is gone.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/826
 """
 import hashlib
 from collections import Counter

--- a/tests/issues/regression/test_issue_836_spurious_part_iv_items.py
+++ b/tests/issues/regression/test_issue_836_spurious_part_iv_items.py
@@ -25,6 +25,8 @@ as #821).
 The unit tests here exercise ``_make_section_key`` directly (no network). The
 UNH end-to-end assertion is marked ``network`` and pinned to the reported
 filing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/836
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_837_workiva_item1_missing.py
+++ b/tests/issues/regression/test_issue_837_workiva_item1_missing.py
@@ -22,6 +22,8 @@ the same way the generic parser does.
 
 The unit tests exercise ``_parse_item_from_text`` directly (no network). The
 Allstate end-to-end assertion is VCR-backed and pinned to the reported filing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/837
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_839.py
+++ b/tests/issues/regression/test_issue_839.py
@@ -33,6 +33,8 @@ Cross-company survey (SEC XBRL frames, CY2022-CY2024): ~101 filers report
 ``OtherDepreciationAndAmortization`` with no canonical D&A total — including AMD,
 Workday, Open Text, Elevance, MetLife, Crown Holdings, plus MRVL.
 See engineering/analysis/issue-839-otherDA-survey.md.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/839
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_843_fund_series_filings.py
+++ b/tests/issues/regression/test_issue_843_fund_series_filings.py
@@ -10,6 +10,8 @@ it always silently fell through and returned all series.
 
 The fix adds EFTSSearch.to_filings() and rewrites the series_only path to page
 through the EFTS hits and convert them to a Filings index.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/843
 """
 from datetime import date
 

--- a/tests/issues/regression/test_issue_843_nport_form_alias.py
+++ b/tests/issues/regression/test_issue_843_nport_form_alias.py
@@ -8,6 +8,8 @@ carry the literal form "N-PORT" -- the portfolio-holdings report is filed as
 The fix adds a small form-alias map so "N-PORT"/"NPORT" expand to the real
 "NPORT-P" before filtering, applied centrally in filter_by_form() so both
 edgar.get_filings() and company.get_filings() benefit.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/843
 """
 import pyarrow as pa
 import pytest

--- a/tests/issues/regression/test_issue_844.py
+++ b/tests/issues/regression/test_issue_844.py
@@ -8,6 +8,8 @@ whose ``"<TEXT>" in html[:500]`` check raised
 
 The parser now decodes bytes before those string checks, so bytes and str inputs
 behave identically. No network access required.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/844
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_844_sixk_binary_artifacts.py
+++ b/tests/issues/regression/test_issue_844_sixk_binary_artifacts.py
@@ -10,6 +10,8 @@ rendered into ``sixk.text()`` output — the ``.zip`` as raw binary mojibake.
 
 Adding the archive/office extensions to ``binary_extensions`` makes
 ``is_binary()`` skip them, so they no longer pollute the rendered text.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/844
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_846_ownership_to_context_shares.py
+++ b/tests/issues/regression/test_issue_846_ownership_to_context_shares.py
@@ -15,6 +15,8 @@ parse a number.
 Despite the issue title saying "Form 4", every filing the reporter listed is a
 Form 3; the crash site is the Form 3 holdings line that was missed when the related
 Form 3 fix shipped in v5.35.1.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/846
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_848.py
+++ b/tests/issues/regression/test_issue_848.py
@@ -20,6 +20,8 @@ to the FY-minus-Q1Q2Q3 fallback path.
 
 Correct Q4 for GAIN FY2026 = 57,162,000 - (28,788,000 + 9,289,000 + 9,528,000)
                            = 9,557,000.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/848
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_856.py
+++ b/tests/issues/regression/test_issue_856.py
@@ -8,6 +8,8 @@ application configures logging itself (see the Python logging HOWTO,
 handler in their ancestry and fall back to the ``logging.lastResort`` handler,
 which writes to stderr -- especially harmful in MCP / stdio environments where
 stray stderr output corrupts the protocol stream.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/856
 """
 
 import logging

--- a/tests/issues/regression/test_issue_860_search_snippet_offsets.py
+++ b/tests/issues/regression/test_issue_860_search_snippet_offsets.py
@@ -4,6 +4,8 @@ When _get_context truncates text and adds ellipsis markers, the SearchResult
 start_offset and end_offset must reflect positions within the returned context
 string, not the original text. Otherwise SearchResult.snippet highlights the
 wrong characters.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/860
 """
 
 from edgar.documents.document import Document

--- a/tests/issues/regression/test_issue_868_869_offerings.py
+++ b/tests/issues/regression/test_issue_868_869_offerings.py
@@ -14,6 +14,8 @@ Regression tests for two Offerings bugs reported on Airbnb (ABNB) filings.
 
 Ground truth: Airbnb's December 2020 IPO, registration file 333-250118, led by
 Morgan Stanley with Goldman Sachs, priced at $68.00/share.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/868
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_884_query_eval_injection.py
+++ b/tests/issues/regression/test_issue_884_query_eval_injection.py
@@ -8,6 +8,8 @@ builtin namespace and any query string could execute arbitrary code
 The query is now parsed and evaluated against a restricted AST
 (``_AttachmentQuery``). These tests assert that legitimate filter strings still
 work and that injection payloads raise ``ValueError`` instead of executing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/884
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_885_wrong_period_revenue.py
+++ b/tests/issues/regression/test_issue_885_wrong_period_revenue.py
@@ -21,6 +21,8 @@ edgar/financials.py.
 
 Ground truth is the value reported in each filing's own Condensed Consolidated
 Statements of Operations.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/885
 """
 import pytest
 from edgar import get_by_accession_number

--- a/tests/issues/regression/test_issue_886_images_in_markdown.py
+++ b/tests/issues/regression/test_issue_886_images_in_markdown.py
@@ -19,6 +19,8 @@ Fix:
 
 These tests use a small synthetic document (no network) plus a live NVDA 10-K
 ground-truth check.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/886
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_887_missing_transaction_coding.py
+++ b/tests/issues/regression/test_issue_887_missing_transaction_coding.py
@@ -13,6 +13,8 @@ Fix: _ensure_coding_columns() guarantees those columns exist (default None) in
 both NonDerivativeTable.extract_transactions and
 DerivativeTable.extract_transactions, so uncoded rows degrade to
 TransactionType=None instead of crashing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/887
 """
 import pytest
 from bs4 import BeautifulSoup

--- a/tests/issues/regression/test_issue_888_series_only_filtering.py
+++ b/tests/issues/regression/test_issue_888_series_only_filtering.py
@@ -13,6 +13,8 @@ Fix: _get_series_filings() resolves the series via SEC browse-edgar (series ID a
 the CIK parameter), which returns exactly that series' filings; and series_only
 now returns an empty Filings rather than the unfiltered trust when the series
 cannot be resolved.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/888
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_889_c_ticker_class_resolution.py
+++ b/tests/issues/regression/test_issue_889_c_ticker_class_resolution.py
@@ -15,6 +15,8 @@ searched for `class_id == "CNEQ"` (never true) instead of taking the
 ticker-match branch. The fix replaces the naive prefix check with a proper
 Class-ID shape check, `re.match(r'^C\\d+$', identifier)`, mirroring the check
 `get_fund_object` already uses one level up.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/889
 """
 import pandas as pd
 import pytest

--- a/tests/issues/regression/test_issue_891_split_node_item_metadata.py
+++ b/tests/issues/regression/test_issue_891_split_node_item_metadata.py
@@ -22,6 +22,8 @@ Note: the reporter's other suggested fixes (split-node header *detection* and a
 zero-candidate raw-HTML recovery) are deferred — MD&A is already recovered on
 this filing today, and a broad zero-candidate fallback risks fabricating
 mis-scoped sections from inline body mentions.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/891
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_892_get_concept_recency.py
+++ b/tests/issues/regression/test_issue_892_get_concept_recency.py
@@ -21,6 +21,8 @@ Note: the magnitude ``get_concept`` returns for a flow concept like capex still
 reflects ``get_fact``'s existing period selection (it does not distinguish a
 single quarter from a fiscal-YTD/cumulative value) — a separate, pre-existing
 concern tracked apart from this tag-staleness fix.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/892
 """
 from datetime import date
 

--- a/tests/issues/regression/test_issue_893_ttm_staleness.py
+++ b/tests/issues/regression/test_issue_893_ttm_staleness.py
@@ -19,6 +19,8 @@ Fix (companion of GH #892's get_concept recency fix):
    warning) when the newest quarter lags the reference date (``as_of``, or today)
    by more than one reporting cycle, so genuinely stale data across *all*
    candidates is still detectable programmatically.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/893
 """
 import datetime
 from datetime import date

--- a/tests/issues/regression/test_issue_894_ppe_derivation.py
+++ b/tests/issues/regression/test_issue_894_ppe_derivation.py
@@ -24,6 +24,8 @@ only as prior-year-end comparatives in later 10-Qs, tagged Q1-Q3 of the
 comparable net (Gross - AccumulatedDepreciation); GE additionally folds an
 operating-lease ROU asset into its extension line, but that asset renders on its
 own standardized row (``OperatingLeaseRightOfUseAsset``).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/894
 """
 from datetime import date
 

--- a/tests/issues/regression/test_issue_904_toc_subset_overflow.py
+++ b/tests/issues/regression/test_issue_904_toc_subset_overflow.py
@@ -29,6 +29,8 @@ A fourth, belt-and-braces layer (the successor-header guardrail on
 ``HybridSectionDetector``) flags any remaining item section that still embeds
 a line-anchored header of a later, undetected item — the failure class size
 bands can't see (Item 7's band is generous; Item 1B has no band at all).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/904
 """
 import re
 

--- a/tests/issues/regression/test_issue_905_phantom_part_items.py
+++ b/tests/issues/regression/test_issue_905_phantom_part_items.py
@@ -14,6 +14,8 @@ to ``ANOMALOUS_CONFIDENCE`` — so callers can tell the Part's boundaries were
 mis-anchored. The content itself is kept: the underlying running-header
 mis-anchoring is a separate, harder problem, and silently dropping the section
 would lose the only copy of the MD&A text.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/905
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_907.py
+++ b/tests/issues/regression/test_issue_907.py
@@ -34,6 +34,8 @@ Ground truth, GOOGL FY2024 investing cash flow (10-K, accession
     Q4 -16.180   = FY      -45.536 - YTD_9M -29.356
                   ------
     sum -45.536  == the reported FY figure
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/907
 """
 
 from datetime import date

--- a/tests/issues/regression/test_issue_909_series_id_target_series.py
+++ b/tests/issues/regression/test_issue_909_series_id_target_series.py
@@ -12,6 +12,8 @@ series' data, which is exactly the harm #888 fixed for tickers.
 Fix: backfill ``_target_series_id`` from the resolved hierarchy (self._series)
 when the ticker path did not set it, so all three identifier forms for the same
 fund behave identically.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/909
 """
 import pytest
 

--- a/tests/issues/regression/test_issue_910_ttm_eps.py
+++ b/tests/issues/regression/test_issue_910_ttm_eps.py
@@ -20,6 +20,8 @@ periods came back NaN.
 
 Root cause (formatting): the renderer formatted anything under $1M as
 f"${value:,.0f}", so EPS of 20.16 displayed as "$20".
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/910
 """
 import pandas as pd
 import pytest

--- a/tests/issues/regression/test_issue_915_workiva_split_toc_hrefs.py
+++ b/tests/issues/regression/test_issue_915_workiva_split_toc_hrefs.py
@@ -30,6 +30,8 @@ carries the number are recovered when exactly one group has a real target.
 The unit tests exercise ``_analyze_workiva_toc`` on a minimal Tesla-shaped
 TOC (no network). The end-to-end assertions are VCR-backed and pinned to the
 reported filing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/915
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_918_cross_reference_anchoring.py
+++ b/tests/issues/regression/test_issue_918_cross_reference_anchoring.py
@@ -24,6 +24,8 @@ Tables" index rows — is tracked separately and not covered here.)
 
 Unit tests are synthetic (no network); the end-to-end assertion is
 VCR-backed and pinned to the reported filing.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/918
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_918_numbered_index_rows.py
+++ b/tests/issues/regression/test_issue_918_numbered_index_rows.py
@@ -24,6 +24,8 @@ Unit tests are synthetic (no network); end-to-end assertions are VCR-backed
 and pinned to the reported filing. The FMCC 10-Q half of the fix (the GH
 #905 phantoms, removed at the source by the same guard) is pinned in
 tests/issues/regression/test_issue_905_phantom_part_items.py.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/918
 """
 
 import lxml.html

--- a/tests/issues/regression/test_issue_920_rf_item7a_anchor_collision.py
+++ b/tests/issues/regression/test_issue_920_rf_item7a_anchor_collision.py
@@ -19,6 +19,8 @@ item's own heading behind its own anchor. Item 7 keeps the shared page anchor
 (it owns the page it starts on); Item 7A is re-pointed at its real body heading.
 
 Offline (local fixture).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/920
 """
 from pathlib import Path
 

--- a/tests/issues/regression/test_issue_928_has_index_backtracking.py
+++ b/tests/issues/regression/test_issue_928_has_index_backtracking.py
@@ -25,6 +25,8 @@ locates, and the single mega-pattern is replaced by a linear row-by-row scan
 reusing the row/cell shapes ``parse()`` relies on. Bounding the search window
 alone was *not* sufficient — on dense markup the old pattern exceeded 10s at
 3.6K chars, so any fixed window remained exploitable.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/928
 """
 import re
 import time

--- a/tests/issues/regression/test_issue_income_statement_revenue_duplicate_root.py
+++ b/tests/issues/regression/test_issue_income_statement_revenue_duplicate_root.py
@@ -4,6 +4,8 @@ Regression test: prevent duplicated revenue rows from additional income statemen
 When revenue is promoted to the top-level income statement, some learned virtual trees also
 contain RevenuesAbstract as an additional root. That extra root must not re-introduce
 Revenues as a second row.
+
+GitHub PR: https://github.com/dgunning/edgartools/pull/790
 """
 
 from types import SimpleNamespace

--- a/tests/issues/regression/test_issue_koq3_prospectus_overlap.py
+++ b/tests/issues/regression/test_issue_koq3_prospectus_overlap.py
@@ -22,6 +22,8 @@ Fix:
 This is the silent-regression guard the existing prospectus test could not catch:
 ``TestProspectusSections.test_section_text_extraction`` only asserts sections are
 non-empty, and bleeding makes a section *longer*, never empty.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/871
 """
 from edgar.documents import parse_html
 from edgar.documents.config import ParserConfig

--- a/tests/issues/regression/test_issue_sc13g_period_of_report.py
+++ b/tests/issues/regression/test_issue_sc13g_period_of_report.py
@@ -8,6 +8,8 @@ each filer's name with no delimiter. Downstream callers (e.g.
 sec-edgar-mcp) then blow up with "Invalid isoformat string: ...". The fix
 is to pick the block by matching its <div class="infoHead"> label instead
 of by position.
+
+GitHub PR: https://github.com/dgunning/edgartools/pull/787
 """
 
 import pytest

--- a/tests/issues/regression/test_issue_xbrl_warning_traceability.py
+++ b/tests/issues/regression/test_issue_xbrl_warning_traceability.py
@@ -25,6 +25,8 @@ Three defects combined:
 
 Additionally, lxml's "Document is empty" is benign here - a document with no
 parseable root has no inline XBRL either - so it is now DEBUG, not WARNING.
+
+Bead: edgartools-cxvz
 """
 import logging
 

--- a/tests/issues/regression/test_mcp_fpi_support.py
+++ b/tests/issues/regression/test_mcp_fpi_support.py
@@ -10,6 +10,8 @@ The core library already supports 20-F and 6-K - the gap was only in the MCP lay
 - SixK = CurrentReport alias exists
 - IFRS tags exist in statement_resolver.py alongside US-GAAP
 - Missing: Section maps in MCP edgar_filing tool
+
+GitHub PR: https://github.com/dgunning/edgartools/pull/660
 """
 
 import logging

--- a/tests/issues/regression/test_to_context_hint_integrity.py
+++ b/tests/issues/regression/test_to_context_hint_integrity.py
@@ -25,6 +25,8 @@ Two independent checks:
    resolve to a real attribute (class descriptor, dataclass field, ``__init__``
    parameter, or annotation), and the call shape must match (methods shown with
    ``()``, properties/attributes shown without).
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/841
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Closes finding 5 of `edgartools-07lk.24`.

## The finding was real but the shape was different

The bead said *"195 of 250 files carry no GitHub issue URL"* and that this **blocks pruning**, because you cannot answer "is this bug still reachable?" without the link. Measured on `main` before touching anything:

| | files |
|---|---|
| total | 256 |
| already carried a URL or beads id | 143 |
| carried neither | 113 |
| …of those, **named the issue in prose** | **109** |
| …genuinely said nothing | **4** |

**Provenance was not lost — it was unlinkable.** Written four different ways (`GH #812`, `GitHub issue #488`, `issue #762`, `#819`), so no tool could follow it. The premise that you can't cheaply tell whether a bug is still reachable was wrong: the number was in the docstring, and usually the filename too.

## Normalised, with the numbers verified first

Every candidate number was checked against the GitHub API **before** anything was written: **103 distinct numbers, 103 resolved** (100 issues, 1 PR, none missing). Then the set of numbers actually written was diffed against the set verified — exact match, nothing invented.

Deriving a URL from the number the author already put in the filename and docstring asserts nothing new. It makes an existing claim clickable.

Three needed a decision rather than a derivation, each checked by hand:

| file | resolution |
|---|---|
| `test_issue_381_pr_493.py` | issue 381, fixed by PR 493 → **381** |
| `test_issue_koq3_prospectus_overlap.py` | docstring: "the GH #871 follow-up" → **871** |
| `test_to_context_hint_integrity.py` | body names GH #841 → **841** |

The four with no number anywhere were traced with `git log --reverse` on the file, which names the commit that added it: PR #790, PR #787, PR #660, and bead `edgartools-cxvz`.

Then the new gate caught **four more** — the bulk script accepted provenance anywhere in the file, the gate requires it in the module docstring. That disagreement is the gate doing its job on its first run.

## The gate

`scripts/check_regression_provenance.py`, wired as a step in `test-fast` beside `check_regression_skips.py`. Static for the same reason as its sibling: half this tree runs post-merge, so a runtime hook never sees it on a PR.

Two things it rejects on purpose:

- **Prose doesn't count.** One canonical form is what makes "which of these bugs are still open?" a script instead of a reading exercise.
- **The filename doesn't count.** It usually carries the number, but 67 files here are named after a beads slug and 9 are free-form — so it answers for part of the tree and silently not the rest.

And one it deliberately does **not** check: whether the issue exists, is open, or matches the test. That needs the network and this runs pre-merge. The one-time verification above did it; keeping it true is a periodic audit, not a per-commit gate.

## Verification

Load-bearing checked against planted offenders, on the **exit code** rather than the message:

| state | exit |
|---|---|
| clean tree | 0 |
| URL stripped back to prose | 1 |
| new file with no docstring | 1 |

Fast suite **4,585 passed**. Both gates green over 256 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)