### PR TITLE
fix(verification): wfc/10k was never broken — the parity harness could not read it

### DIFF
--- a/tests/fixtures/parser_corpus/parity_benchmark.py
+++ b/tests/fixtures/parser_corpus/parity_benchmark.py
@@ -86,6 +86,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 warnings.filterwarnings("ignore")
 
 from edgar.documents.config import ParserConfig  # noqa: E402
+from edgar.documents.form_schema import get_form_schema  # noqa: E402
 from edgar.documents.parser import HTMLParser  # noqa: E402
 from edgar.files.htmltools import ChunkedDocument  # noqa: E402
 
@@ -138,17 +139,47 @@ def normalise_new(section_name: str, form: str) -> Optional[str]:
     digits (``item_801`` is Item 8.01); we return the major number only, because
     that is the granularity legacy can also express. ``subitem_of`` below
     recovers the precision for the separate precision report.
+
+    TWO KEY VOCABULARIES, AND MISSING ONE OF THEM COSTS REAL FILINGS. The parser
+    names 10-K sections structurally (``part_ii_item_7``) or by friendly name
+    (``mda``) depending on which detection strategy fired, and both are live on
+    this corpus — ten friendly names appear across the 10-K fixtures. This
+    function originally matched the structural form only, and silently returned
+    None for the rest, which scored a *naming convention* as a parser miss.
+
+    It cost `wfc/10k` ten items: its sections come back as ``business``,
+    ``risk_factors``, ``mda`` and so on, all of them correct and all of them
+    reachable through ``TenK.items`` and ``tenk['Item 1']``. The benchmark
+    reported a near-total failure on a filing the parser handles perfectly, and
+    that reading reached ``BASELINE_GAPS`` and the ratchet's prose, where it sat
+    for a week as "a live bug on a modern large-bank filing".
+
+    The friendly names are resolved through ``FormSchema.item_for_section_key``
+    rather than a second table here, so the benchmark and the library cannot
+    drift about what a section key means. The schema does not know the
+    structural spellings, so the two are complements: the regex handles
+    ``item_1``/``part_i_item_1``, the schema handles ``mda``, and together they
+    cover every key the corpus produces. What neither resolves is genuinely not
+    an item — ``signatures``, ``part_iv_signatures``, ``part_i``.
     """
     if section_name.lower() in NON_ITEM_SECTIONS:
         return None
+
     m = _NEW_ITEM_RE.match(section_name)
-    if not m:
+    if m:
+        digits, suffix = m.group(1), m.group(2)
+        if form == "8-K":
+            # 8-K majors are single-digit (1-9), so a 3-digit group is major+minor.
+            return digits[0] if len(digits) == 3 else digits
+        return f"{digits}{suffix}".upper()
+
+    # Friendly names ('mda', 'risk_factors'), via the library's own mapping.
+    item = get_form_schema(form).item_for_section_key(section_name)
+    if not item:
         return None
-    digits, suffix = m.group(1), m.group(2)
     if form == "8-K":
-        # 8-K majors are single-digit (1-9), so a 3-digit group is major+minor.
-        return digits[0] if len(digits) == 3 else digits
-    return f"{digits}{suffix}".upper()
+        return item.split(".")[0]
+    return item.upper()
 
 
 def subitem_of(section_name: str, form: str) -> Optional[str]:

--- a/tests/test_parity_benchmark_normalisation.py
+++ b/tests/test_parity_benchmark_normalisation.py
@@ -1,0 +1,144 @@
+"""The parity benchmark must not score a naming convention as a parser miss.
+
+``parity_benchmark.normalise_new`` maps a new-parser section key to a canonical
+item number so the two parsers can be compared. It originally matched only the
+structural key spelling (``part_ii_item_7``) and returned None for everything
+else — including the friendly names (``mda``, ``risk_factors``) the same parser
+emits when a different detection strategy fires.
+
+Both spellings are live on the corpus, so the benchmark under-counted the new
+parser on every filing named the friendly way. On ``wfc/10k`` that reported ten
+missing items — Items 1, 1A, 7, 8 among them — for a filing where
+``TenK.items`` lists all 23 and ``tenk['Item 1']`` returns 46,618 characters.
+The false reading reached ``BASELINE_GAPS`` and sat there for a week described
+as "a live bug on a modern large-bank filing".
+
+These tests are cheap and the harness is not otherwise unit-tested; the ratchet
+exercises it end-to-end but takes ~150s and lives in the slow lane, so a
+normalisation bug could not fail fast. A measurement harness that is wrong is
+worse than no harness, because its output is trusted and acted on.
+"""
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "fixtures" / "parser_corpus"))
+import parity_benchmark  # noqa: E402
+
+normalise_new = parity_benchmark.normalise_new
+normalise_legacy = parity_benchmark.normalise_legacy
+
+
+@pytest.mark.fast
+class TestBothKeyVocabulariesResolve:
+    """The parser names 10-K sections two ways; the benchmark must know both."""
+
+    @pytest.mark.parametrize("key,expected", [
+        # Friendly names — the ones that used to normalise to None.
+        ("business", "1"),
+        ("risk_factors", "1A"),
+        ("unresolved_staff_comments", "1B"),
+        ("cybersecurity", "1C"),
+        ("properties", "2"),
+        ("legal_proceedings", "3"),
+        ("mda", "7"),
+        ("market_risk", "7A"),
+        ("financial_statements", "8"),
+        ("controls_procedures", "9A"),
+        # Structural names — what the regex always handled.
+        ("part_i_item_1", "1"),
+        ("part_ii_item_7a", "7A"),
+        ("part_iv_item_15", "15"),
+        ("item_1", "1"),
+    ])
+    def test_10k_keys(self, key, expected):
+        assert normalise_new(key, "10-K") == expected
+
+    def test_the_two_spellings_of_one_item_agree(self):
+        """The whole point: same item, two keys, one answer."""
+        assert normalise_new("mda", "10-K") == normalise_new("part_ii_item_7", "10-K") == "7"
+
+
+@pytest.mark.fast
+class TestNonItemsStayOut:
+    """Legacy has no equivalent concept, so these must not enter the comparison."""
+
+    @pytest.mark.parametrize("key", [
+        "signatures", "Signatures", "part_iv_signatures", "part_ii_signatures",
+        "cover", "toc", "exhibits", "part_i", "part_ii",
+    ])
+    def test_not_an_item(self, key):
+        assert normalise_new(key, "10-K") is None
+        assert normalise_new(key, "20-F") is None
+
+
+@pytest.mark.fast
+class TestEightKGranularity:
+    """8-K is compared at the granularity legacy can also express.
+
+    Legacy cannot say "Item 8.01" — it reports 'Item 8'. Comparing the new
+    parser's precision against that would score a legacy *limitation* as a new
+    parser miss, which is the same class of error as the friendly-name bug.
+    """
+
+    def test_subitems_compare_at_the_major_number(self):
+        assert normalise_new("item_801", "8-K") == "8"
+        assert normalise_new("item_502", "8-K") == "5"
+        assert normalise_legacy("Item 8", "8-K") == "8"
+        assert normalise_legacy("Item 8.01", "8-K") == "8"
+
+    def test_the_precision_is_still_recoverable(self):
+        assert parity_benchmark.subitem_of("item_801", "8-K") == "8.01"
+        assert parity_benchmark.subitem_of("part_ii_item_7", "10-K") is None
+
+
+@pytest.mark.fast
+class TestTheCorpusHasNoUnresolvedKeys:
+    """Every key the corpus produces is either an item or knowably not one.
+
+    This is the check that would have caught the original bug. It reads the
+    committed golden key list rather than re-parsing 115 fixtures, so it belongs
+    in the fast lane; the ratchet covers the live parse.
+    """
+
+    # Section keys observed across the whole parity corpus (2026-08-14), with
+    # the ones that are legitimately not items listed separately. Regenerate by
+    # collecting doc.sections keys over parity_benchmark.build_corpus().
+    OBSERVED_NON_ITEMS = {
+        "10-K": {"Signatures", "part_iv_signatures"},
+        "10-Q": {"part_ii_signatures"},
+        "20-F": {"part_i", "part_ii", "part_iii", "signatures"},
+        "8-K": {"signatures"},
+    }
+
+    OBSERVED_ITEM_KEYS = {
+        "10-K": {"business", "risk_factors", "unresolved_staff_comments",
+                 "cybersecurity", "properties", "legal_proceedings", "mda",
+                 "market_risk", "financial_statements", "controls_procedures",
+                 "part_i_item_4", "part_ii_item_5", "part_ii_item_9b",
+                 "part_iii_item_10", "part_iv_item_15", "item_1", "item_7"},
+        "10-Q": {"part_i_item_1", "part_ii_item_1a", "part_ii_item_6"},
+        "20-F": {"item_1", "item_4a", "item_16g", "part_i_item_1",
+                 "part_ii_item_16a", "part_iii_item_19", "Item 1"},
+        "8-K": {"item_801", "item_502", "item_901"},
+    }
+
+    @pytest.mark.parametrize("form", ["10-K", "10-Q", "20-F", "8-K"])
+    def test_every_item_key_resolves(self, form):
+        unresolved = sorted(
+            key for key in self.OBSERVED_ITEM_KEYS[form]
+            if normalise_new(key, form) is None
+        )
+        assert not unresolved, (
+            f"{form}: these section keys are items the parser emits, and the "
+            f"benchmark scores them as misses: {unresolved}"
+        )
+
+    @pytest.mark.parametrize("form", ["10-K", "10-Q", "20-F", "8-K"])
+    def test_every_non_item_key_is_excluded(self, form):
+        leaked = sorted(
+            key for key in self.OBSERVED_NON_ITEMS[form]
+            if normalise_new(key, form) is not None
+        )
+        assert not leaked, f"{form}: non-item sections entering the comparison: {leaked}"

--- a/tests/test_section_parity_ratchet.py
+++ b/tests/test_section_parity_ratchet.py
@@ -13,8 +13,12 @@ WHAT THIS GUARDS. ``BASELINE_GAPS`` is every (form, filing, item) the legacy
 parser finds and the new one misses, as measured on 2026-08-05. The assertion is
 a **subset** check, mirroring the anomaly census in
 ``test_section_boundary_corpus.py``: the live gap set may shrink freely, and any
-*new* gap fails. So a fix that closes ``wfc/10k`` needs no change here, while a
+*new* gap fails. So a fix that closes an entry needs no change here, while a
 change that breaks a currently-clean filing turns this red.
+
+That asymmetry is why ``wfc/10k`` is no longer listed at all: it now measures
+clean, so any gap appearing on it is a *new* gap and fails. Removing a fixture
+from ``BASELINE_GAPS`` tightens this guard rather than loosening it.
 
 TWO CORPORA, AND ONLY ONE OF THEM REACHES CI. ``tests/fixtures/html`` is tracked.
 ``tests/fixtures/text_boundary_corpus`` — which holds every 8-K and 20-F fixture,
@@ -56,13 +60,28 @@ pytestmark = pytest.mark.slow
 #      in 2023) on bac/jpm/tsla. Both look like detection-pattern holes rather
 #      than per-filing damage, so each is likely one fix for several filings.
 #   2. Near-total failures, where the new parser returns almost nothing on a
-#      filing legacy handles: wfc/10k (10 core items including 1, 1A, 7, 8 —
-#      a live bug on a modern large-bank filing) and three era fixtures. The
-#      20-F outlier 0001144204-10-017467 is EDGARizer-generated filer-agent
-#      HTML: 12,880 <font> tags and zero <p>, the class edgartools-mpjh tracks.
-#      It left this group on 2026-08-13 (22 gaps -> 8) when dt1f Defect 1 was
-#      fixed; the eight that remain are an ordinary gap, not a collapse.
+#      filing legacy handles: two era fixtures. The 20-F outlier
+#      0001144204-10-017467 is EDGARizer-generated filer-agent HTML: 12,880
+#      <font> tags and zero <p>, the class edgartools-mpjh tracks. It left this
+#      group on 2026-08-13 (22 gaps -> 8) when dt1f Defect 1 was fixed; the
+#      eight that remain are an ordinary gap, not a collapse.
 #   3. Singletons, most of them pre-2015 HTML.
+#
+# wfc/10k WAS IN GROUP 2 AND WAS NEVER BROKEN. Removed 2026-08-14 with its
+# fixture unchanged and the parser untouched: all ten "missing" items were a
+# measurement artefact. The benchmark's normalise_new() matched only the
+# structural key spelling (part_ii_item_7) and returned None for the friendly
+# one (mda), so a filing whose sections are named the friendly way scored as a
+# near-total miss. TenK.items lists all 23 items on that filing and
+# tenk['Item 1'] returns 46,618 characters of Wells Fargo's business section —
+# it was correct the whole time.
+#
+# The lesson is about this file as much as that one: a gap recorded here is a
+# claim about the parser, and it sat for a week as "a live bug on a modern
+# large-bank filing" without anyone asking the library the same question the
+# harness was asking. Before triaging any remaining entry, check what a user
+# actually gets — report.items and report['Item N'] — not only what the
+# benchmark reports.
 #
 # Entries keyed on an accession number come from the untracked era corpus and
 # are unmeasurable in CI; the ticker-keyed ones are tracked and always run.
@@ -80,20 +99,19 @@ BASELINE_GAPS = {
     ("8-K", "0001104659-03-004925"): ["9"],
     ("10-K", "0000927356-01-000369"): ["7"],
     ("10-K", "0000950153-99-001234"): ["1", "10", "11", "12", "13", "14", "2",
-                                       "3", "4", "5", "6", "7", "7A", "8", "9"],
+                                       "3", "4", "5", "6", "7", "7A", "9"],
     ("10-K", "0001193125-10-073212"): ["9A"],
-    ("10-K", "0001193125-21-101193"): ["1", "10", "11", "1B", "5"],
+    ("10-K", "0001193125-21-101193"): ["1", "10", "11", "5"],
     ("10-K", "0001193125-21-101902"): ["16"],
     ("10-K", "0001376474-16-000635"): ["1", "10", "11", "12", "13", "14", "15",
                                        "1A", "1B", "2", "3", "4", "5", "6", "7",
-                                       "7A", "8", "9", "9A", "9B"],
+                                       "7A", "9", "9A", "9B"],
     ("10-K", "axp/10k"): ["16"],
     ("10-K", "bac/10k"): ["1C"],
     ("10-K", "cvx/10k"): ["16"],
     ("10-K", "jnj/10k"): ["16"],
     ("10-K", "jpm/10k"): ["1C"],
     ("10-K", "tsla/10k"): ["1C"],
-    ("10-K", "wfc/10k"): ["1", "1A", "1B", "1C", "2", "3", "7", "7A", "8", "9A"],
     ("10-Q", "0001193125-21-082408"): ["1"],
     ("10-Q", "gs/10q"): ["5", "6"],
     ("20-F", "0000928385-01-500187"): ["7"],


### PR DESCRIPTION
I set out to fix `wfc/10k`, the sharpest entry in `BASELINE_GAPS` — ten core items missing including Items 1, 1A, 7 and 8, recorded there as *"a live bug on a modern large-bank filing"*. There is no bug. The harness was misreading a filing the parser handles perfectly.

## What the library actually returns

```python
TenK.items       # all 23 items, Item 1 through Item 16
tenk['Item 1']   # 46,618 chars of Wells Fargo's business section
tenk['Item 1A']  # the risk-factors incorporation-by-reference
tenk.mda         # Item 7, correct
```

All ten "missing" items are present and reachable. Several are short because Wells Fargo genuinely incorporates them by reference from the Annual Report — that's the filing being correct, and the parser reproducing it faithfully.

## The actual defect

`wfc/10k` is Workiva-generated with no navigable TOC, so it falls through to pattern detection. That strategy names 10-K sections by **friendly name** (`mda`, `risk_factors`, `business`) while the TOC path names them **structurally** (`part_ii_item_7`). Both spellings are live across the corpus.

`normalise_new()` matched the structural spelling only:

```python
_NEW_ITEM_RE = re.compile(r"^(?:part_[ivx]+_)?item[_\s]*(\d+)([a-z]?)$")
```

and returned `None` for everything else. A naming convention scored as a parser miss.

Friendly names now resolve through `FormSchema.item_for_section_key` rather than a second table in the harness, so the benchmark and the library cannot drift about what a section key means. The two lookups are complements — the schema doesn't know `part_i_item_1`, the regex doesn't know `mda`. I collected every section key the corpus emits to confirm coverage:

| form | resolved by regex | by schema | by neither |
|---|---|---|---|
| 10-K | 28 | 10 | 2 (`Signatures`, `part_iv_signatures`) |
| 20-F | 60 | 0 | 4 (`part_i`–`part_iii`, `signatures`) |
| 10-Q | 13 | 0 | 1 (`part_ii_signatures`) |
| 8-K | 5 | 0 | 1 (`signatures`) |

Everything unresolved is genuinely not an item.

## Effect — measurement only, no parser code touched

| form | `legacy_only` |
|---|---|
| **10-K** | **59 → 46** |
| 20-F | 12 (unchanged) |
| 10-Q | 3 (unchanged) |
| 8-K | 1 (unchanged) |

**Zero gaps appeared.** 10-K coverage delta moves −1.0% → **+0.1%** — the new parser is now measured as marginally ahead of the one we plan to delete.

Per filing: `wfc/10k` 10 → 0 (leaves `BASELINE_GAPS`), `0000950153-99-001234` −1, `0001376474-16-000635` −1, `0001193125-21-101193` −1.

Removing a fixture from `BASELINE_GAPS` **tightens** the ratchet — a clean filing's next gap is a *new* gap, which fails. The docstring now says so, since it previously used `wfc/10k` as its example of the opposite.

## Tests

`tests/test_parity_benchmark_normalisation.py`, 34 tests, fast lane. **12 fail against the old normaliser.**

The harness had no unit tests; the ratchet exercised it end-to-end but takes ~150s and lives in the slow lane, which CI skips. So a normalisation bug could not fail fast, and this one didn't — it produced a plausible-looking work item that survived a week of being read.

- Fast lane: **5020 passed** (was 4986)
- Parity ratchet: **6 passed**, including `test_closed_gaps_are_recorded`
- `test_parser_corpus` + boundary corpus + schema parity: 32 passed
- Ruff clean on the new file; the 43 in `parity_benchmark.py` pre-date this branch

## The part worth keeping

A gap recorded in `BASELINE_GAPS` is a claim about the parser, and this one was never checked against what a user gets. The ratchet's prose now says to verify `report.items` and `report['Item N']` before triaging any remaining entry — the check that would have taken two minutes and saved the week.

Three of the remaining 46 10-K gaps come from the same two fixtures that shed items here, so they're worth re-examining on the same basis before anyone treats them as parser work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
