### PR TITLE
fix(reports): the deprecation warned about our fallback, not your code (07lk.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`report.items` warned you about `chunked_document`, an attribute you never touched.** `TenK`, `TenQ`, `TwentyF` and `CurrentReport` try the new parser first and fall back to the legacy `ChunkedDocument`, and those fallbacks read the *public* deprecated property — so a plain `twentyf.items` emitted `chunked_document is deprecated` about a choice that was ours, not yours. 20-F got it on every call, because 20-F prefers the legacy path deliberately. If you run `-W error::DeprecationWarning`, that was not a warning but an exception. Internal paths now use a private accessor and say nothing; asking for `chunked_document` yourself still warns.
+
+- **Three report classes had silently lost that deprecation entirely.** `TenK`, `TenQ` and `CurrentReport` each overrode `chunked_document` to change how it was built, and an override that replaces the property also replaces the `warnings.warn` inside it — so their users got no notice that the attribute disappears in 6.0, which is the population the deprecation exists for. Construction now happens in `_chunked_document`, the warning lives in exactly one place, and a test asserts no subclass can take it away again.
+
 ## [5.48.0] - 2026-08-12
 
 ### Added

--- a/edgar/company_reports/_base.py
+++ b/edgar/company_reports/_base.py
@@ -194,6 +194,26 @@ class CompanyReport:
         return self._parser.parse(self._filing.html())
 
     @cached_property
+    def _chunked_document(self):
+        """Build the legacy chunked document, without warning anybody.
+
+        This is what our own fallback paths read. `items` and `__getitem__` on
+        several report classes try the new parser first and drop back to the old
+        one when it finds nothing, and routing those through the public property
+        told the user their code was deprecated when the choice was ours — a
+        plain `twentyf.items` emitted a `chunked_document is deprecated` warning
+        naming an attribute the caller had never mentioned.
+
+        Subclasses override THIS to change construction (`TenQ` needs
+        `prefix_src`, `CurrentReport` a decimal-aware `chunk_fn`). The
+        deprecation lives once, on the public property below, so an override
+        cannot accidentally drop it — which is exactly what happened before:
+        `TenQ` and `CurrentReport` overrode `chunked_document` itself and
+        silently lost the warning, so their users got no notice at all.
+        """
+        return ChunkedDocument(self._filing.html())
+
+    @cached_property
     def chunked_document(self):
         """
         Get chunked document using old parser.
@@ -207,7 +227,7 @@ class CompanyReport:
             DeprecationWarning,
             stacklevel=2
         )
-        return ChunkedDocument(self._filing.html())
+        return self._chunked_document
 
     @property
     def doc(self):

--- a/edgar/company_reports/current_report.py
+++ b/edgar/company_reports/current_report.py
@@ -658,7 +658,9 @@ class CurrentReport(CompanyReport):
             return PressReleases(press_release_results)
 
     @cached_property
-    def chunked_document(self):
+    def _chunked_document(self):
+        # Construction only; the deprecation lives on the public property in
+        # CompanyReport. See the note there.
         html = self._filing.html()
         if not html:
             return None
@@ -672,7 +674,7 @@ class CurrentReport(CompanyReport):
 
     @property
     def doc(self):
-        return self.chunked_document
+        return self._chunked_document
 
     @property
     def items(self) -> List[str]:
@@ -712,8 +714,8 @@ class CurrentReport(CompanyReport):
 
         # Strategy 2: chunked parser of the primary document — backfills items the
         # new parser missed; same precision domain (excludes exhibit text).
-        if self.chunked_document:
-            chunked_items = self.chunked_document.list_items()
+        if self._chunked_document:
+            chunked_items = self._chunked_document.list_items()
             if chunked_items:
                 item_set.update(_canonical_item(item) for item in chunked_items)
 
@@ -779,9 +781,9 @@ class CurrentReport(CompanyReport):
         # Only return a hit — chunked_document returns None for an unmatched key
         # (e.g. '1.05' when it indexes by 'Item 1.05'); returning that None here
         # would short-circuit the text-based fallback below. (edgartools-83gh)
-        if self.chunked_document:
+        if self._chunked_document:
             try:
-                result = self.chunked_document[item_name]
+                result = self._chunked_document[item_name]
                 if result:
                     return result
             except (KeyError, TypeError):

--- a/edgar/company_reports/ten_k.py
+++ b/edgar/company_reports/ten_k.py
@@ -330,11 +330,11 @@ class TenK(CompanyReport):
                     items.append(key)
             if items:
                 return _canonical(items)
-            return _canonical(self.chunked_document.list_items()) if self.chunked_document else []
+            return _canonical(self._chunked_document.list_items()) if self._chunked_document else []
 
         # Fallback to old parser for backward compatibility
-        if self.chunked_document:
-            return _canonical(self.chunked_document.list_items())
+        if self._chunked_document:
+            return _canonical(self._chunked_document.list_items())
 
         return []
 
@@ -387,7 +387,10 @@ class TenK(CompanyReport):
         return None
 
     @cached_property
-    def chunked_document(self):
+    def _chunked_document(self):
+        # Construction only — the deprecation lives on the public
+        # `chunked_document` in CompanyReport. Overriding that one here is what
+        # previously cost TenK users their warning entirely.
         return ChunkedDocument(self._filing.html(), prefix_src=self._filing.base_dir)
 
     @cached_property
@@ -722,7 +725,7 @@ class TenK(CompanyReport):
             f"New parser sections available: {list(self.sections.keys()) if self.sections else 'none'}. "
             f"This fallback will be removed in v6.0."
         )
-        item_text = self.chunked_document[item_or_part]
+        item_text = self._chunked_document[item_or_part]
 
         # Clean up the text if found
         if item_text:
@@ -765,7 +768,7 @@ class TenK(CompanyReport):
             return self.id_parse_document(markdown).get(item.lower())
 
         # Try chunked_document
-        item_text = self.chunked_document.get_item_with_part(part, item, markdown=markdown)
+        item_text = self._chunked_document.get_item_with_part(part, item, markdown=markdown)
         if item_text and item_text.strip():
             return item_text
 

--- a/edgar/company_reports/ten_q.py
+++ b/edgar/company_reports/ten_q.py
@@ -281,11 +281,11 @@ class TenQ(CompanyReport):
                             items.append(f"{part}, Item {item_num}")
                         else:
                             items.append(f"Item {item_num}")
-            return items if items else (self.chunked_document.list_items() if self.chunked_document else [])
+            return items if items else (self._chunked_document.list_items() if self._chunked_document else [])
 
         # Fallback to old parser for backward compatibility
-        if self.chunked_document:
-            return self.chunked_document.list_items()
+        if self._chunked_document:
+            return self._chunked_document.list_items()
 
         return []
 
@@ -371,7 +371,7 @@ class TenQ(CompanyReport):
                         return self.sections[section_key].text()
 
         # Fallback to old chunked_document for backward compatibility
-        if self.chunked_document:
+        if self._chunked_document:
             try:
                 # Log fallback usage for Phase 1 deprecation tracking
                 log.warning(
@@ -380,7 +380,7 @@ class TenQ(CompanyReport):
                     f"New parser sections available: {list(self.sections.keys()) if self.sections else 'none'}. "
                     f"This fallback will be removed in v6.0."
                 )
-                return self.chunked_document[item_or_part]
+                return self._chunked_document[item_or_part]
             except (KeyError, TypeError):
                 pass
 
@@ -434,8 +434,8 @@ class TenQ(CompanyReport):
             return self.id_parse_document(markdown).get(part.lower(), {}).get(item.lower())
 
         # Try chunked_document
-        if self.chunked_document:
-            item_text = self.chunked_document.get_item_with_part(part, item, markdown=markdown)
+        if self._chunked_document:
+            item_text = self._chunked_document.get_item_with_part(part, item, markdown=markdown)
             if item_text and item_text.strip():
                 return item_text
 
@@ -453,7 +453,10 @@ class TenQ(CompanyReport):
         return result
 
     @cached_property
-    def chunked_document(self):
+    def _chunked_document(self):
+        # Construction only — the deprecation warning lives on the public
+        # `chunked_document` in CompanyReport. Overriding that one here is what
+        # previously cost TenQ users their warning entirely.
         return ChunkedDocument(self._filing.html(), prefix_src=self._filing.base_dir)
 
     def get_structure(self):

--- a/edgar/company_reports/twenty_f.py
+++ b/edgar/company_reports/twenty_f.py
@@ -163,8 +163,8 @@ class TwentyF(CompanyReport):
             List of item titles for backward compatibility (e.g., ['Item 5', 'Item 8'])
         """
         # For 20-F, prefer chunked_document which handles TOC format better
-        if self.chunked_document:
-            return self.chunked_document.list_items()
+        if self._chunked_document:
+            return self._chunked_document.list_items()
 
         # Fallback to new parser sections
         if self.sections and len(self.sections) > 0:
@@ -222,9 +222,9 @@ class TwentyF(CompanyReport):
                     return self.sections[friendly_key].text()
 
         # Fallback to old chunked_document for backward compatibility
-        if self.chunked_document:
+        if self._chunked_document:
             try:
-                return self.chunked_document[item_name]
+                return self._chunked_document[item_name]
             except (KeyError, TypeError):
                 pass
 

--- a/tests/issues/regression/test_chunked_document_deprecation.py
+++ b/tests/issues/regression/test_chunked_document_deprecation.py
@@ -1,0 +1,163 @@
+"""`chunked_document` warns the user, and only the user.
+
+Bead: edgartools-07lk.3 (the `edgar.files` removal).
+
+Two defects, both found by measuring rather than reading:
+
+1. **The library tripped its own deprecation.** `items` and `__getitem__` on
+   TenK, TenQ, TwentyF and CurrentReport try the new parser first and fall back
+   to the legacy `ChunkedDocument`. Those fallbacks read the *public*
+   `chunked_document`, so a plain `twentyf.items` emitted
+   "chunked_document is deprecated" — naming an attribute the caller had never
+   used, about a choice that was ours. Under `-W error::DeprecationWarning`,
+   which plenty of suites run, that is not a warning but an exception.
+
+2. **Two classes had silently dropped the warning.** TenQ and CurrentReport
+   overrode `chunked_document` itself to change construction, and an override
+   that replaces the property replaces the `warnings.warn` inside it. Their
+   users got no notice at all that the attribute disappears in 6.0 — the exact
+   population the deprecation exists to reach.
+
+The fix separates the two jobs: `_chunked_document` constructs (subclasses
+override this) and `chunked_document` warns then delegates (nobody overrides
+this). These tests pin both halves, because the failure mode of each is silence.
+"""
+import warnings
+
+import pytest
+from unittest.mock import MagicMock
+
+from edgar.company_reports import FortyF, TenK, TenQ, TwentyF
+from edgar.company_reports.current_report import CurrentReport
+
+HTML = "<html><body><p>Item 5. Operating Review</p><p>body text</p></body></html>"
+
+
+def _filing(form):
+    filing = MagicMock()
+    filing.form = form
+    filing.html.return_value = HTML
+    filing.accession_number = "0000000000-00-000000"
+    filing.accession_no = "0000000000-00-000000"
+    filing.base_dir = None
+    return filing
+
+
+def _report(cls, form):
+    report = cls.__new__(cls)
+    report._filing = _filing(form)
+    report._parser = None
+    report.__dict__["_cross_reference_index"] = None
+    return report
+
+
+REPORTS = [
+    pytest.param(TenK, "10-K", id="TenK"),
+    pytest.param(TenQ, "10-Q", id="TenQ"),
+    pytest.param(TwentyF, "20-F", id="TwentyF"),
+    pytest.param(CurrentReport, "8-K", id="CurrentReport"),
+    # Found by sweeping CompanyReport.__subclasses__() rather than by grep —
+    # the grep that built this list missed TenK's own override, so the class
+    # list here is generated from the type system, not from reading files.
+    pytest.param(FortyF, "40-F", id="FortyF"),
+]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cls,form", REPORTS)
+def test_the_public_name_still_warns(cls, form):
+    """Every class, not just the two that inherited it.
+
+    A deprecation only some subclasses emit is worse than none: it reads as
+    "this call is fine" to exactly the users whose class dropped it.
+    """
+    report = _report(cls, form)
+    with pytest.warns(DeprecationWarning, match="chunked_document is deprecated"):
+        report.chunked_document
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("cls,form", REPORTS)
+def test_the_private_accessor_is_silent(cls, form):
+    """What our own fallbacks read must not warn."""
+    report = _report(cls, form)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        report._chunked_document
+    offenders = [w for w in caught
+                 if "chunked_document is deprecated" in str(w.message)]
+    assert not offenders, (
+        "the internal accessor warned; fallback paths would blame the user for "
+        "our choice"
+    )
+
+
+@pytest.mark.fast
+def test_a_plain_items_call_does_not_warn_about_an_attribute_nobody_used():
+    """The bug, stated as the user experiences it.
+
+    20-F is the case that always reaches the legacy parser — TwentyF prefers
+    `chunked_document` because the pattern-based extractor does not handle the
+    TOC format well — so it is the one where the self-inflicted warning fired on
+    every call rather than only on a fallback.
+    """
+    twentyf = _report(TwentyF, "20-F")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            twentyf.items
+        except Exception:
+            # The parse may fail on this stub; the warning is what is under test,
+            # and it would have been emitted before any failure.
+            pass
+    offenders = [w for w in caught
+                 if "chunked_document is deprecated" in str(w.message)]
+    assert not offenders, (
+        f"`.items` emitted {len(offenders)} deprecation warning(s) naming an "
+        f"attribute the caller never touched"
+    )
+
+
+@pytest.mark.fast
+def test_no_subclass_overrides_the_warning_away():
+    """The guard, generated from the type system rather than from a grep.
+
+    Three classes independently overrode `chunked_document` to change how it was
+    built and took the `warnings.warn` with them — TenK, TenQ and CurrentReport.
+    Two of those were found by reading; the third was found only when a
+    parametrized test failed, because the grep that built the list missed it.
+
+    So this asserts the shape instead of the instances: construction belongs on
+    `_chunked_document`, and any subclass that redefines the public name has
+    almost certainly deleted the deprecation without meaning to.
+    """
+    import importlib
+    import pkgutil
+
+    import edgar.company_reports as cr
+    from edgar.company_reports._base import CompanyReport
+
+    for module in pkgutil.iter_modules(cr.__path__):
+        importlib.import_module(f"edgar.company_reports.{module.name}")
+
+    offenders = [cls.__name__ for cls in CompanyReport.__subclasses__()
+                 if "chunked_document" in cls.__dict__]
+    assert not offenders, (
+        f"{offenders} override the public `chunked_document`, which replaces the "
+        f"property containing the deprecation warning. Override "
+        f"`_chunked_document` instead — that is the construction hook, and the "
+        f"warning then stays in exactly one place."
+    )
+
+
+@pytest.mark.fast
+def test_the_public_property_returns_the_same_object_the_internals_use():
+    """The split must not fork the two paths onto different documents.
+
+    If it did, a user debugging via `chunked_document` would be inspecting
+    something other than what produced their result.
+    """
+    tenk = _report(TenK, "10-K")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert tenk.chunked_document is tenk._chunked_document

--- a/tests/issues/regression/test_exceptions_none_flips.py
+++ b/tests/issues/regression/test_exceptions_none_flips.py
@@ -84,7 +84,10 @@ class _Report(TenK):
         return self._items
 
     @property
-    def chunked_document(self):
+    def _chunked_document(self):
+        # The private accessor: it is what TenK's fallback path reads. Stubbing
+        # the public `chunked_document` would leave the real constructor in
+        # play, which needs a filing this fake does not have.
         class _Empty:
             def __getitem__(self, key):
                 return None

--- a/tests/issues/regression/test_issue_710_combined_items_heading.py
+++ b/tests/issues/regression/test_issue_710_combined_items_heading.py
@@ -45,7 +45,11 @@ class TestCombinedItemsHeading:
         # Use patch.object on the instance to avoid polluting the class
         self._patches = [
             patch.object(type(tenk), 'document', new_callable=lambda: property(lambda self: fake_doc)),
-            patch.object(type(tenk), 'chunked_document', new_callable=lambda: property(lambda self: {})),
+            # `_chunked_document`, not the public name: the fallback path reads
+            # the private accessor, so patching the public property here would
+            # be a no-op that still passed — the patch has to sit where the code
+            # actually looks.
+            patch.object(type(tenk), '_chunked_document', new_callable=lambda: property(lambda self: {})),
         ]
         for p in self._patches:
             p.start()

--- a/tests/issues/regression/test_issue_821_gs_part_misclassification.py
+++ b/tests/issues/regression/test_issue_821_gs_part_misclassification.py
@@ -33,8 +33,11 @@ def make_tenk(monkeypatch):
 
     def _factory(sections_data: dict) -> TenK:
         tenk = TenK.__new__(TenK)
-        tenk.chunked_document = MagicMock()
-        tenk.chunked_document.__getitem__ = MagicMock(return_value=None)
+        # The private accessor, because that is what TenK's own fallback path
+        # reads. Mocking the public `chunked_document` would leave the real one
+        # in play here and quietly stop mocking anything.
+        tenk._chunked_document = MagicMock()
+        tenk._chunked_document.__getitem__ = MagicMock(return_value=None)
         tenk._cross_reference_index = None
         tenk._filing = MagicMock()
         tenk._filing.accession_number = "0000000000-00-000000"


### PR DESCRIPTION
`chunked_document` has been deprecated since 5.0. Measuring it before starting the `edgar.files` removal turned up **two defects pointing in opposite directions**.

## It fired when nobody asked for it

`TenK`, `TenQ`, `TwentyF` and `CurrentReport` try the new parser first and drop back to the legacy `ChunkedDocument`. Those fallbacks read the **public** deprecated property, so:

```python
>>> twentyf.items          # never mentions chunked_document
DeprecationWarning: chunked_document is deprecated and will be removed in v6.0.
```

The warning named an attribute the caller had never touched, about a choice that was ours. 20-F got it on **every** call, because `TwentyF` prefers the legacy path deliberately — the pattern-based extractor doesn't handle the TOC format well.

For anyone running `-W error::DeprecationWarning`, that wasn't a warning but an exception raised from inside our own fallback.

## And it didn't fire when somebody did

`TenK`, `TenQ` and `CurrentReport` each overrode `chunked_document` to change how it was built — and an override that replaces the property also replaces the `warnings.warn` inside it. **Three of the five report classes had silently dropped the deprecation**, so their users got no notice at all that the attribute disappears in 6.0. That's the exact population a deprecation exists to reach.

## The fix

Separate the two jobs the property was doing:

- `_chunked_document` **constructs** — subclasses override this
- `chunked_document` **warns and delegates** — nobody overrides this

| | Before | After |
|---|---|---|
| `twentyf.items` | 1 spurious warning | **0** |
| `twentyf.chunked_document` | 1 warning | **1** (asked for, so told) |
| Classes warning on public access | 2 of 5 | **5 of 5** |

## Two things worth knowing for the work that follows

**The `TenK` override was not found by grep.** It surfaced only when a parametrized test failed. That's why the guard test enumerates `CompanyReport.__subclasses__()` rather than trusting a file search — and that sweep also turned up `FortyF`, a fifth affected class no list had named. Any future audit of this cluster should generate its list from the type system.

**The same trap sits in the tests.** Three stubs mocked the public property; once the internals moved, they were mocking something nothing reads. Two failed loudly — but `test_issue_710`'s patch quietly became a no-op **and kept passing**. All three now target `_chunked_document`, and any future test double must too.

## Deliberately left alone

`CurrentReport.doc` returns the chunked document and now routes through the silent accessor, so an 8-K user calling `.doc` gets an object that disappears in 6.0 with no notice. What `.doc` should return in 6.0 is an API decision, not a side effect of this fix.

## Verification

- Fast suite green in **both** modes: **4,963 passed**, 4 skipped, 1 xfailed (from 4,950)
- 13 new tests in `test_chunked_document_deprecation.py`, including the structural guard
- Both directions pinned: internal paths silent, public access warns on every class, and the public property returns the same object the internals use

## Context

This came out of the `07lk.3` re-measurement, which also found that the migration is smaller and differently shaped than `3dp` describes — `.chunks` is used nowhere outside `edgar/files`, the real surface is three methods, and the new parser is already primary everywhere except 20-F. This PR is item 1 of that work list and stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)