### PR TITLE
feat(api): declare the public API — edgar.__all__ (07lk.5, additive half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`edgar` now declares `__all__` — 110 names — so the supported API is answerable.** There was no way to tell an API from an accident: 141 names were reachable from the top level, including `Optional` and `partial` (imported for annotations) and `Document`, the *legacy* `edgar.files` parser, which is a different class from `edgar.documents.Document` and is removed in 6.0. Names left out stay importable; 6.0 makes them private. **`from edgar import *` is narrower** — it no longer yields those 31 names. Direct imports are unaffected.
+
 ### Changed
 
 - **`Filing.markdown()` and `Attachment.markdown()` now render through `edgar.documents`.** They were the last public rendering methods still on the legacy `edgar.files` pipeline, which has no image node at all — `MarkdownRenderer.render` handles text blocks, tables, headings and page breaks, and drops everything else. Every `<img>` in every filing vanished silently. NVIDIA's FY2026 10-K now renders both of its images, including the Item 5 stock performance graph whose five-year return comparison exists only as a chart. Relative `src` values are resolved against the filing's SEC archive directory, so the markdown carries working absolute links rather than bare sibling file names. Output also differs where the two renderers disagree on tables; a parity ratchet pins the numeric content of both. (GH #886)

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -19,6 +19,49 @@ against them yet.
 
 ---
 
+## `edgar` now declares `__all__`
+
+**What changed.** The top-level package declares its public API — 110 names.
+Until now there was no way to tell an API from an accident: 141 names were
+reachable from `edgar`, including `Optional` and `partial` (imported for
+annotations) and `Document`, which is the *legacy* `edgar.files` parser and a
+different class from `edgar.documents.Document`.
+
+**What breaks today: `from edgar import *` is narrower.** It no longer supplies
+the 31 names outside `__all__`. If you use star-import and something stops
+resolving, import it from where it lives:
+
+```python
+# Before — arrived via `from edgar import *`
+from edgar import *
+doc = Document.parse(html)
+
+# Now
+from edgar.files.html import Document   # the legacy parser, removed in 6.0
+# or, for the current one:
+from edgar.documents import Document
+```
+
+**Direct imports are unaffected.** `from edgar import <anything>` works exactly
+as it did, listed or not.
+
+**What is coming in 6.0.** Names outside `__all__` become private. They fall
+into three groups: stdlib that leaked in through annotation imports; everything
+belonging to `edgar.files`, which is removed; and internal plumbing that already
+has a supported entry point in front of it — filesystem/config helpers, the
+cache-clearing functions behind `clear_cache()`, and lower-level variants such
+as `get_by_accession_number_enriched`.
+
+**To check whether you are affected**, compare what you import against the list:
+
+```python
+import edgar
+mine = {"Company", "Filing", "Document"}          # whatever your code imports
+print(sorted(mine - set(edgar.__all__)))          # -> ['Document']
+```
+
+---
+
 ## `Filing.cik` and `Filing.company` on multi-filer filings
 
 **What changed.** A filing with more than one filer now reports the *issuer*
@@ -312,7 +355,7 @@ against these; each will get a section above when it lands.
 | `edgar.files` removal | The legacy parser package and `chunked_document` go. Use `edgar.documents`. |
 | `include_page_breaks` on `markdown()` | Already deprecated in 5.x: `Filing.markdown()` and `Attachment.markdown()` render through `edgar.documents`, but `include_page_breaks=True` still falls back to the legacy renderer — which drops images. Both it and `start_page_number` go with `edgar.files`. There is no replacement: the new builder treats page-break `<hr>`s and page-number containers as print chrome and discards them. |
 | `httpx` → `httpx2` | Exception namespace moves; code catching `httpx.*` will need updating. |
-| Public API definition | `__all__`, stable import paths, and internals made private — some currently-importable names will move. |
+| Public API **enforcement** | `__all__` is already declared (see below) — 6.0 makes the names outside it private, and some currently-importable names will move. |
 | Unified error policy | Silent `None` returns become typed exceptions from an `edgar.exceptions` hierarchy. |
 | Source tree reorganisation | Module locations change; import paths follow. |
 | `FactQuery.to_dataframe()` sentinels | `preferred_sign` and `fiscal_year` move to nullable `Int64`. |

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -149,6 +149,106 @@ get_insider_transaction_filings = partial(get_filings, form=[3, 4, 5])
 get_portfolio_holding_filings = partial(get_filings, form=THIRTEENF_FORMS)
 
 
+# ---------------------------------------------------------------------------
+# The public API
+# ---------------------------------------------------------------------------
+#
+# This list is the supported surface of `edgar`: the names covered by the
+# deprecation policy, and the ones a release may not break without saying so in
+# docs/upgrade/. Until it existed there was no answer to "is this part of the
+# API?" other than whether the import happened to work, which made every
+# removal a guess about who might be relying on what (bead edgartools-07lk.5).
+#
+# WHAT BEING ABSENT FROM THIS LIST MEANS TODAY. Nothing breaks. Every name that
+# was importable before still is; `__all__` only governs `from edgar import *`.
+# What it does say is that a name outside this list is internal, and 6.0 may
+# make it private (bead edgartools-07lk.23 stages the declaration in 5.x and
+# the enforcement in 6.0). If something you depend on is missing here, that is
+# worth an issue before 6.0 rather than after.
+#
+# THREE THINGS DELIBERATELY LEFT OUT, of 141 public names on 2026-08-10:
+#
+#   1. `List`, `Optional`, `Union`, `lru_cache`, `partial` — imported above for
+#      annotations and never API. `from edgar import Optional` works today and
+#      is an accident.
+#   2. `Document`, `detect_page_breaks`, `mark_page_breaks` — these come from
+#      `edgar.files`, which 6.0 removes (bead edgartools-07lk.3). `edgar.Document`
+#      is the LEGACY parser and a different class from `edgar.documents.Document`;
+#      no documentation teaches `from edgar import Document`, and the name
+#      collides with its own replacement.
+#   3. Filesystem/config plumbing (`edgar.paths`), the internal cache-clearing
+#      helpers behind `clear_cache`, and lower-level variants of supported entry
+#      points (`get_by_accession_number_enriched`, `get_entity_submissions`,
+#      `get_cik_lookup_data`, `get_ticker_to_cik_lookup`).
+#
+# Submodules are not listed. `from edgar.xbrl import XBRL` works regardless of
+# `__all__`; this governs the top-level namespace only.
+#
+# Keep it grouped rather than sorted — the grouping is the documentation of what
+# the library is for, and a flat alphabetical list of 110 names is not.
+__all__ = [
+    # -- Entry points --------------------------------------------------------
+    "find", "obj",
+    "get_filings", "get_by_accession_number",
+    "get_current_filings", "get_all_current_filings", "iter_current_filings_pages",
+    "get_latest_filings", "latest_filings", "current_filings",
+    "search_filings",
+    "get_entity", "find_company", "get_company_facts",
+    "get_company_tickers", "get_icon_from_ticker",
+
+    # -- Core objects --------------------------------------------------------
+    "Filing", "Filings", "CurrentFilings",
+    "Company", "CompanyData", "CompanyFiling", "CompanyFilings",
+    "CompanySearchResults", "Entity", "EntityData",
+    "Attachment", "Attachments", "FilingHomepage", "FilingHeader",
+    "CompanyNotFoundError", "DataObjectException",
+
+    # -- Financial statements ------------------------------------------------
+    "Financials", "MultiFinancials", "XBRL",
+
+    # -- Funds ---------------------------------------------------------------
+    "Fund", "FundCompany", "FundClass", "FundSeries",
+    "FundReport", "FundCensus", "FundShareholderReport",
+    "MoneyMarketFund", "Prospectus497K",
+    "find_fund", "find_funds",
+    "get_fund_portfolio_filings", "get_money_market_filings",
+    "get_portfolio_holding_filings",
+
+    # -- Form-specific data objects ------------------------------------------
+    "ThirteenF", "NPX",
+    "ProxyStatement", "ProxyContests", "proxy_contests",
+    "Correspondence", "CorrespondenceThread", "CorrespondenceType",
+    "AlternativeTradingSystem", "AlternativeTradingSystemWithdrawal",
+    "get_insider_transaction_filings", "get_restricted_stock_filings",
+
+    # -- Business development companies --------------------------------------
+    "BDCEntity", "BDCEntities", "get_bdc_list", "get_active_bdc_ciks", "is_bdc_cik",
+
+    # -- Full-text search ----------------------------------------------------
+    "EFTSSearch", "EFTSResult",
+
+    # -- Identity, HTTP and diagnostics --------------------------------------
+    "set_identity", "get_identity",
+    "NORMAL", "CAUTION", "CRAWL",
+    "configure_http", "get_http_config", "diagnose_ssl",
+
+    # -- Local and cloud storage ---------------------------------------------
+    "use_local_storage", "is_using_local_storage", "set_local_storage_path",
+    "download_edgar_data", "download_filings",
+    "use_cloud_storage", "is_cloud_storage_enabled", "sync_to_cloud",
+    "use_datamule_storage", "is_using_datamule_storage",
+    "storage_info", "StorageInfo", "analyze_storage", "StorageAnalysis",
+    "cleanup_storage", "optimize_storage", "clear_cache",
+    "availability_summary", "check_filing", "check_filings_batch",
+
+    # -- Form constants ------------------------------------------------------
+    "ATS_N_FORMS", "ATS_N_ALL_FORMS", "ATS_N_AMENDMENT_FORMS", "ATS_N_WITHDRAWAL_FORMS",
+    "CORRESPONDENCE_FORMS", "MONEY_MARKET_FORMS",
+    "NCEN_FORMS", "NCSR_FORMS", "NMFP2_FORMS", "NMFP3_FORMS", "NPORT_FORMS",
+    "PROSPECTUS497K_FORMS", "PROXY_FORMS", "THIRTEENF_FORMS",
+]
+
+
 @lru_cache(maxsize=16)
 def find(search_id: Union[str, int]) -> Optional[Union[Filing, Entity, CompanySearchResults, FundCompany, FundClass, FundSeries]]:
     """This is an uber search function that can take a variety of search ids and return the appropriate object

--- a/tests/issues/regression/test_public_api_surface.py
+++ b/tests/issues/regression/test_public_api_surface.py
@@ -1,0 +1,159 @@
+"""
+The declared public API of `edgar`, pinned.
+
+Bead: edgartools-07lk.5
+
+`edgar/__init__.py` had no `__all__`, so "is this part of the API?" had no
+answer except whether the import happened to work. 141 names were reachable
+from the top-level namespace, including `Optional` and `partial` — imported for
+annotations and never API — and `Document`, the *legacy* parser from
+`edgar.files`, a different class from `edgar.documents.Document` and scheduled
+for removal in 6.0.
+
+WHAT THESE TESTS ARE FOR. Not to freeze the API — names get added, and adding
+one here is a two-line change. They exist so that adding a name to the top-level
+namespace forces a decision about whether it is public, at the moment it is
+added rather than at the moment someone tries to remove it. That is the whole
+content of "define the public API": the boundary is only real if crossing it
+is noticeable.
+
+`__all__` governs `from edgar import *` only. Every name below is still
+importable directly whether or not it is listed, so nothing here is a
+compatibility guarantee about `from edgar import X` — the enforcement half
+lands in 6.0 (bead edgartools-07lk.23).
+"""
+import types
+
+import pytest
+
+import edgar
+
+# Public names deliberately NOT in __all__. Each is either stdlib that leaked in
+# through an annotation import, part of `edgar.files` (removed in 6.0, bead
+# edgartools-07lk.3), or internal plumbing with a supported entry point in front
+# of it. Moving a name OUT of this set and into __all__ is a promise; moving one
+# in is a decision to make it private in 6.0. Either way, do it deliberately.
+INTERNAL = {
+    # stdlib, imported in __init__.py for annotations
+    "List", "Optional", "Union", "lru_cache", "partial",
+    # edgar.files — removed in 6.0
+    "Document", "detect_page_breaks", "mark_page_breaks",
+    # filesystem/config plumbing
+    "get_anchor_cache_directory", "get_cache_directory", "get_claude_skills_directory",
+    "get_data_directory", "get_search_cache_directory", "get_test_directory",
+    "set_cache_directory", "set_claude_skills_directory", "set_data_directory",
+    "set_test_directory",
+    # internal cache management; clear_cache() is the supported entry point
+    "clear_company_facts_cache", "clear_empty_cached_responses",
+    "clear_locale_corrupted_cache",
+    # helpers and protocols used inside the package
+    "listify", "matches_form", "edgar_mode", "get_obj_info",
+    "HasContext", "compose_context",
+    # lower-level variants of supported entry points
+    "get_by_accession_number_enriched", "get_entity_submissions",
+    "get_cik_lookup_data", "get_ticker_to_cik_lookup",
+}
+
+
+def _public_names():
+    """Top-level names a user can reach, excluding submodules.
+
+    Submodules are excluded because `from edgar.xbrl import XBRL` works
+    regardless of `__all__` — this is about the top-level namespace only.
+    """
+    return {
+        name for name in dir(edgar)
+        if not name.startswith("_")
+        and not isinstance(getattr(edgar, name), types.ModuleType)
+    }
+
+
+def test_all_is_declared():
+    """Guard the guard: without this the tests below are vacuous."""
+    assert hasattr(edgar, "__all__"), "edgar.__init__ no longer declares __all__"
+    assert len(edgar.__all__) > 50, (
+        f"__all__ has shrunk to {len(edgar.__all__)} names, which is not a "
+        f"plausible public API for this library — check what removed them"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(edgar.__all__))
+def test_every_exported_name_resolves(name):
+    """A name in __all__ that does not exist breaks `from edgar import *`."""
+    assert hasattr(edgar, name), (
+        f"edgar.__all__ exports {name!r}, which does not exist. `from edgar "
+        f"import *` raises AttributeError on this."
+    )
+
+
+def test_all_has_no_duplicates():
+    assert len(edgar.__all__) == len(set(edgar.__all__)), (
+        "duplicates in __all__: "
+        f"{sorted(n for n in set(edgar.__all__) if edgar.__all__.count(n) > 1)}"
+    )
+
+
+def test_every_public_name_is_classified():
+    """The ratchet. A new top-level name is public or internal — pick one.
+
+    This is the test that does the work. If it fails, a name became reachable
+    from `edgar` without anyone deciding what it is. Add it to `__all__` if
+    callers should rely on it, or to INTERNAL above if it is plumbing.
+    """
+    unclassified = _public_names() - set(edgar.__all__) - INTERNAL
+    assert not unclassified, (
+        f"{len(unclassified)} name(s) are importable from `edgar` but are neither "
+        f"exported in __all__ nor listed as internal: {sorted(unclassified)}.\n"
+        f"Decide which: add to __all__ in edgar/__init__.py (a supported API, "
+        f"covered by the deprecation policy) or to INTERNAL in this file (may be "
+        f"made private in 6.0)."
+    )
+
+
+def test_internal_names_are_not_also_exported():
+    """A name cannot be both supported and internal."""
+    both = sorted(set(edgar.__all__) & INTERNAL)
+    assert not both, (
+        f"{both} appear in both __all__ and INTERNAL. One of the two lists is wrong."
+    )
+
+
+def test_internal_list_has_no_dead_entries():
+    """An entry for a name that no longer exists reads as coverage it is not."""
+    dead = sorted(INTERNAL - _public_names())
+    assert not dead, (
+        f"INTERNAL lists {dead}, which are no longer importable from `edgar`. "
+        f"Delete the entries — they describe a boundary that has moved."
+    )
+
+
+def test_stdlib_does_not_leak_through_star_import():
+    """The specific accident that motivated this: `from edgar import Optional`.
+
+    Named rather than folded into the sweep above, because it is the one a
+    reader is most likely to think is intentional.
+    """
+    for name in ("List", "Optional", "Union", "partial", "lru_cache"):
+        assert name not in edgar.__all__, (
+            f"{name} is stdlib imported for annotations in edgar/__init__.py, "
+            f"not part of the API"
+        )
+
+
+def test_the_exported_document_class_is_not_the_legacy_one():
+    """`edgar.Document` is `edgar.files.html.Document` — the parser 6.0 removes.
+
+    It is a different class from `edgar.documents.Document`, which is the one
+    the guides teach. Exporting it under a name that collides with its own
+    replacement is why it is not in __all__.
+    """
+    from edgar.documents import Document as ModernDocument
+
+    assert "Document" not in edgar.__all__, (
+        "edgar.Document is the legacy edgar.files parser, removed in 6.0. If it "
+        "is ever exported again it should be the edgar.documents one."
+    )
+    assert edgar.Document is not ModernDocument, (
+        "edgar.Document now IS edgar.documents.Document — that is a change worth "
+        "making deliberately, and this test and __all__ should follow it."
+    )

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,8 +1,12 @@
 from bs4 import BeautifulSoup
 
 from edgar.files.html_documents import table_to_markdown, table_to_text
-from edgar.files.html import BaseNode
-from edgar import *
+# Document here is the LEGACY edgar.files parser, not edgar.documents.Document.
+# It used to arrive via `from edgar import *`; declaring __all__ stopped exporting
+# it (bead edgartools-07lk.5), because the top-level name collided with its own
+# replacement and edgar.files is removed in 6.0 (bead edgartools-07lk.3).
+from edgar.files.html import BaseNode, Document
+from edgar import *  # noqa: F403
 from edgar.files.htmltools import ChunkedDocument
 from edgar.richtools import rich_to_text
 from pathlib import Path


### PR DESCRIPTION
The additive half of `edgartools-07lk.5`, and the keystone for the 6.0 reorg — you can't write import shims (`07lk.12.1`), delete `edgar.files` (`07lk.3`), sweep dead code (`07lk.4`) or add lazy imports (`07lk.9`) without knowing what's public.

## The problem

There was no way to tell an API from an accident. **141 names** were reachable from the top-level `edgar` namespace and nothing said which of them a release was allowed to break. `__all__` now names **110**.

## What's deliberately left out

| group | examples | why |
|---|---|---|
| stdlib | `List`, `Optional`, `Union`, `lru_cache`, `partial` | imported at the top of `__init__.py` for annotations. `from edgar import Optional` works today and is an accident |
| `edgar.files` | `Document`, `detect_page_breaks`, `mark_page_breaks` | the package 6.0 removes (`07lk.3`) |
| internal plumbing | `edgar.paths` helpers, the cache-clearers behind `clear_cache()`, `get_by_accession_number_enriched` | already have a supported entry point in front of them |

**`edgar.Document` deserves its own note.** It is the *legacy* parser and a **different class** from `edgar.documents.Document` — the top-level name collides with its own replacement. Grep over `docs/`, skills and README for `from edgar import ... Document` returns **zero**; the 74 mentions of "Document" are prose and `edgar.documents`.

## This is not purely additive, and the changelog says so

Declaring `__all__` **narrows `from edgar import *`** — it stops supplying those 31 names. Direct imports are unaffected.

The suite proved the point rather than my asserting it: `tests/test_tables.py` took the legacy `Document` through a star-import and broke — exactly the failure a consumer would hit. It now imports from `edgar.files.html`, which has the side benefit of making its dependency on the removed package visible to `07lk.3`.

Staging split per `07lk.23`: **declare now, enforce later.** Names outside `__all__` stay importable in 5.x and become private in 6.0.

## The test is a ratchet, not a snapshot

`test_public_api_surface.py` asserts every public top-level name is either in `__all__` or in an `INTERNAL` list — so a new name forces the public/internal decision **when it is added**, rather than when someone tries to remove it. That is the whole content of "define the public API": a boundary is only real if crossing it is noticeable.

It also pins that the two lists never overlap, that `INTERNAL` has no dead entries, and the two specific accidents that motivated this.

**Verified against planted regressions**: a new unclassified public name fails it; an `__all__` entry that doesn't resolve fails it.

## Verified

4,708 fast tests pass · both regression gates green · ruff unchanged against main (262 fixable) · every upgrade-guide snippet executed before being written down

> **Merge note:** #1024 rewrites the "Nothing here is a rename" admonition in `docs/upgrade/6.0.md`. I deliberately did not touch it here to avoid a conflict — whichever lands second should extend it to mention that `from edgar import *` narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)