### PR TITLE
fix(entity): require word boundaries for spaced LP suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Entity(2037927)` classified Wyatt Michael P. as a company.** The name heuristic treated spaced `L P` as a loose substring, matching across the end of "Michael" and the middle initial. Spaced `L P` now requires whole-word boundaries while remaining a recognized legal suffix. (GH #1019)
+
 - **A table data row rendered only the first line of each cell, discarding the rest.** Header rows were expanded line by line; data rows went through a formatter that did `content.split('\n')[0]`. Both text renderers had the same split — the Rich path paired `overflow="fold"` for headed columns with `overflow="ellipsis"` for headerless ones. Filers from the 1990s and 2000s wrap an entire document in a single-cell layout table, so the cut discarded the filing: Autoliv's 2001 DEFR14A rendered 20,523 characters instead of 83,316, losing its "DEAR STOCKHOLDER" cover letter from an 18,759-character cell. Modern filings lost less but still lost — Apple's FY2024 10-K gains 843 characters of non-whitespace content, AbbVie's 2,828. Exposed rather than caused by the exhibit-index fix, which reclassified three of Autoliv's layout tables from header rows to data rows and so moved them onto the truncating path. (`edgartools-j8bs`)
 
 - **Table lines carried trailing padding to the last column's full width.** Harmless when a tall cell paid it once; now that multi-line cells expand to one line each it is paid per line. Trimmed, which makes rendered text substantially smaller with identical content — Autoliv is 53,278 characters against 83,316 before the truncation bug existed, carrying 39,420 non-whitespace characters against 39,307.

--- a/edgar/entity/constants.py
+++ b/edgar/entity/constants.py
@@ -163,7 +163,7 @@ FILER_TYPE_DOMESTIC_FORMS = frozenset({
 COMPANY_NAME_KEYWORDS = {
     # Corporate structure (long or punctuated - safe as substring)
     "CORPORATION", "L.L.C.", "L L C", "LIMITED",
-    "L.P.", "L P", "COMPANY", "HOLDINGS",
+    "L.P.", "COMPANY", "HOLDINGS",
     "PARTNERS", "PARTNERSHIP",
     # Investment entities
     "CAPITAL", "VENTURES",
@@ -188,6 +188,9 @@ COMPANY_NAME_KEYWORDS_STRICT = {
 # Pre-compiled regex for SEC filing suffixes like /ADR/, /BD/, /TA/
 _SEC_SUFFIX_RE = re.compile(r"/[A-Z0-9-]{2,}(?:/|\s|$)")
 
+# Spaced legal suffixes must not match across words in personal names.
+_SPACED_LP_RE = re.compile(r"\bL P\b")
+
 # Pre-compiled regex for joint filer detection (same first word on both sides of &)
 # Matches SEC-format names like "SMITH JOHN & SMITH JANE" where the surname repeats
 _JOINT_FILER_RE = re.compile(r"\b(\w+)\s+\w+.*&.*\b\1\b")
@@ -206,6 +209,9 @@ def _name_suggests_company(name: str) -> bool:
     # Strict keyword match (whole word only)
     words = set(re.split(r"\W+", upper))
     if words & COMPANY_NAME_KEYWORDS_STRICT:
+        return True
+
+    if _SPACED_LP_RE.search(upper):
         return True
 
     # SEC filing suffixes like /ADR/, /BD/, /TA/ indicate companies

--- a/tests/test_entity_core.py
+++ b/tests/test_entity_core.py
@@ -305,6 +305,7 @@ CLASSIFICATION_UNIT_TESTS = [
     ("name_corporation", dict(name="MICROSOFT CORPORATION"), False),
     ("name_co_whole_word", dict(name="STANDARD OIL CO"), False),
     ("name_co_not_substring", dict(name="SCOTT JOHNSON"), True),
+    ("name_spaced_lp_not_substring", dict(name="WYATT MICHAEL P.", cik=2037927), True),
     ("name_plain_individual", dict(name="JOHN SMITH"), True),
     # Signal 8: owner flag (weak → individual)
     ("owner_flag_alone", dict(insider_transaction_for_owner_exists=True), True),
@@ -364,6 +365,10 @@ class TestNameSuggestsCompany:
 
     def test_strict_keyword_not_substring(self):
         assert _name_suggests_company("SCOTT JOHNSON") is False
+
+    def test_spaced_lp_suffix_requires_word_boundaries(self):
+        assert _name_suggests_company("WYATT MICHAEL P.") is False
+        assert _name_suggests_company("ACME L P") is True
 
     def test_sec_suffix(self):
         assert _name_suggests_company("TOYOTA MOTOR CORP /ADR/") is True


### PR DESCRIPTION
## Summary

- treat spaced `L P` as a whole-word legal suffix instead of a loose substring
- preserve detection for names such as `ACME L P`
- add regression coverage for SEC entity 2037927 (`WYATT MICHAEL P.`)

Fixes #1019

## Testing

- `.venv/bin/python -m pytest -q tests/test_entity_core.py` — 52 passed
- focused Ruff checks on the changed source and test files — passed
