### PR TITLE
chore(release): 5.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.47.0] - 2026-08-10
+
 ### Added
 
 - **`edgar` now declares `__all__` — 110 names — so the supported API is answerable.** There was no way to tell an API from an accident: 141 names were reachable from the top level, including `Optional` and `partial` (imported for annotations) and `Document`, the *legacy* `edgar.files` parser, which is a different class from `edgar.documents.Document` and is removed in 6.0. Names left out stay importable; 6.0 makes them private. **`from edgar import *` is narrower** — it no longer yields those 31 names. Direct imports are unaffected.
+
+- **`Filing.text(include_images=True)` and `Document.text(include_images=True)` emit an `[Image: <alt or filename>]` placeholder per image.** This completes the text half of GH #886: a `TextExtractor` flag existed but never fired on a real filing, because SEC filers wrap `<img>` in a paragraph and the paragraph branch returned without descending to it. NVIDIA's 10-K now marks both its images, including the Item 5 stock performance graph whose five-year return comparison has no table beside it. Off by default, so the text feeding sections, search and embeddings stays image-free. (GH #886)
 
 ### Changed
 
@@ -20,10 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Filing.text()` truncated long table cells at 200 characters, with no ellipsis to show it had happened.** It rendered its document with `rich_to_text(document, width=500)`, but `Document` is not a rich renderable, so rich fell back to `repr()` — and `Document.__repr__` is hardcoded `text(table_max_col_width=200)`. The `500` never reached the table renderer. On Apple's FY2024 10-K that cost 1,434 characters across 8 chunks (whitespace collapsed, so wrapping does not account for it), including 300 characters of the unrecognized-tax-benefits disclosure: `$22.0 billion, of which $10.8 billion, if recognized, would impact the Company's effective tax rate`. Seven of eight 10-K fixtures lost content with no ellipsis marker. `Filing.text()` now calls `document.text(table_max_col_width=500)` directly, which also drops the rich round-trip — a 400 KB string was being rendered through a console and stripped of ANSI to recover text the extractor had already produced. Rendering is 4.5× faster (6.61s → 1.46s across 8 filings).
 
 - **Image `alt` text leaked into `Filing.text()` as unlabelled prose.** `ImageNode.text()` returned `alt`, which `ParagraphNode.text()` aggregates, so the bare string `nvidialogoa10.jpg` appeared inline in NVIDIA's 10-K text with nothing marking it as an image. `alt` describes an image rather than being text the filer wrote, and on SEC filings it is usually just the source file name; it no longer contributes to text. Callers that want images represented ask explicitly — see `include_images` below.
-
-### Added
-
-- **`Filing.text(include_images=True)` and `Document.text(include_images=True)` emit an `[Image: <alt or filename>]` placeholder per image.** This completes the text half of GH #886: a `TextExtractor` flag existed but never fired on a real filing, because SEC filers wrap `<img>` in a paragraph and the paragraph branch returned without descending to it. NVIDIA's 10-K now marks both its images, including the Item 5 stock performance graph whose five-year return comparison has no table beside it. Off by default, so the text feeding sections, search and embeddings stays image-free. (GH #886)
 
 ### Deprecated
 

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.46.0'
+__version__ = '5.47.0'


### PR DESCRIPTION
Folds `[Unreleased]` into a dated section and bumps `edgar/__about__.py` to 5.47.0. 33 commits since 5.46.0 (2026-08-07). Rebased onto #1028, so the deleted `edgar.xbrl.analysis` subtree is out of this wheel.

## Why now rather than at the next convenient moment

Two rows of the `07lk.23` staging table are sitting on `main` unreleased, and that bead's acceptance is *"shipped in a 5.x release with a deprecation warning and an upgrade-guide entry"* — not merged. A deprecation nobody has installed warns nobody.

| staging row | additive half | after this release |
|---|---|---|
| `iirl` | `cash_flow_statement()` canonical, old names warn | **shipped** |
| `07lk.5` | `__all__` declared, 110 names | **shipped** |

Staging closes ~2026-10-12 and 6.0 targets 2026-11-09, so every week these sit unreleased is a week of warning users do not get before the break.

## What users see

- `cashflow_statement()` and `cash_flow()` now emit `DeprecationWarning` — upgrade path in `docs/upgrade/6.0.md:26`
- `from edgar import *` yields 110 names instead of 141; direct imports unaffected
- entity classification: individuals whose names contain "l p" are no longer companies (#1019), and `LLP`/`LLLP`/`PLLC` plus non-US legal forms are now recognised
- `Filing.markdown()` renders images; `Filing.text()` no longer truncates table cells at 200 chars
- `edgar.xbrl.analysis` is gone — it raised `AttributeError` on construction and nothing imported it

## Changelog hygiene

`[Unreleased]` had two separate `### Added` blocks with a `### Changed` between them. Merged into one on the way past — the `include_images` entry moved up beside the `__all__` entry, no wording touched. All 19 bullets are accounted for under `[5.47.0]`; `[Unreleased]` is empty.

## Verified

- `edgar.__version__ == '5.47.0'`, `len(edgar.__all__) == 110`
- deprecated cash-flow spelling still warns on a real `Financials` object
- `hatch build` clean: `edgartools-5.47.0-py3-none-any.whl` (501 files, down from 504) and the sdist
- `edgar.xbrl.analysis` absent from the wheel and no longer importable

## Known gap, not blocking

`py.typed` is still not in the wheel — that is `07lk.6`, the other half of the `07lk.5` staging row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)