### PR TITLE
test(regression): parse each big 10-K fixture once per module (07lk.24 Tier 3)

### DIFF
--- a/tests/issues/regression/test_issue_920_rf_item7a_anchor_collision.py
+++ b/tests/issues/regression/test_issue_920_rf_item7a_anchor_collision.py
@@ -24,6 +24,8 @@ GitHub Issue: https://github.com/dgunning/edgartools/issues/920
 """
 from pathlib import Path
 
+import pytest
+
 from edgar.documents.config import ParserConfig
 from edgar.documents.parser import HTMLParser
 
@@ -31,14 +33,27 @@ _FIXTURE = (Path(__file__).resolve().parents[2]
             / "fixtures" / "html" / "rf" / "10k" / "rf-10-k-2022-02-24.html")
 
 
-def _sections():
+@pytest.fixture(scope="module")
+def sections():
+    """Parse the RF 10-K once for the whole module.
+
+    This was a plain `_sections()` helper that every test called, so the 9.5 MB
+    fixture was parsed once per test. Measured 2026-08-10: 3 parses, 3.7s of
+    them redundant — the largest single such cost in the offline regression
+    tree (bead edgartools-07lk.24, Tier 3).
+
+    Module scope rather than session scope so the parsed document is
+    released when this file finishes; one parsed 10-K of this size costs
+    ~0.3 GB resident, and `test-ci-fast` runs `-n auto`, which would multiply
+    that across workers.
+    """
     doc = HTMLParser(ParserConfig(form="10-K", detect_sections=True)).parse(_FIXTURE.read_text())
     return doc.sections
 
 
-def test_item7a_is_its_own_stub_not_item7():
+def test_item7a_is_its_own_stub_not_item7(sections):
     """Item 7A resolves to its own incorporation-by-reference stub."""
-    secs = _sections()
+    secs = sections
     item7 = secs["part_ii_item_7"].text()
     item7a = secs["part_ii_item_7a"].text()
 
@@ -53,15 +68,15 @@ def test_item7a_is_its_own_stub_not_item7():
     assert "EXECUTIVE OVERVIEW" not in item7a.upper()
 
 
-def test_item7_mda_stays_intact():
+def test_item7_mda_stays_intact(sections):
     """Item 7's MD&A body is unchanged (it keeps the shared page anchor)."""
-    item7 = _sections()["part_ii_item_7"].text()
+    item7 = sections["part_ii_item_7"].text()
     assert len(item7) > 150_000, f"Item 7 MD&A regressed ({len(item7)} chars)"
     assert "EXECUTIVE OVERVIEW" in item7.upper()
 
 
-def test_item7a_does_not_overrun_into_later_items():
+def test_item7a_does_not_overrun_into_later_items(sections):
     """The re-pointed 7A stops before Item 8 — no later item header bleeds in."""
-    item7a = _sections()["part_ii_item_7a"].text().upper()
+    item7a = sections["part_ii_item_7a"].text().upper()
     for later in ("ITEM 8", "ITEM 9", "ITEM 9A"):
         assert later not in item7a, f"Item 7A overran into {later}"

--- a/tests/issues/regression/test_issue_gegs_axp_short_items.py
+++ b/tests/issues/regression/test_issue_gegs_axp_short_items.py
@@ -23,20 +23,33 @@ content, and the large neighbours they used to swallow stay intact.
 """
 from pathlib import Path
 
+import pytest
+
 from edgar.documents.config import ParserConfig
 from edgar.documents.parser import HTMLParser
 
 _FIXTURE = Path(__file__).resolve().parents[2] / "fixtures" / "html" / "axp" / "10k" / "axp-10-k-2025-02-07.html"
 
 
-def _sections():
+@pytest.fixture(scope="module")
+def sections():
+    """Parse the AXP 10-K once for the whole module.
+
+    This was a plain `_sections()` helper called by every test, so the 5.1 MB
+    fixture was parsed once per test: 4 parses, 3.3s of them redundant
+    (measured 2026-08-10, bead edgartools-07lk.24 Tier 3).
+
+    Module scope, not session scope: one parsed 10-K of this size costs ~0.3 GB
+    resident, and `test-ci-fast` runs `-n auto`, so a session-scoped document
+    would be held on every worker that touched this file.
+    """
     doc = HTMLParser(ParserConfig(form="10-K", detect_sections=True)).parse(_FIXTURE.read_text())
     return doc.sections
 
 
-def test_item3_legal_proceedings_stays_a_reference_stub():
+def test_item3_legal_proceedings_stays_a_reference_stub(sections):
     """Item 3 keeps its incorporated-by-reference one-liner (was 166KB over-capture)."""
-    item3 = _sections()["part_i_item_3"].text()
+    item3 = sections["part_i_item_3"].text()
     assert len(item3) < 500, f"Item 3 over-extracted ({len(item3)} chars) — rescue swallowed neighbours"
     assert "LEGAL PROCEEDINGS" in item3
     assert "Note 12" in item3
@@ -44,26 +57,26 @@ def test_item3_legal_proceedings_stays_a_reference_stub():
     assert "MARKET FOR REGISTRANT" not in item3
 
 
-def test_item4_mine_safety_stays_not_applicable():
+def test_item4_mine_safety_stays_not_applicable(sections):
     """Item 4 keeps 'Not applicable' (was 166KB over-capture)."""
-    item4 = _sections()["part_i_item_4"].text()
+    item4 = sections["part_i_item_4"].text()
     assert len(item4) < 300, f"Item 4 over-extracted ({len(item4)} chars)"
     assert "MINE SAFETY" in item4
     assert "Not applicable" in item4
 
 
-def test_item7a_points_to_mda_not_the_financials():
+def test_item7a_points_to_mda_not_the_financials(sections):
     """Item 7A is a pointer to MD&A Risk Management, not the Item 8 financial body."""
-    item7a = _sections()["part_ii_item_7a"].text()
+    item7a = sections["part_ii_item_7a"].text()
     assert len(item7a) < 500, f"Item 7A over-extracted ({len(item7a)} chars) — swallowed Item 8"
     assert "QUANTITATIVE AND QUALITATIVE" in item7a
     # The over-capture used to pull in the financial statements' MD&A report.
     assert "MANAGEMENT'S REPORT" not in item7a.upper()
 
 
-def test_large_neighbours_intact():
+def test_large_neighbours_intact(sections):
     """The genuine large items the rescue used to swallow are unchanged."""
-    secs = _sections()
+    secs = sections
     item7 = secs["part_ii_item_7"].text()
     item8 = secs["part_ii_item_8"].text()
     assert len(item7) > 100_000, f"Item 7 MD&A regressed ({len(item7)} chars)"

--- a/tests/issues/regression/test_issue_gegs_section_boundaries.py
+++ b/tests/issues/regression/test_issue_gegs_section_boundaries.py
@@ -16,31 +16,44 @@ Offline (local fixture); asserts ranges + content, not exact recovery lengths.
 """
 from pathlib import Path
 
+import pytest
+
 from edgar.documents.config import ParserConfig
 from edgar.documents.parser import HTMLParser
 
 _FIXTURE = Path(__file__).resolve().parents[2] / "fixtures" / "html" / "cvx" / "10k" / "cvx-10-k-2025-02-21.html"
 
 
-def _sections():
+@pytest.fixture(scope="module")
+def sections():
+    """Parse the CVX 10-K once for the whole module.
+
+    This was a plain `_sections()` helper called by every test, so the 6.0 MB
+    fixture was parsed once per test: 3 parses, 2.6s of them redundant
+    (measured 2026-08-10, bead edgartools-07lk.24 Tier 3).
+
+    Module scope, not session scope: one parsed 10-K of this size costs ~0.3 GB
+    resident, and `test-ci-fast` runs `-n auto`, so a session-scoped document
+    would be held on every worker that touched this file.
+    """
     doc = HTMLParser(ParserConfig(form="10-K", detect_sections=True)).parse(_FIXTURE.read_text())
     return doc.sections
 
 
-def test_cvx_mda_recovered_not_a_pointer_stub():
+def test_cvx_mda_recovered_not_a_pointer_stub(sections):
     """Item 7 carries the real MD&A, not the 242-char incorporation pointer."""
-    item7 = _sections()["part_ii_item_7"].text()
+    item7 = sections["part_ii_item_7"].text()
     assert len(item7) > 50_000, f"Item 7 MD&A not recovered (got {len(item7)} chars)"
     assert "Management" in item7 and "Discussion" in item7
 
 
-def test_cvx_financials_recovered():
+def test_cvx_financials_recovered(sections):
     """Item 8 carries the financial statements, not the 158-char stub."""
-    item8 = _sections()["part_ii_item_8"].text()
+    item8 = sections["part_ii_item_8"].text()
     assert len(item8) > 50_000, f"Item 8 financials not recovered (got {len(item8)} chars)"
 
 
-def test_cvx_item14_not_over_extracted():
+def test_cvx_item14_not_over_extracted(sections):
     """Item 14 (Principal Accountant Fees) no longer absorbs the financial body."""
-    item14 = _sections()["part_iii_item_14"].text()
+    item14 = sections["part_iii_item_14"].text()
     assert len(item14) < 50_000, f"Item 14 over-extracted ({len(item14)} chars) — clamp failed"


### PR DESCRIPTION
Tier 3 of `edgartools-07lk.24`. Like Tier 2, the work is real but the bead's list pointed at the wrong files.

## What changed

Three files defined `_sections()` as a plain helper called by every test, so a multi-megabyte committed fixture was re-parsed once per test:

| file | fixture | parses | redundant |
|---|---|---|---|
| `test_issue_920_rf_item7a_anchor_collision.py` | RF 9.5 MB | 3 | 3.7s |
| `test_issue_gegs_axp_short_items.py` | AXP 5.1 MB | 4 | 3.3s |
| `test_issue_gegs_section_boundaries.py` | CVX 6.0 MB | 3 | 2.6s |

Each becomes a module-scoped fixture — the bead's own prescription. **Every assertion is unchanged**; only the parse count drops, 10 → 3.

## Measured, not estimated

`HTMLParser.parse` was instrumented to record a hash of its input and its duration across a full offline run of `tests/issues/regression`:

|  | parses | distinct docs | parsing | redundant | wall |
|---|---|---|---|---|---|
| before | 193 | 107 | 54.3s | 23.8s | 97.3s |
| after | 186 | 107 | 48.0s | 15.2s | 91.5s |

Same outcome both times: **1323 passed, 1 xfailed**.

## The bead's Tier 3 list is not where the cost is

It names 30 zero-unique-coverage files and asserts they are *"all edgar/documents section-extraction tests re-parsing the same handful of big filings"*. Measured, its eight named large files carry **0.59s of redundant parsing between them** — `test_issue_2vzk_exhibit_index.py` parses once and already had a module fixture, and `test_issue_825.py` and `test_issue_796.py` parse no HTML at all.

Zero unique **coverage** and redundant **parsing** are different properties. The bead assumed one implied the other.

Extra-parse *count* is a bad proxy too: `test_issue_918_cross_reference_anchoring.py` makes 9 extra parses worth 0.01s. The 14 files below the top three account for 0.23s combined and are left alone.

## Not consolidated, deliberately

Two files re-parse on purpose, and the seconds are worth less than the assertion:

- **`test_filing_text_baseline.py` (2.25s)** — a golden-hash baseline whose `test_both_paths_agree` exists to run `Filing.text()` and `FilingSGML.text()` as two independent end-to-end paths.
- **`test_issue_sfnr_filing_text_fidelity.py` (1.25s)** — parses three times inside one test to compare `text(200)`, `text(500)` and the rich route. `Document.text()` memoises into `_text_cache`; its read guard requires `not include_tables` so these calls miss the cache *today*, but the test's subject **is** text-extraction state.

## Why module scope, not session scope

One parsed 16.7 MB 10-K costs **~0.28 GB resident** (measured). `test-ci-fast` runs `-n auto`, so a session-scoped document would be held per worker.

**10.1s of cross-file duplicate parsing remains** (four file pairs read the same fixtures). Not addressed here — it needs session scope, which is what that memory number argues against. Numbers are on the bead.

## Also measured and rejected

`--dist loadfile` would make module-scoped fixtures pay under xdist too. It is 12% faster on `tests/issues/regression` alone (26.4s vs 30.0s) but **a wash on the full fast suite** (64.4s vs 63.9s) — better fixture reuse cancels against worse load balancing across 4577 tests. No change made.

> Note: measurement covers the offline half. The 652 network-marked regression tests were not instrumented; their dominant cost is the network, not parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)