### PR TITLE
feat(typing): ship the py.typed marker, so the annotations are visible (07lk.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`edgartools` ships a PEP 561 `py.typed` marker, so its type hints now reach your type checker.** The README has said "type hints throughout" for a long time and it was true of the source and false of the installed package: without the marker, mypy refuses to look inside `edgar` at all — `Skipping analyzing "edgar": module is installed, but missing library stubs or py.typed marker` — and every symbol degrades to `Any`. `Company(cik_or_ticker=[1, 2, 3])` type-checked clean against 5.47.0; it now reports `Argument "cik_or_ticker" to "Company" has incompatible type "list[int]"; expected "str | int"`. Nothing in the library changed — this makes the annotations already there visible, and it is why the typing work behind them was worth doing. Pyright users saw types already, because it reads library source by default; mypy and stub-strict configurations did not.
+
 ## [5.47.0] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,10 @@ path = "edgar/__about__.py"
 [tool.hatch.build]
 include = [
   "edgar/**/*.py",
+  # PEP 561 marker. This list is an allowlist and no other pattern here would
+  # match an extensionless file, so dropping this line ships an untyped wheel
+  # while the repo still looks correct — which is what 5.47.0 did.
+  "edgar/py.typed",
   "edgar/**/templates/*.html",
   "edgar/**/docs/*.md",
   "edgar/ai/skills/**/*.yaml",

--- a/tests/issues/regression/test_py_typed_marker.py
+++ b/tests/issues/regression/test_py_typed_marker.py
@@ -1,0 +1,83 @@
+"""
+The PEP 561 marker that makes edgartools' annotations visible downstream.
+
+Bead: edgartools-07lk.6 (public issue gh-932, shared with 07lk.5)
+
+Every annotation in this library was invisible to a downstream type checker.
+Without `edgar/py.typed`, mypy refuses to look inside an installed package at
+all:
+
+    error: Skipping analyzing "edgar": module is installed, but missing library
+           stubs or py.typed marker  [import-untyped]
+
+and every symbol it exports degrades to `Any` — so a consumer calling
+`Company(cik_or_ticker=[1, 2, 3])` got no error. With the marker, mypy reports
+the argument type. That was the entire user-visible payoff of the typing work
+in edgartools-v7iz and edgartools-q9tf, and it was one empty file away.
+
+TWO WAYS TO LOSE IT, one test each. The file can be deleted, or — the quieter
+one, and the reason this test exists rather than a note in a checklist — it can
+survive in the repo while falling out of the distribution. `[tool.hatch.build]`
+`include` is an allowlist whose only source pattern is `edgar/**/*.py`. A
+zero-byte file with no extension is exactly what such a list drops silently:
+the repo looks correct, the tests pass, and the wheel ships untyped. That is
+what 5.47.0 did.
+"""
+import re
+from pathlib import Path
+
+import edgar
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_py_typed_marker_exists():
+    """The marker sits inside the package, next to __init__.py."""
+    marker = Path(edgar.__file__).resolve().parent / "py.typed"
+    assert marker.is_file(), (
+        f"{marker} is missing. Without it every type annotation in this library "
+        f"is invisible to mypy and to pyright in stub-only mode: `import edgar` "
+        f"reports import-untyped and the whole API resolves to Any."
+    )
+
+
+def test_py_typed_is_a_bare_marker():
+    """PEP 561 marks inline-typed packages with an empty file.
+
+    `partial\\n` means something specific — a stub-only package covering part of
+    a runtime package — and edgartools is not one. Anything else in here is a
+    stray edit.
+    """
+    marker = Path(edgar.__file__).resolve().parent / "py.typed"
+    assert marker.read_text().strip() == "", (
+        f"{marker} should be empty; it contains {marker.read_text()!r}. PEP 561 "
+        f"reserves 'partial' for stub-only distributions."
+    )
+
+
+def test_py_typed_is_in_the_build_include_list():
+    """The marker must be named in the packaging allowlist, or it never ships.
+
+    This is the failure the file-exists test above cannot see: `include` matches
+    `edgar/**/*.py` and nothing else that would catch an extensionless file, so
+    dropping this entry ships a wheel whose annotations are, once again, dead
+    weight.
+    """
+    pyproject = REPO_ROOT / "pyproject.toml"
+    assert pyproject.is_file(), (
+        f"expected the repo's pyproject.toml at {pyproject}; this test resolves "
+        f"it relative to its own location, so a move of this file breaks it"
+    )
+
+    text = pyproject.read_text()
+    build_section = re.search(
+        r"^\[tool\.hatch\.build\]$(.*?)(?=^\[)", text, re.MULTILINE | re.DOTALL
+    )
+    assert build_section, "[tool.hatch.build] section not found in pyproject.toml"
+
+    assert "edgar/py.typed" in build_section.group(1), (
+        "pyproject.toml no longer lists 'edgar/py.typed' under "
+        "[tool.hatch.build] include. The built wheel will not contain the "
+        "marker, and every downstream type checker goes back to treating "
+        "edgartools as untyped — silently, because the file still exists here."
+    )


### PR DESCRIPTION
## The problem

The README says "type hints throughout." That was true of the source and false of the installed package. Without a PEP 561 marker, mypy will not look inside `edgar` at all:

```
error: Skipping analyzing "edgar": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

and every symbol it exports degrades to `Any`. Against the shipped 5.47.0 wheel this type-checks clean:

```python
Company(cik_or_ticker=[1, 2, 3])
```

With the marker, mypy reports `Argument "cik_or_ticker" to "Company" has incompatible type "list[int]"; expected "str | int"`.

## What's here

- `edgar/py.typed` — the marker, empty per PEP 561 (`partial` is reserved for stub-only distributions).
- One line in `[tool.hatch.build] include`. **This is the load-bearing half.** The include list is an allowlist whose only source pattern is `edgar/**/*.py`, and a zero-byte extensionless file is exactly what such a list drops silently — the repo looks correct, the tests pass, the wheel ships untyped. That is what 5.47.0 did.
- Two regression tests, because there are two ways to lose this: delete the file, or drop the packaging line while the file survives. The second is invisible from inside the repo.

## Verification

A/B in one throwaway venv against the built wheel, marker moved aside and back, same consumer script:

| | mypy result |
|---|---|
| without marker | 2 × `import-untyped`, wrong-type call **undetected** |
| with marker | imports resolve, wrong-type call **reported** |

Both artifacts rebuilt and inspected — `edgar/py.typed` present in the wheel and the sdist. Both new tests confirmed to fail when their subject is removed.

**A negative result worth recording:** I checked with pyright first, and it found the types identically with and without the marker. pyright defaults to `useLibraryCodeForTypes: true` and reads library source regardless of PEP 561, so it cannot tell you whether this change worked. Re-verify with mypy, or pyright in stub-strict mode.

1,519 fast regression tests pass; regression-skip gate clean; ruff clean on the new file.

## Notes

Nothing in the library changed — this makes annotations that already exist reach the people they were written for. `edgartools-v7iz` and `edgartools-q9tf` (the annotation-quality work) remain in progress; the marker does not wait on them, because partial annotations a checker can see beat complete annotations it cannot.

Bead: `edgartools-07lk.6`. Completes the 6.0 staging row opened by `edgartools-07lk.5` (public issue gh-932).

🤖 Generated with [Claude Code](https://claude.com/claude-code)