### PR TITLE
feat(errors): wrap the network boundary, so httpx is not our contract (07lk.10, PR2 of 3)

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -28,9 +28,10 @@
 #     gh api repos/dgunning/edgartools/branches/main/protection \
 #        --jq .required_status_checks.contexts
 #
-# test-network, test-slow and Combine Coverage are deliberately NOT required:
-# they carry `if: github.event_name != 'pull_request'` and so report as skipped
-# on every pull request. They run on push to main, which is the integration gate.
+# test-strict-errors, test-network, test-slow and Combine Coverage are
+# deliberately NOT required: they carry `if: github.event_name != 'pull_request'`
+# and so report as skipped on every pull request. They run on push to main,
+# which is the integration gate.
 #
 # Because they cannot gate, they are REPORTED instead — see the `report` job at
 # the end of this file. Combine Coverage is where the 65% floor is enforced
@@ -137,6 +138,57 @@ jobs:
           coverage.xml
         include-hidden-files: true
         retention-days: 1
+
+  test-strict-errors:
+    # Runs the offline suite the way 6.0 will behave, today.
+    #
+    # EDGARTOOLS_STRICT_ERRORS=1 turns on the error changes that are otherwise a
+    # 6.0 break (bead edgartools-07lk.10): the network boundary wraps httpx
+    # exceptions into TransportError, and — as PR3 lands them — the silent-None
+    # returns raise instead. The point is not to test users' code; it is to find
+    # OUR code that still relies on the old behaviour, while there is still a
+    # 5.x release to fix it in. Without this job, the first time all the 6.0
+    # error paths run together is 6.0 itself.
+    #
+    # The design for this bead planned it as continue-on-error, on the
+    # assumption it would arrive amber and go green as the flips landed. It
+    # arrives GREEN — the whole fast suite passes under the flag as of PR2 — so
+    # it is a hard failure from the start. An allowed-to-fail lane that is
+    # already passing teaches nobody anything, and this repository has already
+    # paid for the lesson that an unreported post-merge failure survives several
+    # merges (bead edgartools-hwdp, #999). It is in the `report` job's `needs`
+    # accordingly.
+    #
+    # Post-merge only, matching test-network. It cannot be a REQUIRED check
+    # while it skips pull requests — see the deadlock described at the top of
+    # this file — so it is reported rather than gating, and moves to the pull
+    # request leg when the 6.0 branch is cut and strict becomes the only path.
+    if: github.event_name != 'pull_request'
+    needs: cassette-gate
+    runs-on: ubuntu-latest
+    env:
+      EDGARTOOLS_STRICT_ERRORS: '1'
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Python 3.13
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[ai]"
+        python -m pip install pytest pytest-cov pytest-env pytest-xdist pytest-asyncio pytest-retry pytest-mock pytest-vcr "vcrpy<8.2" freezegun==1.5.1 filelock tqdm responses
+
+    - name: Run fast tests with 6.0 error behaviour
+      run: |
+        # Same selection as test-fast. Offline only: what this is looking for is
+        # internal code that mishandles the wrapped exception types, and that
+        # shows up in mocked and cassette-backed tests just as well as in live
+        # ones — without a second pass over the SEC endpoint.
+        pytest -n auto -m 'fast'
 
   test-network:
     # Network tests skip PRs — SEC API behavior doesn't change per-commit.
@@ -300,8 +352,8 @@ jobs:
   # post-merge regression lane went red on 2026-08-08 and three more pull
   # requests merged through it before anyone noticed. THIS workflow never got
   # one, and it is the lane that carries more: the 65% coverage floor
-  # (`coverage report --fail-under=65`), plus test-network and test-slow. All
-  # three are post-merge only, none is a required check, and until now none of
+  # (`coverage report --fail-under=65`), plus test-network, test-slow and
+  # test-strict-errors. All of them are post-merge only, none is a required check, and until now none of
   # them could tell anybody they had failed.
   #
   # Note what this deliberately does NOT do: make Combine Coverage required.
@@ -310,7 +362,10 @@ jobs:
   # block every pull request forever — the deadlock described at the top of this
   # file. Reporting is the right mechanism for a check that cannot gate.
   #
-  # `needs` names every post-merge job on purpose. A failure in test-network
+  # `needs` names every post-merge job on purpose — including test-strict-errors
+  # (bead edgartools-07lk.10), because a lane whose whole job is proving 6.0
+  # error behaviour still holds is worth nothing if it can go red in silence.
+  # A failure in test-network
   # SKIPS Combine Coverage rather than failing it, so keying on the coverage
   # result alone would stay silent for the failure that stops the threshold
   # being evaluated at all.
@@ -320,7 +375,7 @@ jobs:
   # green last would close an issue the other still needed open.
   report:
     name: Report red main (build)
-    needs: [cassette-gate, test-fast, test-network, test-slow, coverage]
+    needs: [cassette-gate, test-fast, test-strict-errors, test-network, test-slow, coverage]
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -334,6 +389,7 @@ jobs:
       TITLE: "Build and Test Edgartools is failing on main"
       R_GATE: ${{ needs.cassette-gate.result }}
       R_FAST: ${{ needs.test-fast.result }}
+      R_STRICT: ${{ needs.test-strict-errors.result }}
       R_NETWORK: ${{ needs.test-network.result }}
       R_SLOW: ${{ needs.test-slow.result }}
       R_COVERAGE: ${{ needs.coverage.result }}
@@ -347,7 +403,7 @@ jobs:
       id: verdict
       run: |
         red=0
-        for r in "$R_GATE" "$R_FAST" "$R_NETWORK" "$R_SLOW" "$R_COVERAGE"; do
+        for r in "$R_GATE" "$R_FAST" "$R_STRICT" "$R_NETWORK" "$R_SLOW" "$R_COVERAGE"; do
           [ "$r" = "failure" ] && red=1
         done
         echo "red=$red" >> "$GITHUB_OUTPUT"
@@ -360,9 +416,9 @@ jobs:
         # Name the job that failed. This lane has five, and "the build is red"
         # without saying which one sends the reader to the Actions tab to find
         # out — which is the step nobody takes.
-        body=$(printf '%s\n\n- commit: %s\n- run: %s\n\n| job | result |\n| --- | --- |\n| Cassette safety gate | %s |\n| test-fast | %s |\n| test-network | %s |\n| test-slow | %s |\n| Combine Coverage (65%% floor) | %s |\n' \
+        body=$(printf '%s\n\n- commit: %s\n- run: %s\n\n| job | result |\n| --- | --- |\n| Cassette safety gate | %s |\n| test-fast | %s |\n| test-strict-errors | %s |\n| test-network | %s |\n| test-slow | %s |\n| Combine Coverage (65%% floor) | %s |\n' \
                  "The post-merge build lane failed on \`main\`." "$SHA" "$RUN_URL" \
-                 "$R_GATE" "$R_FAST" "$R_NETWORK" "$R_SLOW" "$R_COVERAGE")
+                 "$R_GATE" "$R_FAST" "$R_STRICT" "$R_NETWORK" "$R_SLOW" "$R_COVERAGE")
         if [ -z "$number" ]; then
           gh issue create --repo "$REPO" --label "$LABEL" \
             --title "$TITLE" --body "$body"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A missing-attachment lookup raises `AttachmentNotFoundError`** rather than a bare `KeyError`. It *is* a `KeyError`, so existing handlers are unaffected.
 
+- **`EDGARTOOLS_STRICT_ERRORS=1` runs 6.0's error behaviour today.** The changes that would otherwise be a break are available behind the flag, so you can port before 6.0 lands rather than after. Today it turns on the network wrap below; the silent-`None` conversions join it as they land. Check it yourself with `edgar.exceptions.strict_errors_enabled()`.
+
+- **Under strict, an httpx failure that survived every retry becomes a `TransportError`.** `httpx.ReadTimeout` and friends were propagating verbatim out of `get_with_retry`, `stream_with_retry`, `post_with_retry` and `inspect_response`, which made a dependency's exception types part of our public contract by accident — and made any future HTTP-client change a breaking one for every `except` clause naming them. The wrap happens once at the boundary, carries `.status_code` (`None` when we never got an answer at all) and `.url`, and always chains the original as `__cause__`, so nothing is lost for debugging. This is a 6.0 flip because user code may be catching `httpx.HTTPError` around our calls; without the flag, nothing changes. `TRANSPORT_ERRORS` now catches both eras, so code written against it needs no revisiting.
+
 - **`edgartools` ships a PEP 561 `py.typed` marker, so its type hints now reach your type checker.** The README has said "type hints throughout" for a long time and it was true of the source and false of the installed package: without the marker, mypy refuses to look inside `edgar` at all — `Skipping analyzing "edgar": module is installed, but missing library stubs or py.typed marker` — and every symbol degrades to `Any`. `Company(cik_or_ticker=[1, 2, 3])` type-checked clean against 5.47.0; it now reports `Argument "cik_or_ticker" to "Company" has incompatible type "list[int]"; expected "str | int"`. Nothing in the library changed — this makes the annotations already there visible, and it is why the typing work behind them was worth doing. Pyright users saw types already, because it reads library source by default; mypy and stub-strict configurations did not.
 
 ### Fixed
 
 - **`NoCompanyFactsFound` carried a message nobody could read.** Its `__init__` called `super().__init__()` with no arguments and set `self.message` instead, so `str(exc)` was the empty string — three raise sites whose message never reached a traceback, a log line, or a user. It is now `CompanyFactsNotFoundError` and builds its message through the base class, which makes the empty case unrepresentable rather than merely fixed.
+
+- **An EFTS outage was reported as "there is no filing at that accession".** `resolve_accession()` wrapped its fetch in `except Exception: return None`, and `None` from that function routes the caller to the quarterly index — the correct answer for a pre-2001 accession and a wrong turn during an SEC outage, with the only trace at DEBUG. Transport failures now propagate; a malformed response still returns `None`, which is what that arm was for. This closes the sibling left open by the `edgartools-tg7y` fix, which fixed the same shape in `edgar/funds/core.py`.
 
 ## [5.47.0] - 2026-08-10
 

--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -56,6 +56,7 @@ from edgar.display.formatting import accession_number_text, display_size
 from edgar.display.styles import print_info, print_warning
 from edgar.documents import HTMLParser, ParserConfig
 from edgar.documents.exceptions import ParsingError
+from edgar.exceptions import TransportError, http_status
 from edgar.files._deprecation import PAGE_BREAK_DEPRECATION as _PAGE_BREAK_DEPRECATION
 from edgar.files.html_documents import get_clean_html
 from edgar.files.htmltools import html_sections
@@ -64,7 +65,7 @@ from edgar.filesystem import EdgarPath
 from edgar.filtering import filter_by_accession_number, filter_by_cik, filter_by_date, filter_by_exchange, \
     filter_by_form, filter_by_ticker
 from edgar.headers import FilingDirectory, IndexHeaders
-from edgar.httprequests import download_file, download_text, download_text_between_tags
+from edgar.httprequests import UNREACHABLE_ERRORS, download_file, download_text, download_text_between_tags, is_unreachable
 from edgar.reference import describe_form
 from edgar.reference.tickers import Exchange, find_ticker, find_ticker_safe
 from edgar.richtools import Docs, print_rich, repr_rich
@@ -456,8 +457,10 @@ def fetch_filing_index(year_and_quarter: YearAndQuarter,
     try:
         index_table = fetch_filing_index_at_url(url, index)
         return (year, quarter), index_table
-    except httpx.HTTPStatusError as e:
-        if is_start_of_quarter() and e.response.status_code == 403:
+    except (httpx.HTTPStatusError, TransportError) as e:
+        # Dual-era: httpx raises the status error today, TransportError under the
+        # strict wrap and in 6.0. http_status() reads either.
+        if is_start_of_quarter() and http_status(e) == 403:
             # Return an empty filing index
             return (year, quarter), _empty_filing_index()
         else:
@@ -1573,9 +1576,10 @@ class Filing:
             # Skip when local storage is enabled to avoid unexpected network access
             try:
                 period = self.homepage.period_of_report
-            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadTimeout,
-                    httpcore.TimeoutException, httpcore.ConnectError, httpcore.NetworkError):
-                pass  # Offline or network unavailable — return None
+            except (*UNREACHABLE_ERRORS, TransportError) as e:
+                if not is_unreachable(e):
+                    raise  # SEC answered, or SSL/identity — not something to fall back from
+                # Offline or network unavailable — leave it as None
         return period
 
     @cached_property
@@ -1652,9 +1656,10 @@ class Filing:
                 document = self.homepage.primary_xml_document
                 if document and not document.is_binary() and not document.empty:
                     return document.content
-            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadTimeout,
-                    httpcore.TimeoutException, httpcore.ConnectError, httpcore.NetworkError):
-                pass  # Offline or network unavailable — return None
+            except (*UNREACHABLE_ERRORS, TransportError) as e:
+                if not is_unreachable(e):
+                    raise  # SEC answered, or SSL/identity — not something to fall back from
+                # Offline or network unavailable — leave it as None
         return xml_content
 
     @lru_cache(maxsize=4)
@@ -1860,10 +1865,9 @@ class Filing:
             return XBRL.from_filing(self)
         except XBRLFilingWithNoXbrlData:
             return None
-        except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadTimeout,
-                httpcore.TimeoutException, httpcore.ConnectError, httpcore.NetworkError) as e:
+        except (*UNREACHABLE_ERRORS, TransportError) as e:
             # Provide helpful message when local storage is enabled but filing content is missing
-            if is_using_local_storage():
+            if is_unreachable(e) and is_using_local_storage():
                 log.error(
                     f"Network error accessing filing content for {self.accession_no}. "
                     f"You have local storage enabled, but filing documents are not downloaded.\n\n"

--- a/edgar/ai/mcp/tools/base.py
+++ b/edgar/ai/mcp/tools/base.py
@@ -588,6 +588,44 @@ def classify_error(exc: Exception) -> dict[str, Any]:
     except ImportError:
         pass
 
+    # --- The same failures, in the wrapped era ---
+    # Under EDGARTOOLS_STRICT_ERRORS (and unconditionally in 6.0) the network
+    # boundary raises TransportError instead of the httpx types above, so this
+    # block has to answer the same questions the httpx blocks just did. It sits
+    # last among the transport checks because TooManyRequestsError,
+    # SSLVerificationError and IdentityNotSetError are all TransportError
+    # subclasses and each has its own, better answer earlier in this function.
+    try:
+        from edgar.exceptions import TransportError
+        if isinstance(exc, TransportError):
+            status = exc.status_code
+            if status == 404:
+                return {
+                    "error_code": "FILING_NOT_FOUND",
+                    "message": f"Resource not found (HTTP 404): {exc.url}",
+                    "suggestions": ["Check the URL or accession number", "The filing may have been removed"],
+                }
+            elif status is not None and status >= 500:
+                return {
+                    "error_code": "NETWORK_CONNECTION",
+                    "message": f"SEC server error (HTTP {status})",
+                    "suggestions": ["SEC EDGAR is experiencing server issues", "Try again in a few minutes"],
+                }
+            elif status is not None:
+                return {
+                    "error_code": "INTERNAL_ERROR",
+                    "message": f"HTTP error {status}: {exc}",
+                    "suggestions": ERROR_SUGGESTIONS["HTTPStatusError"],
+                }
+            # No status means we never got an answer — connect failure or timeout.
+            return {
+                "error_code": "NETWORK_CONNECTION",
+                "message": f"Could not reach SEC EDGAR: {exc}",
+                "suggestions": ERROR_SUGGESTIONS["ConnectError"],
+            }
+    except ImportError:
+        pass
+
     # --- Standard Python exceptions ---
     if isinstance(exc, ValueError):
         return {

--- a/edgar/entity/core.py
+++ b/edgar/entity/core.py
@@ -605,7 +605,11 @@ class Company(Entity):
         income statement, balance sheet, and cash flow statement.
 
         Returns:
-            Financials object, or None if no annual filing is available
+            Financials object, or None — and None means exactly one thing: this
+            company has filed no 10-K, 20-F or 40-F that we can see. It is never
+            how a failure is reported. If we could not reach SEC, a
+            ``TransportError`` propagates; if the filing was there but would not
+            parse, a ``ParsingError`` does.
 
         Example::
 
@@ -634,7 +638,9 @@ class Company(Entity):
         but with quarterly data instead of annual.
 
         Returns:
-            Financials object, or None if no quarterly filing is available
+            Financials object, or None — and None means exactly one thing: this
+            company has filed no 10-Q or 6-K that we can see. It is never how a
+            failure is reported; a transport or parsing failure raises.
 
         Example::
 

--- a/edgar/entity/entity_facts.py
+++ b/edgar/entity/entity_facts.py
@@ -46,7 +46,7 @@ from edgar.storage import get_edgar_data_directory, is_using_local_storage
 # never reached a traceback or a log. The canonical class builds the message
 # and passes it up. Old name kept as a deprecated alias below.
 from edgar._compat import deprecated_alias
-from edgar.exceptions import CompanyFactsNotFoundError
+from edgar.exceptions import CompanyFactsNotFoundError, TransportError, http_status
 
 __getattr__ = deprecated_alias(NoCompanyFactsFound=CompanyFactsNotFoundError)
 
@@ -59,8 +59,12 @@ def download_company_facts_from_sec(cik: int) -> Dict[str, Any]:
     company_facts_url = build_company_facts_url(cik)
     try:
         return download_json(company_facts_url)
-    except httpx.HTTPStatusError as err:
-        if err.response.status_code == 404:
+    except (httpx.HTTPStatusError, TransportError) as err:
+        # The model for domain translation across both error eras: a 404 is
+        # something this layer understands, so it becomes the domain's own
+        # NotFoundError. Everything else propagates as a transport failure,
+        # because nobody here knows better than "we could not get an answer".
+        if http_status(err) == 404:
             log.warning(f"No company facts found on url {company_facts_url}")
             raise CompanyFactsNotFoundError(cik=cik) from None
         else:

--- a/edgar/entity/submissions.py
+++ b/edgar/entity/submissions.py
@@ -8,6 +8,7 @@ import httpx
 
 from edgar.core import log
 from edgar.entity.data import parse_entity_submissions
+from edgar.exceptions import TransportError, http_status
 from edgar.httprequests import download_json
 from edgar.storage import get_edgar_data_directory, is_using_local_storage
 
@@ -129,9 +130,10 @@ def download_entity_submissions_from_sec(cik: int) -> Optional[Dict[str, Any]]:
     try:
         from edgar.urls import build_submissions_url
         submission_json = download_json(build_submissions_url(cik))
-    except httpx.HTTPStatusError as e:
-        # Handle the case where the cik is invalid and not found on Edgar
-        if e.response.status_code == 404:
+    except (httpx.HTTPStatusError, TransportError) as e:
+        # Handle the case where the cik is invalid and not found on Edgar.
+        # Only a 404 becomes None — an outage must not read as "no such CIK".
+        if http_status(e) == 404:
             return None
         else:
             raise

--- a/edgar/exceptions.py
+++ b/edgar/exceptions.py
@@ -36,9 +36,13 @@ RULES FOR THIS MODULE:
 """
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, List, Optional
 
 __all__ = [
+    # helpers
+    "strict_errors_enabled",
+    "http_status",
     # root
     "EdgarError",
     # transport
@@ -63,6 +67,44 @@ __all__ = [
     "ValidationError",
     "InvalidDateError",
 ]
+
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def strict_errors_enabled() -> bool:
+    """True when `EDGARTOOLS_STRICT_ERRORS` asks for 6.0 error behaviour today.
+
+    Under strict, the changes that would otherwise be a 6.0 break run now: the
+    network boundary wraps httpx errors into `TransportError`, and the silent
+    `None` returns raise instead. Two payoffs — a user can port before the break
+    lands, and our own CI gets a job that runs the whole suite the 6.0 way,
+    which is what flushes out internal code still relying on the old behaviour.
+
+    Read fresh on every call rather than captured at import, so a test can set
+    the variable, exercise a code path, and unset it. The branches this gates
+    are all deleted in 6.0, when strict becomes the only path.
+    """
+    return os.environ.get("EDGARTOOLS_STRICT_ERRORS", "").strip().lower() in _TRUTHY
+
+
+def http_status(exc: BaseException) -> Optional[int]:
+    """The HTTP status behind a failure, whichever era raised it.
+
+    `TransportError` carries `.status_code`; an httpx `HTTPStatusError` carries
+    `.response.status_code`. Every dual-era `except` needs to ask the same
+    question of both, and asking it through `getattr` rather than an isinstance
+    check is what keeps this module free of any httpx import.
+
+    Returns None when we never got an answer at all — a connection failure, a
+    timeout, or a client-side refusal such as a missing identity. That None is
+    load-bearing: it is the discriminator between "SEC said no" and "we could
+    not ask", which is the whole distinction the transport branch exists for.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        return status
+    return getattr(getattr(exc, "response", None), "status_code", None)
 
 
 class EdgarError(Exception):

--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -1,4 +1,5 @@
 import gzip
+import inspect
 import logging
 import os
 import shutil
@@ -23,7 +24,12 @@ from tqdm import tqdm
 logging.getLogger("stamina").setLevel(logging.ERROR)
 
 from edgar.core import get_edgar_data_directory, text_extensions
-from edgar.exceptions import IdentityNotSetError, TooManyRequestsError, TransportError
+from edgar.exceptions import (
+    IdentityNotSetError,
+    TooManyRequestsError,
+    TransportError,
+    strict_errors_enabled,
+)
 from edgar.httpclient import async_http_client, http_client
 
 """
@@ -47,8 +53,10 @@ __all__ = [
     "decompress_gzip_with_retry",
     "SSLVerificationError",
     "TooManyRequestsError",
-    "IdentityNotSetException",
+    "IdentityNotSetError",
     "TRANSPORT_ERRORS",
+    "UNREACHABLE_ERRORS",
+    "is_unreachable",
 ]
 
 attempts = 6
@@ -534,19 +542,166 @@ Details: https://github.com/dgunning/edgartools/blob/main/docs/guides/ssl_verifi
 # signature of a swallowed transport failure.
 #
 # Catch this tuple and re-raise BEFORE any `except Exception` that converts a
-# failure into None. Not a replacement for the exception hierarchy in bead
-# edgartools-07lk.10 — this is the vocabulary those call sites need today, and it
-# is deliberately a tuple of existing types so it introduces no new public class.
+# failure into None.
 #
-# IdentityNotSetError belongs here despite not being a transport error: it
-# means no request can be made at all, so reporting it as "not found" is the same
-# lie in a different costume.
+# It is two entries rather than the four it started as, because the tree in
+# edgar.exceptions (bead edgartools-07lk.10) absorbed the other three:
+# TooManyRequestsError, SSLVerificationError and IdentityNotSetError are all
+# TransportError subclasses now. IdentityNotSetError belongs under transport
+# despite no request being made, because "no request can be made at all"
+# reported as "not found" is the same lie in a different costume.
+#
+# Both families stay listed through 6.0 on purpose. `TransportError` is what the
+# boundary wrap raises under strict; `HTTPError` is what still comes through
+# unwrapped when it is off. Keeping both means a call site written against this
+# tuple behaves identically in either era — cheap insurance, and the reason the
+# strict CI job can prove the internal code is ready before the flip lands.
 TRANSPORT_ERRORS = (
-    HTTPError,               # httpx base: connect, read, timeout, protocol, status
-    TooManyRequestsError,    # SEC rate limit, after retries are exhausted
-    SSLVerificationError,
-    IdentityNotSetError,
+    HTTPError,        # httpx base: connect, read, timeout, protocol, status
+    TransportError,   # ours: the wrapped era, plus 429 / SSL / identity always
 )
+
+
+# The subset of transport failures meaning "we never got an answer" — offline,
+# DNS, timeout, connection reset. Callers that quietly degrade when the user is
+# offline want exactly this set and not the rest of TRANSPORT_ERRORS: an SEC
+# 404, an expired certificate or a missing identity are all answers of a kind,
+# and swallowing them would hide a bug behind a plausible empty result.
+UNREACHABLE_ERRORS = (
+    TimeoutException, ConnectError, ReadTimeout,
+    httpcore.TimeoutException, httpcore.ConnectError, httpcore.NetworkError,
+)
+
+
+def is_unreachable(exc: BaseException) -> bool:
+    """True when the request never reached SEC, in either error era.
+
+    The pre-wrap era raises httpx and httpcore types; under the strict wrap the
+    same failure arrives as a `TransportError` carrying no status. Asking this
+    function instead of naming types is what lets one `except` clause mean the
+    same thing before and after the 6.0 flip.
+
+    `SSLVerificationError` and `IdentityNotSetError` are excluded although they
+    too carry no status. They are deterministic and user-fixable: retrying will
+    not help, a fallback path will not help, and the diagnostic message each one
+    carries is the entire value of raising it. Swallowing those as "offline"
+    would throw away the only thing that tells the user what to change.
+    """
+    if isinstance(exc, (SSLVerificationError, IdentityNotSetError)):
+        return False
+    if isinstance(exc, TransportError):
+        return exc.status_code is None
+    return isinstance(exc, UNREACHABLE_ERRORS)
+
+
+def _request_url(exc: BaseException) -> Optional[str]:
+    """The URL an httpx error was raised for, or None if it does not carry one."""
+    # httpx.RequestError.request RAISES RuntimeError when the request was never
+    # attached, so this cannot be a getattr with a default.
+    try:
+        return str(exc.request.url)  # type: ignore[attr-defined]
+    except (AttributeError, RuntimeError):
+        return None
+
+
+def _called_url(args, kwargs) -> Optional[str]:
+    """The URL a boundary function was called with, as a fallback for the above.
+
+    Every boundary function takes `url` either by keyword or as its first string
+    positional — the async pair takes `client` ahead of it, which is not a str.
+    """
+    url = kwargs.get("url")
+    if url is not None:
+        return url
+    return next((arg for arg in args if isinstance(arg, str)), None)
+
+
+def _as_transport_error(exc: HTTPError, url: Optional[str]) -> TransportError:
+    """Translate an httpx failure into our own vocabulary.
+
+    Two outcomes, and the difference between them is the point: a status means
+    SEC answered and refused, no status means we never got that far.
+    """
+    # Not every URL through here is an SEC one — the icon lookup in
+    # reference/tickers.py fetches from GitHub through the same boundary — so
+    # the message names the host it actually got instead of asserting EDGAR.
+    url = _request_url(exc) or url
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if status is not None:
+        return TransportError(
+            f"HTTP {status} from {url}",
+            suggestions=[
+                "a 404 means the path is wrong — it is not the same as a filing that does not exist",
+                "a 403 from SEC usually means the identity or the request rate was rejected",
+            ],
+            url=url,
+            status_code=status,
+        )
+    return TransportError(
+        f"Could not reach {url} ({type(exc).__name__}: {exc})",
+        suggestions=[
+            "check your network connection",
+            "check https://www.sec.gov/ — EDGAR takes scheduled maintenance windows",
+        ],
+        url=url,
+    )
+
+
+def wrap_transport_errors(func):
+    """Translate httpx failures into `TransportError` at the network boundary.
+
+    APPLY THIS ABOVE `@retry`, NEVER BELOW IT. stamina decides whether to retry
+    by testing the raised exception against `should_retry`, and `TransportError`
+    is not in `RETRYABLE_EXCEPTIONS`. Wrapping inside the retried function would
+    therefore translate the first attempt's timeout into a type stamina does not
+    recognise and turn every retried request into a single-shot one — a silent
+    reliability regression that no test asserting the exception type would
+    notice. Outside the decorator, the translation only ever sees the exception
+    that survived every attempt.
+
+    Gated on `strict_errors_enabled()` because user code may be catching
+    `httpx.HTTPError` around our calls; the wrap becomes unconditional in 6.0.
+    The original is always the `__cause__`, so `raise ... from e` keeps it
+    reachable for debugging without putting an httpx type in any signature.
+    """
+    # inspect must see through stamina's and with_identity's wrappers.
+    # isgeneratorfunction does not follow __wrapped__ on its own, and reading
+    # the outermost wrapper instead would classify the generator boundary as a
+    # plain function — which returns the generator without entering it, so the
+    # except clause would never fire.
+    target = inspect.unwrap(func)
+
+    if inspect.iscoroutinefunction(target):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except HTTPError as e:
+                if not strict_errors_enabled():
+                    raise
+                raise _as_transport_error(e, _called_url(args, kwargs)) from e
+        return wrapper
+
+    if inspect.isgeneratorfunction(target):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                yield from func(*args, **kwargs)
+            except HTTPError as e:
+                if not strict_errors_enabled():
+                    raise
+                raise _as_transport_error(e, _called_url(args, kwargs)) from e
+        return wrapper
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPError as e:
+            if not strict_errors_enabled():
+                raise
+            raise _as_transport_error(e, _called_url(args, kwargs)) from e
+    return wrapper
 
 
 def is_redirect(response):
@@ -628,6 +783,7 @@ def async_with_identity(func):
     return wrapper
 
 
+@wrap_transport_errors
 @retry(
     on=should_retry,
     attempts=QUICK_RETRY_ATTEMPTS,
@@ -653,6 +809,9 @@ def get_with_retry(url, identity=None, identity_callable=None, **kwargs):
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
         SSLVerificationError: If SSL certificate verification fails.
+        TransportError: Under EDGARTOOLS_STRICT_ERRORS (unconditional in 6.0),
+            any other httpx failure that survived every retry, with the original
+            as its ``__cause__``. Without the flag those propagate as httpx types.
     """
     try:
         with http_client() as client:
@@ -668,6 +827,7 @@ def get_with_retry(url, identity=None, identity_callable=None, **kwargs):
         raise
 
 
+@wrap_transport_errors
 @retry(
     on=should_retry,
     attempts=QUICK_RETRY_ATTEMPTS,
@@ -693,6 +853,9 @@ async def get_with_retry_async(client: AsyncClient, url, identity=None, identity
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
         SSLVerificationError: If SSL certificate verification fails.
+        TransportError: Under EDGARTOOLS_STRICT_ERRORS (unconditional in 6.0),
+            any other httpx failure that survived every retry, with the original
+            as its ``__cause__``. Without the flag those propagate as httpx types.
     """
     try:
         response = await client.get(url, **kwargs)
@@ -709,6 +872,7 @@ async def get_with_retry_async(client: AsyncClient, url, identity=None, identity
         raise
 
 
+@wrap_transport_errors
 @retry(
     on=should_retry,
     attempts=BULK_RETRY_ATTEMPTS,
@@ -736,6 +900,9 @@ def stream_with_retry(url, identity=None, identity_callable=None, bypass_cache=F
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
         SSLVerificationError: If SSL certificate verification fails.
+        TransportError: Under EDGARTOOLS_STRICT_ERRORS (unconditional in 6.0),
+            any other httpx failure that survived every retry, with the original
+            as its ``__cause__``. Without the flag those propagate as httpx types.
     """
     try:
         with http_client(bypass_cache=bypass_cache) as client:
@@ -753,6 +920,7 @@ def stream_with_retry(url, identity=None, identity_callable=None, bypass_cache=F
         raise
 
 
+@wrap_transport_errors
 @retry(
     on=should_retry,
     attempts=QUICK_RETRY_ATTEMPTS,
@@ -780,6 +948,9 @@ def post_with_retry(url, data=None, json=None, identity=None, identity_callable=
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
         SSLVerificationError: If SSL certificate verification fails.
+        TransportError: Under EDGARTOOLS_STRICT_ERRORS (unconditional in 6.0),
+            any other httpx failure that survived every retry, with the original
+            as its ``__cause__``. Without the flag those propagate as httpx types.
     """
     try:
         with http_client() as client:
@@ -797,6 +968,7 @@ def post_with_retry(url, data=None, json=None, identity=None, identity_callable=
         raise
 
 
+@wrap_transport_errors
 @retry(
     on=should_retry,
     attempts=QUICK_RETRY_ATTEMPTS,
@@ -824,6 +996,9 @@ async def post_with_retry_async(client: AsyncClient, url, data=None, json=None, 
     Raises:
         TooManyRequestsError: If the response status code is 429 (Too Many Requests).
         SSLVerificationError: If SSL certificate verification fails.
+        TransportError: Under EDGARTOOLS_STRICT_ERRORS (unconditional in 6.0),
+            any other httpx failure that survived every retry, with the original
+            as its ``__cause__``. Without the flag those propagate as httpx types.
     """
     try:
         response = await client.post(url, data=data, json=json, **kwargs)
@@ -846,9 +1021,19 @@ def inspect_response(response: Response):
 
     Accepts both 200 (OK) and 304 (Not Modified) as successful responses.
     304 indicates the cached content is still valid.
+
+    This is the sixth network boundary, and it needs the same wrap as the five
+    decorated functions: `raise_for_status()` raises httpx's own
+    `HTTPStatusError`, which would otherwise leak straight out of every caller
+    that inspects a response after the fact.
     """
     if response.status_code not in (200, 304):
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            if not strict_errors_enabled():
+                raise
+            raise _as_transport_error(e, str(response.url)) from e
 
 
 def decode_content(content: bytes) -> str:

--- a/edgar/reference/tickers.py
+++ b/edgar/reference/tickers.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pyarrow as pa
 
 from edgar.core import get_edgar_data_directory, listify, log
+from edgar.exceptions import http_status
 from edgar.httprequests import download_file, download_json
 from edgar.reference.data.common import read_csv_from_package, read_parquet_from_package
 
@@ -622,13 +623,17 @@ def get_icon_from_ticker(ticker: str) -> Optional[bytes]:
         return downloaded if isinstance(downloaded, bytes) else None
     except Exception as e:
         # If the status code is 404, the icon is not available.
-        # Duck-type on the response rather than the exception class: depending on
+        # Duck-type on the status rather than the exception class: depending on
         # the installed httpx build the raised type may not be our imported
         # HTTPStatusError (e.g. CI environments surface it under a different module
-        # identity such as httpx2), so matching on isinstance is fragile. Any
-        # exception that isn't a 404 is re-raised unchanged.
-        response = getattr(e, "response", None)
-        if response is not None and getattr(response, "status_code", None) == 404:
+        # identity such as httpx2), so matching on isinstance is fragile. It is
+        # also why this reads the status through http_status() — under
+        # EDGARTOOLS_STRICT_ERRORS the boundary raises a TransportError, which
+        # carries `.status_code` and no `.response` at all, and a check written
+        # against `.response` silently stops recognising the 404 and starts
+        # raising for every ticker without an icon. Anything that isn't a 404 is
+        # re-raised unchanged.
+        if http_status(e) == 404:
             return None
         raise
 

--- a/edgar/search/efts.py
+++ b/edgar/search/efts.py
@@ -680,14 +680,23 @@ def resolve_accession(accession_number: str) -> Optional[dict]:
     """
     import orjson
 
-    from edgar.httprequests import get_with_retry
+    from edgar.httprequests import TRANSPORT_ERRORS, get_with_retry
 
     normalized = accession_number.replace("-", "")
 
     try:
         response = get_with_retry(EFTS_BASE_URL, params={"q": f'"{accession_number}"'})
         hits = orjson.loads(response.content).get("hits", {}).get("hits", [])
-    except Exception as exc:  # network, rate limit, schema drift
+    except TRANSPORT_ERRORS:
+        # Let the caller see the outage (bead edgartools-07lk.10, closing the
+        # tg7y follow-up). The `return None` below means "EFTS has no filing at
+        # this accession", which for a pre-2001 accession is the expected answer
+        # and sends the caller to the quarterly index. Collapsing an outage into
+        # that same None tells the caller to go looking somewhere else for a
+        # filing that was there all along, and the only trace is a DEBUG line
+        # nobody has enabled.
+        raise
+    except Exception as exc:  # schema drift, malformed JSON
         logger.debug("EFTS accession lookup failed for %s: %s", accession_number, exc)
         return None
 

--- a/edgar/storage/_local.py
+++ b/edgar/storage/_local.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 import pandas as pd
 from bs4 import BeautifulSoup
 
-from edgar.exceptions import EdgarError
+from edgar.exceptions import EdgarError, TransportError, http_status
 from httpx import AsyncClient, HTTPStatusError
 from tqdm.auto import tqdm
 
@@ -597,17 +597,24 @@ def get_sec_file_listing(url:str) -> pd.DataFrame:
 
     Raises:
         ValueError: If URL is invalid or doesn't point to SEC EDGAR
-        ConnectionError: If unable to download the page
+        ConnectionError: If unable to download the page (pre-6.0; under
+            EDGARTOOLS_STRICT_ERRORS the TransportError propagates as itself)
         RuntimeError: If page structure is invalid or no table found
     """
     try:
         html = download_text(url)
-    except HTTPStatusError as e:
-        if e.response.status_code == 403:
+    except (HTTPStatusError, TransportError) as e:
+        status = http_status(e)
+        if status == 403:
             log.warning(f"There are no feed files for url {url}")
             return pd.DataFrame(columns=['Name', 'File', 'Size', 'Modified'])
-        elif e.response.status_code == 404:
+        elif status == 404:
             raise FileNotFoundError(f"Page not found: {url}") from None
+        if isinstance(e, TransportError):
+            # Already the right type under the strict wrap. Re-wrapping it as a
+            # builtin ConnectionError would demote a typed error back to the
+            # vocabulary the hierarchy exists to replace.
+            raise
         raise ConnectionError(f"Failed to download page: {str(e)}") from e
 
     if "Directory Browsing Not Allowed" in html:
@@ -671,7 +678,8 @@ def list_filing_feed_files(url: str) -> pd.DataFrame:
 
     Raises:
         ValueError: If URL is invalid or doesn't point to SEC EDGAR
-        ConnectionError: If unable to download the page
+        ConnectionError: If unable to download the page (pre-6.0; under
+            EDGARTOOLS_STRICT_ERRORS the TransportError propagates as itself)
         RuntimeError: If page structure is invalid or no table found
     """
     # Validate URL

--- a/tests/issues/regression/test_exceptions_network_boundary.py
+++ b/tests/issues/regression/test_exceptions_network_boundary.py
@@ -38,6 +38,14 @@ import httpx
 import pytest
 from stamina import retry
 
+# Bound here, at module import time, ON PURPOSE. tests/conftest.py replaces this
+# module attribute with a session-wide memoizing wrapper, and collection runs
+# before session fixtures are set up — so this name is the real function while
+# `submissions.download_entity_submissions_from_sec` is the wrapper. See
+# test_the_submissions_tests_call_the_real_function for what goes wrong without it.
+from edgar.entity.submissions import (
+    download_entity_submissions_from_sec as _real_download_submissions,
+)
 from edgar.exceptions import (
     IdentityNotSetError,
     TooManyRequestsError,
@@ -383,7 +391,7 @@ def test_submissions_404_returns_none_in_both_eras(monkeypatch, raised):
         raise raised
 
     monkeypatch.setattr(submissions, "download_json", fail)
-    assert submissions.download_entity_submissions_from_sec(99999999) is None
+    assert _real_download_submissions(99999999) is None
 
 
 @pytest.mark.parametrize("raised", [
@@ -400,7 +408,27 @@ def test_submissions_outage_is_not_reported_as_an_unknown_cik(monkeypatch, raise
 
     monkeypatch.setattr(submissions, "download_json", fail)
     with pytest.raises(type(raised)):
-        submissions.download_entity_submissions_from_sec(320193)
+        _real_download_submissions(320193)
+
+
+def test_the_submissions_tests_call_the_real_function():
+    """Guard the two tests above against the wrapper that already broke them.
+
+    `tests/conftest.py` memoizes `download_entity_submissions_from_sec` for the
+    whole session by replacing the module attribute. For a CIK some earlier test
+    already fetched — 320193 appears hundreds of times in this suite — the
+    wrapper answers from its cache and never reaches the `except` clause under
+    test. That is a green test that verifies nothing, and it is exactly what
+    happened: both tests passed run alone and failed in the full regression run.
+
+    Binding the function at module import time gets the real one, because
+    collection finishes before session fixtures are set up. This asserts that
+    binding still holds, so the day the import moves the test says so.
+    """
+    assert _real_download_submissions.__name__ == "download_entity_submissions_from_sec", (
+        "the submissions tests are calling conftest's memoizing wrapper, which "
+        "short-circuits on a cache hit and never exercises the code under test"
+    )
 
 
 @pytest.mark.parametrize("raised", [

--- a/tests/issues/regression/test_exceptions_network_boundary.py
+++ b/tests/issues/regression/test_exceptions_network_boundary.py
@@ -1,0 +1,455 @@
+"""The network boundary: httpx failures become TransportError, once, at the edge.
+
+Bead: edgartools-07lk.10, PR2 of 3. Design §5.
+
+Before this, an httpx exception that survived every retry propagated verbatim
+out of `get_with_retry` and friends, so `httpx.ReadTimeout` was part of our
+public contract by accident — every user `except` clause naming it, and every
+future call site, inherited a dependency's type. The wrap fixes that once at the
+boundary rather than at each of the call sites.
+
+The wrap is a 6.0 break (someone may be catching `httpx.HTTPError` around our
+calls), so in 5.x it is gated on `EDGARTOOLS_STRICT_ERRORS`. That makes this
+file's job two-sided: prove the wrap does the right thing when it is on, and
+prove nothing at all changed when it is off.
+
+WHAT THESE TESTS PROTECT, in order of how quietly each could break:
+
+  1. **Retries still happen under strict.** The wrap must sit ABOVE `@retry`.
+     Move it below and stamina sees `TransportError`, which is not in
+     `RETRYABLE_EXCEPTIONS`, so every retried request silently becomes a
+     single-shot one. Nothing about the raised type would look wrong; the
+     library would just get worse at bad networks. `test_*_still_retries` is the
+     only thing standing between us and that.
+  2. **The generator boundary is entered.** `stream_with_retry` is a generator,
+     and a decorator that treats it as a plain function returns the generator
+     object without running a line of it — so the `except` never fires and the
+     wrap silently does not apply to streaming.
+  3. **`is_unreachable` excludes the deterministic failures.** SSL and identity
+     errors carry no status, so a naive `status_code is None` check would let
+     the offline-fallback paths swallow the two errors whose whole value is the
+     message telling the user what to change.
+  4. **The flag off is byte-for-byte the old behaviour.** That is what makes
+     this shippable in 5.x.
+"""
+import asyncio
+
+import httpx
+import pytest
+from stamina import retry
+
+from edgar.exceptions import (
+    IdentityNotSetError,
+    TooManyRequestsError,
+    TransportError,
+    http_status,
+    strict_errors_enabled,
+)
+from edgar.httprequests import (
+    RETRYABLE_EXCEPTIONS,
+    TRANSPORT_ERRORS,
+    UNREACHABLE_ERRORS,
+    SSLVerificationError,
+    inspect_response,
+    is_unreachable,
+    should_retry,
+    wrap_transport_errors,
+)
+
+URL = "https://www.sec.gov/cgi-bin/browse-edgar"
+
+
+@pytest.fixture
+def strict(monkeypatch):
+    monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", "1")
+
+
+@pytest.fixture
+def lenient(monkeypatch):
+    monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS", raising=False)
+
+
+def _status_error(status: int, url: str = URL) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", url)
+    return httpx.HTTPStatusError(
+        f"{status}", request=request, response=httpx.Response(status, request=request)
+    )
+
+
+# Boundary doubles. Same decorator order as the real functions in
+# httprequests.py: wrap_transport_errors OUTSIDE @retry.
+def _retrying(fn):
+    return wrap_transport_errors(
+        retry(on=should_retry, attempts=3, wait_initial=0.001, wait_max=0.001)(fn)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The flag
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value,expected", [
+    ("1", True), ("true", True), ("TRUE", True), ("yes", True), ("on", True),
+    (" 1 ", True), ("0", False), ("false", False), ("", False), ("maybe", False),
+])
+def test_strict_flag_reading(monkeypatch, value, expected):
+    monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", value)
+    assert strict_errors_enabled() is expected
+
+
+def test_strict_flag_is_read_per_call_not_captured_at_import(monkeypatch):
+    """A test that sets the variable must be able to unset it again.
+
+    Caching this at import would make the strict CI job the only way to
+    exercise the wrapped paths, and make every test in this file order-dependent.
+    """
+    monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS", raising=False)
+    assert strict_errors_enabled() is False
+    monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", "1")
+    assert strict_errors_enabled() is True
+    monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS")
+    assert strict_errors_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# The wrap, on
+# ---------------------------------------------------------------------------
+
+def test_connect_failure_becomes_a_transport_error_with_no_status(strict):
+    @_retrying
+    def boundary(url):
+        raise httpx.ConnectError("nodename nor servname provided")
+
+    with pytest.raises(TransportError) as excinfo:
+        boundary(URL)
+
+    exc = excinfo.value
+    assert exc.status_code is None, "no status means we never got an answer — the whole distinction"
+    assert exc.url == URL
+    assert isinstance(exc.__cause__, httpx.ConnectError), "the original must stay reachable"
+
+
+def test_status_error_becomes_a_transport_error_carrying_the_status(strict):
+    @_retrying
+    def boundary(url):
+        raise _status_error(503)
+
+    with pytest.raises(TransportError) as excinfo:
+        boundary(URL)
+
+    exc = excinfo.value
+    assert exc.status_code == 503
+    assert http_status(exc) == 503
+    assert "HTTP 503" in str(exc)
+    assert isinstance(exc.__cause__, httpx.HTTPStatusError)
+
+
+def test_the_url_comes_from_the_exception_when_it_has_one(strict):
+    """After a redirect the call argument is stale; the exception is not."""
+    redirected = "https://www.sec.gov/somewhere-else"
+
+    @_retrying
+    def boundary(url):
+        raise _status_error(404, url=redirected)
+
+    with pytest.raises(TransportError) as excinfo:
+        boundary(URL)
+    assert excinfo.value.url == redirected
+
+
+def test_async_boundary_wraps(strict):
+    @_retrying
+    async def boundary(client, url):
+        raise httpx.ReadTimeout("timed out")
+
+    with pytest.raises(TransportError) as excinfo:
+        asyncio.run(boundary(None, URL))
+    assert isinstance(excinfo.value.__cause__, httpx.ReadTimeout)
+    assert excinfo.value.url == URL
+
+
+def test_generator_boundary_wraps(strict):
+    """The failure mode here is silent: a generator treated as a plain function
+    returns without executing, so the except clause never sees anything."""
+    @_retrying
+    def boundary(url):
+        yield b"first chunk"
+        raise httpx.ReadTimeout("connection dropped mid-stream")
+
+    with pytest.raises(TransportError) as excinfo:
+        list(boundary(URL))
+    assert isinstance(excinfo.value.__cause__, httpx.ReadTimeout)
+
+
+def test_inspect_response_wraps_raise_for_status(strict):
+    request = httpx.Request("GET", URL)
+    response = httpx.Response(500, request=request)
+
+    with pytest.raises(TransportError) as excinfo:
+        inspect_response(response)
+    assert excinfo.value.status_code == 500
+    assert isinstance(excinfo.value.__cause__, httpx.HTTPStatusError)
+
+
+@pytest.mark.parametrize("status", [200, 304])
+def test_inspect_response_still_accepts_success_and_not_modified(strict, status):
+    request = httpx.Request("GET", URL)
+    assert inspect_response(httpx.Response(status, request=request)) is None
+
+
+def test_our_own_transport_errors_pass_through_untouched(strict):
+    """429 and SSL are already ours; the wrap must not re-wrap them."""
+    @_retrying
+    def rate_limited(url):
+        raise TooManyRequestsError(url, retry_after=600)
+
+    with pytest.raises(TooManyRequestsError) as excinfo:
+        rate_limited(URL)
+    assert excinfo.value.retry_after == 600
+    assert excinfo.value.__cause__ is None
+
+
+# ---------------------------------------------------------------------------
+# The wrap, off — nothing changed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("original", [
+    httpx.ConnectError("no route"),
+    httpx.ReadTimeout("timed out"),
+    _status_error(404),
+])
+def test_without_the_flag_httpx_propagates_verbatim(lenient, original):
+    @_retrying
+    def boundary(url):
+        raise original
+
+    with pytest.raises(type(original)) as excinfo:
+        boundary(URL)
+    assert excinfo.value is original, "not merely the same type — the same object"
+
+
+def test_without_the_flag_inspect_response_still_raises_httpx(lenient):
+    request = httpx.Request("GET", URL)
+    with pytest.raises(httpx.HTTPStatusError):
+        inspect_response(httpx.Response(500, request=request))
+
+
+# ---------------------------------------------------------------------------
+# Retries survive the wrap
+# ---------------------------------------------------------------------------
+
+def test_transport_error_is_not_retryable_which_is_why_order_matters():
+    """The mechanism behind the bug the next two tests exist to catch."""
+    assert not isinstance(TransportError("boom"), RETRYABLE_EXCEPTIONS)
+    assert should_retry(httpx.ReadTimeout("x")) is True
+    assert should_retry(TransportError("x")) is False
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_the_boundary_still_retries(monkeypatch, flag):
+    """Wrapping inside @retry would make this 1 instead of 3, and nothing else
+    would look wrong."""
+    if flag:
+        monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", "1")
+    else:
+        monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS", raising=False)
+
+    attempts = []
+
+    @_retrying
+    def boundary(url):
+        attempts.append(1)
+        raise httpx.ReadTimeout("timed out")
+
+    with pytest.raises((TransportError, httpx.ReadTimeout)):
+        boundary(URL)
+    assert len(attempts) == 3, (
+        "the boundary stopped retrying — wrap_transport_errors is almost "
+        "certainly applied below @retry instead of above it"
+    )
+
+
+def test_the_async_boundary_still_retries(strict):
+    attempts = []
+
+    @_retrying
+    async def boundary(client, url):
+        attempts.append(1)
+        raise httpx.ReadTimeout("timed out")
+
+    with pytest.raises(TransportError):
+        asyncio.run(boundary(None, URL))
+    assert len(attempts) == 3
+
+
+# ---------------------------------------------------------------------------
+# TRANSPORT_ERRORS and is_unreachable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("exc_type", [
+    httpx.ConnectError, httpx.ReadTimeout, httpx.HTTPStatusError,
+    TransportError, TooManyRequestsError, SSLVerificationError, IdentityNotSetError,
+])
+def test_transport_errors_catches_both_eras(exc_type):
+    """One `except TRANSPORT_ERRORS:` must mean the same thing before and after
+    the flip, or every call site written against it needs revisiting in 6.0."""
+    assert issubclass(exc_type, TRANSPORT_ERRORS)
+
+
+@pytest.mark.parametrize("not_transport", [ValueError, AttributeError, KeyError, TypeError])
+def test_transport_errors_stays_narrow(not_transport):
+    assert not issubclass(not_transport, TRANSPORT_ERRORS)
+
+
+@pytest.mark.parametrize("exc,expected", [
+    (httpx.ConnectError("no route"), True),
+    (httpx.ReadTimeout("timed out"), True),
+    (httpx.TimeoutException("timed out"), True),
+    (TransportError("could not reach"), True),
+    (TransportError("SEC said no", status_code=404), False),
+    (_status_error(500), False),
+    (TooManyRequestsError(URL), False),
+    (IdentityNotSetError(), False),
+])
+def test_is_unreachable(exc, expected):
+    assert is_unreachable(exc) is expected
+
+
+def test_ssl_failure_is_never_treated_as_unreachable():
+    """It carries no status, so a `status_code is None` check would swallow it.
+
+    The offline-fallback paths call is_unreachable to decide whether to give up
+    quietly. An expired or intercepted certificate is deterministic and
+    user-fixable, and the diagnostic message is the entire point of raising it —
+    degrading it to "you seem to be offline" throws that away.
+    """
+    ssl_error = SSLVerificationError(httpx.ConnectError("certificate verify failed"), URL)
+    assert ssl_error.status_code is None
+    assert is_unreachable(ssl_error) is False
+
+
+def test_unreachable_errors_are_all_retryable():
+    """These are the transient ones; if one were not retryable, a caller falling
+    back on it would be giving up on the first blip."""
+    for exc_type in UNREACHABLE_ERRORS:
+        assert issubclass(exc_type, RETRYABLE_EXCEPTIONS), exc_type
+
+
+# ---------------------------------------------------------------------------
+# The internal call sites, in both eras
+#
+# These are what the strict CI job is for. Each site sits above the boundary and
+# translates a status it understands into a domain answer; each must give the
+# same answer whichever era raised. A site that only handles the httpx type
+# keeps passing today and starts falling through to its `raise` in 6.0 — the
+# 404-becomes-None handling would simply stop existing, and no test naming httpx
+# would notice.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raised", [_status_error(404), TransportError("gone", status_code=404)])
+def test_company_facts_404_becomes_the_domain_error_in_both_eras(monkeypatch, raised):
+    from edgar.entity import entity_facts
+    from edgar.exceptions import CompanyFactsNotFoundError
+
+    def fail(_url):
+        raise raised
+
+    monkeypatch.setattr(entity_facts, "download_json", fail)
+    with pytest.raises(CompanyFactsNotFoundError) as excinfo:
+        entity_facts.download_company_facts_from_sec(99999999)
+    assert excinfo.value.cik == 99999999
+
+
+@pytest.mark.parametrize("raised", [_status_error(503), TransportError("outage", status_code=503)])
+def test_company_facts_outage_is_not_reported_as_missing_facts(monkeypatch, raised):
+    """The distinction the transport branch exists for: a 503 is not "no facts"."""
+    from edgar.entity import entity_facts
+    from edgar.exceptions import CompanyFactsNotFoundError
+
+    def fail(_url):
+        raise raised
+
+    monkeypatch.setattr(entity_facts, "download_json", fail)
+    with pytest.raises(type(raised)) as excinfo:
+        entity_facts.download_company_facts_from_sec(320193)
+    assert not isinstance(excinfo.value, CompanyFactsNotFoundError)
+
+
+@pytest.mark.parametrize("raised", [_status_error(404), TransportError("gone", status_code=404)])
+def test_submissions_404_returns_none_in_both_eras(monkeypatch, raised):
+    from edgar.entity import submissions
+
+    def fail(_url):
+        raise raised
+
+    monkeypatch.setattr(submissions, "download_json", fail)
+    assert submissions.download_entity_submissions_from_sec(99999999) is None
+
+
+@pytest.mark.parametrize("raised", [
+    httpx.ConnectError("no route"),
+    TransportError("could not reach SEC"),
+])
+def test_submissions_outage_is_not_reported_as_an_unknown_cik(monkeypatch, raised):
+    """`None` here means "SEC has no such CIK". An outage returning None tells
+    the user their company does not exist."""
+    from edgar.entity import submissions
+
+    def fail(_url):
+        raise raised
+
+    monkeypatch.setattr(submissions, "download_json", fail)
+    with pytest.raises(type(raised)):
+        submissions.download_entity_submissions_from_sec(320193)
+
+
+@pytest.mark.parametrize("raised", [
+    httpx.ConnectError("no route"),
+    TransportError("could not reach SEC"),
+])
+def test_efts_accession_lookup_surfaces_the_outage(monkeypatch, raised):
+    """Closes the tg7y sibling. `None` from this function means "EFTS has no
+    filing at this accession", which routes the caller to the quarterly index —
+    the wrong destination entirely when the real answer was an outage."""
+    from edgar import httprequests
+    from edgar.search import efts
+
+    def fail(*_args, **_kwargs):
+        raise raised
+
+    monkeypatch.setattr(httprequests, "get_with_retry", fail)
+    with pytest.raises(type(raised)):
+        efts.resolve_accession("0000320193-23-000106")
+
+
+def test_efts_accession_lookup_still_swallows_schema_drift(monkeypatch):
+    """The other half of the same change: a malformed response is still None.
+
+    Narrowing the transport case out of `except Exception` must not turn every
+    parse hiccup into a raise — a pre-2001 accession legitimately answers None.
+    """
+    from edgar import httprequests
+    from edgar.search import efts
+
+    def garbage(*_args, **_kwargs):
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    monkeypatch.setattr(httprequests, "get_with_retry", garbage)
+    assert efts.resolve_accession("0000320193-23-000106") is None
+
+
+# ---------------------------------------------------------------------------
+# http_status reads either era
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("exc,expected", [
+    (_status_error(404), 404),
+    (_status_error(403), 403),
+    (TransportError("x", status_code=500), 500),
+    (TransportError("x"), None),
+    (httpx.ConnectError("no route"), None),
+    (TooManyRequestsError(URL), 429),
+    (ValueError("not a transport failure at all"), None),
+])
+def test_http_status(exc, expected):
+    assert http_status(exc) == expected

--- a/tests/issues/regression/test_exceptions_tree.py
+++ b/tests/issues/regression/test_exceptions_tree.py
@@ -73,16 +73,25 @@ def _instance(name):
     return getattr(ex, name)(*CONSTRUCTOR_ARGS[name])
 
 
+# `__all__` also exports the two helpers the dual-era call sites use
+# (strict_errors_enabled, http_status), which are functions rather than classes.
+# Everything below is about the tree, so it enumerates the classes only.
+EXCEPTION_NAMES = sorted(
+    name for name in ex.__all__
+    if isinstance(getattr(ex, name), type) and issubclass(getattr(ex, name), BaseException)
+)
+
+
 def test_every_public_class_is_constructible():
     """Guard the guard: the tests below all instantiate the tree."""
-    missing = sorted(set(ex.__all__) - set(CONSTRUCTOR_ARGS))
+    missing = sorted(set(EXCEPTION_NAMES) - set(CONSTRUCTOR_ARGS))
     assert not missing, (
         f"{missing} are exported from edgar.exceptions but have no constructor "
         f"arguments in this file, so nothing below exercises them. Add an entry."
     )
 
 
-@pytest.mark.parametrize("name", sorted(ex.__all__))
+@pytest.mark.parametrize("name", EXCEPTION_NAMES)
 def test_every_public_exception_is_an_edgar_error(name):
     """One root, or `except EdgarError` is a lie."""
     cls = getattr(ex, name)
@@ -93,7 +102,7 @@ def test_the_tree_has_four_branches():
     """The shape is the documentation. A fifth branch is a design decision."""
     branches = {c for c in (ex.TransportError, ex.NotFoundError,
                             ex.ParsingError, ex.ValidationError)}
-    direct_children = {getattr(ex, n) for n in ex.__all__
+    direct_children = {getattr(ex, n) for n in EXCEPTION_NAMES
                        if ex.EdgarError in getattr(ex, n).__bases__}
     assert direct_children == branches, (
         f"direct children of EdgarError are {sorted(c.__name__ for c in direct_children)}; "
@@ -245,7 +254,7 @@ def test_no_third_party_type_in_the_public_tree():
     Owning our own types is what makes swapping the HTTP client a non-event
     rather than a breaking change to every user's `except` clause.
     """
-    for name in ex.__all__:
+    for name in EXCEPTION_NAMES:
         for base in getattr(ex, name).__mro__:
             root = base.__module__.split(".")[0]
             assert root in ("edgar", "builtins"), (

--- a/tests/issues/regression/test_issue_tg7y_fund_series_network_silence.py
+++ b/tests/issues/regression/test_issue_tg7y_fund_series_network_silence.py
@@ -32,7 +32,7 @@ import pytest
 from edgar.funds.core import Fund
 from edgar.httprequests import (
     TRANSPORT_ERRORS,
-    IdentityNotSetException,
+    IdentityNotSetError,
     SSLVerificationError,
     TooManyRequestsError,
 )
@@ -143,15 +143,18 @@ def test_transport_errors_tuple_covers_what_the_http_layer_actually_raises():
     """A guard keyed on the wrong types is not a guard.
 
     httpx.HTTPError is the base of ConnectError/ReadTimeout/HTTPStatusError, so
-    naming it covers the transport family without enumerating it. The other three
-    are edgartools' own and are not httpx subclasses, so they have to be listed.
+    naming it covers that family without enumerating it. TransportError covers
+    ours the same way — 429, SSL and identity are all subclasses of it, and so
+    is everything the boundary wrap raises under EDGARTOOLS_STRICT_ERRORS. Both
+    bases stay listed through 6.0 so this tuple means the same thing in either
+    era (bead edgartools-07lk.10).
     """
     assert issubclass(httpx.ConnectError, TRANSPORT_ERRORS)
     assert issubclass(httpx.ReadTimeout, TRANSPORT_ERRORS)
     assert issubclass(httpx.HTTPStatusError, TRANSPORT_ERRORS)
     assert issubclass(TooManyRequestsError, TRANSPORT_ERRORS)
     assert issubclass(SSLVerificationError, TRANSPORT_ERRORS)
-    assert issubclass(IdentityNotSetException, TRANSPORT_ERRORS)
+    assert issubclass(IdentityNotSetError, TRANSPORT_ERRORS)
 
     # And it must NOT swallow ordinary bugs into the transport bucket.
     assert not issubclass(ValueError, TRANSPORT_ERRORS)

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -22,7 +22,7 @@ from edgar.httprequests import (
     post_with_retry,
     post_with_retry_async,
     TooManyRequestsError,
-    IdentityNotSetException,
+    IdentityNotSetError,
     SSLVerificationError,
     is_ssl_error,
     should_retry,
@@ -124,7 +124,7 @@ async def test_post_with_retry_async():
 def test_identity_not_set_exception(monkeypatch):
     # Remove the EDGAR_IDENTITY environment variable
     monkeypatch.delenv("EDGAR_IDENTITY", raising=False)
-    with pytest.raises(IdentityNotSetException):
+    with pytest.raises(IdentityNotSetError):
         get_with_retry("http://example.com")
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -212,8 +212,8 @@ class TestErrorClassification:
         assert any("use_system_certs" in s for s in result["suggestions"])
 
     def test_identity_not_set(self):
-        from edgar.httprequests import IdentityNotSetException
-        result = classify_error(IdentityNotSetException())
+        from edgar.httprequests import IdentityNotSetError
+        result = classify_error(IdentityNotSetError())
         assert result["error_code"] == "IDENTITY_NOT_SET"
         assert any("EDGAR_IDENTITY" in s for s in result["suggestions"])
 


### PR DESCRIPTION
PR2 of 3 for bead `edgartools-07lk.10`. [PR1](https://github.com/dgunning/edgartools/pull/1034) built the vocabulary; this one makes the network layer speak it.

## The problem

An httpx exception that survived every retry propagated verbatim out of `get_with_retry`, `stream_with_retry`, `post_with_retry` and `inspect_response`. stamina's `on=` predicate only decides *whether* to retry — on exhaustion it re-raises the original untouched. So `httpx.ReadTimeout` was part of our public contract by accident, and any future HTTP-client change was a breaking one for every `except` clause naming it.

## The wrap

Once at the six boundary functions, not at each call site. Carries `.status_code` (`None` when we never got an answer at all — the discriminator between "SEC said no" and "we could not ask") and `.url`, and always chains the original as `__cause__`. Gated on `EDGARTOOLS_STRICT_ERRORS` because user code may be catching `httpx.HTTPError` around our calls; unconditional in 6.0.

### The one thing to know when reviewing

`wrap_transport_errors` sits **above** `@retry`, not below. Below it, stamina sees a `TransportError` — not in `RETRYABLE_EXCEPTIONS` — and every retried request silently becomes a single-shot one. No test asserting the raised exception type would notice; the library would just get quietly worse at bad networks. `test_the_boundary_still_retries` is what stands between us and that.

The generator boundary has the same shape of trap: `inspect.isgeneratorfunction` does not follow `__wrapped__`, so the decorator unwraps first. Without that, `stream_with_retry` gets the plain-function wrapper, which returns the generator without entering it — the `except` never fires and the wrap silently does not apply to streaming.

## Also in this PR

- **`TRANSPORT_ERRORS` collapses to `(HTTPError, TransportError)`.** The other three entries are `TransportError` subclasses now. Both families stay listed through 6.0, so a call site written against the tuple means the same thing in either era.
- **Eight internal `except httpx.*` sites made dual-era**, not the five the design named — the three tuple-catches in `_filings.py` sit above the boundary too. They read status through a new `http_status()` helper, and the two that quietly degrade when offline ask `is_unreachable()` rather than catching `TransportError` outright, which would newly swallow 4xx, SSL and identity failures.
- **`reference/tickers.py` duck-typed the icon 404 on `e.response.status_code`.** `TransportError` has no `.response`, so under strict every ticker without an icon would have started raising. Found by the new CI job — which is exactly what it is for.
- **`resolve_accession()` reported an EFTS outage as "no filing at that accession"**, routing the caller to the quarterly index mid-outage with the only trace at DEBUG. Closes the `tg7y` sibling.

## Deviations from the design doc

Both are flagged in the code comments:

1. **The wrap goes outside `@retry`**, not inside the decorated function bodies as §5's wording implies. Inside would disable retries — see above.
2. **`test-strict-errors` is not `continue-on-error`.** The design assumed it would arrive amber; it arrives green — all 4,913 fast tests pass under the flag — so it is a hard failure and is in the `report` lane's `needs`. An allowed-to-fail lane that already passes teaches nobody anything, and this repo has already paid for the lesson that an unreported post-merge failure survives several merges (`edgartools-hwdp`, #999).

## Verification

- `tests/issues/regression/test_exceptions_network_boundary.py` — 67 tests: the wrap on and off, sync/async/generator, retries preserved in both modes, `__cause__` chained, `is_unreachable` excluding the deterministic failures, and the internal call sites answering identically in both eras.
- 4,913 fast tests pass **both** with and without `EDGARTOOLS_STRICT_ERRORS=1`.
- No new ruff findings (1,120 before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)