### PR TITLE
chore(release): 5.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.48.0] - 2026-08-12
+
 ### Added
 
 - **`edgar.exceptions` — one exception vocabulary, four branches.** There were 27 exception classes across ten packages with no shared base and no cross-package inheritance, of which exactly two were reachable from the top level, so `except` had to name a type from whichever module happened to raise. There is now a root, `EdgarError`, and four branches that answer the question a caller actually has: `TransportError` (we could not get an answer from SEC), `NotFoundError` (you named a thing and it does not exist), `ParsingError` (we got bytes and could not build the object), `ValidationError` (your input was wrong before we asked). The distinction between the first two is the one that matters most — an outage and an empty result must never arrive as the same value. **Nothing changed about what is raised today**: every existing class was re-based into the tree or kept as a deprecated alias for the same object, so `except StatementNotFound:` and `pytest.raises(SECFilingNotFoundError)` still work. The branches also inherit the builtin they replace — `ValidationError` is a `ValueError`, `NotFoundError` is a `LookupError` — so the `except ValueError:` you wrote against our 135 raw `ValueError` raises keeps working as those convert. Deprecated spellings warn and are removed in 6.0: `StatementNotFound`, `NoCompanyFactsFound`, `SECFilingNotFoundError`, `InvalidDateException`, `IdentityNotSetException`, `TooManyRequestsException`, `DataObjectException`.
 
 - **A missing-attachment lookup raises `AttachmentNotFoundError`** rather than a bare `KeyError`. It *is* a `KeyError`, so existing handlers are unaffected.
 
-- **`EDGARTOOLS_STRICT_ERRORS=1` runs 6.0's error behaviour today.** The changes that would otherwise be a break are available behind the flag, so you can port before 6.0 lands rather than after. Today it turns on the network wrap below; the silent-`None` conversions join it as they land. Check it yourself with `edgar.exceptions.strict_errors_enabled()`.
+- **`EDGARTOOLS_STRICT_ERRORS=1` runs 6.0's error behaviour today.** The changes that would otherwise be a break are available behind the flag, so you can port before 6.0 lands rather than after. It turns on both halves of that change: the network wrap below, and the four silent-`None` conversions under **Deprecated**. Check it yourself with `edgar.exceptions.strict_errors_enabled()`.
 
 - **`report.get(item, default)` on every company report.** The counterpart to `report[item]`, and the reason that one can start raising in 6.0: a lookup whose only form raises leaves the "I'll take it if it's there" caller wrapping a one-liner in try/except. It never warns — it is the migration target, and warning there would give the users who took our advice the same noise as the users who ignored it.
 

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.47.0'
+__version__ = '5.48.0'


### PR DESCRIPTION
Cuts **5.48.0** — the release that converts `07lk.10`'s staging work from merged into *received*.

## Why now

Everything here has been on `main` for days and none of it has reached an installed package. A deprecation warning nobody has received is not a warning: the period during which users can act on these starts at **this release**, not at those merges.

It is bounded on the far side by the 6.0 **freeze window** (~2026-10-12) rather than by 6.0 itself — once the window opens, 5.x releases stop and there is no release left to carry a warning. Anything staged but unreleased at that point delivers zero user protection. That is the whole argument for cutting now rather than batching with the remaining staging work (`07lk.3`, `07lk.12.1`, `07lk.11`), which is weeks out.

## What ships

| | Bead |
|---|---|
| `edgar.exceptions` — one vocabulary, four branches; nothing raised differently, 7 old spellings warn | `07lk.10` |
| `py.typed`, so annotations already written reach mypy | `07lk.6` |
| `EDGARTOOLS_STRICT_ERRORS=1` runs 6.0's error behaviour today | `07lk.10` |
| `report.get(item, default)` beside `report[item]` | `07lk.10` |
| Four silent `None`s that now name what they raise in 6.0 | `07lk.10` |
| Three fixes: an unfireable `ConnectionError` handler in the docs, an unreadable `NoCompanyFactsFound` message, an EFTS outage misreported as "no such filing" | |

**Backward compatible.** Every deprecated spelling still resolves to the same object, the branches inherit the builtins they replace (`ValidationError` is a `ValueError`, `NotFoundError` is a `LookupError`), and the 6.0 behaviour is opt-in behind the env var. Nothing raises differently than it did in 5.47.0 unless you ask it to.

## Changes in this PR

Two files: `edgar/__about__.py` `5.47.0` → `5.48.0`, and the `CHANGELOG.md` `[Unreleased]` block folded into `## [5.48.0] - 2026-08-12` with a fresh empty `[Unreleased]`. One stale line corrected — the strict-mode entry said the silent-`None` conversions would "join it as they land"; they have landed, so it now says the flag turns on both halves.

## Verification

- `hatch run test-fast`: **4950 passed, 4 skipped, 1 xfailed**
- `edgar.__version__` reports `5.48.0`
- Post-merge run on `8023ecc2` (the commit this releases) was green across every job the repo has, including the PR-exempt `test-strict-errors`, `test-network` and `test-slow`


🤖 Generated with [Claude Code](https://claude.com/claude-code)