### PR TITLE
docs(changelog): the BDC entry documents the next release, not a published one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BDC investment parsing now recognizes structured Schedule of Investments labels and normalizes trailing numeric XBRL disambiguators out of `investment_type`.** The original label remains available in `identifier`, so separate tranches remain distinguishable while grouping by investment type is stable. Fourteen more BDC tickers parse their investment types, and two label shapes that previously yielded a company name of `'Specialty finance'` or `'Class AA'` now return the issuer. (GH #990)
+
 ### Fixed
 
 - **`Item 1C` (Cybersecurity) and `Item 16` were missing from filings whose table of contents omitted them.** A TOC is something the filer wrote, not a manifest, and items go missing from it routinely — Part III when it is incorporated by reference from the proxy, Item 16 because it is optional and usually empty, Item 1C because it was new in 2023 and templates lagged. The parser already handled this by augmenting a successful TOC result with items found in the body, but the check deciding whether that pass was worth running asked only whether Part III was complete. Part III is complete on nearly every filing, so the pass was skipped nearly always, and the items a TOC actually omits were the ones nobody got: `TenK.items` on Bank of America, JPMorgan and Tesla listed no Item 1C, and American Express, Chevron and Johnson & Johnson no Item 16, on filings where the parser had already found them and thrown the result away. Item 1C has been mandatory since December 2023, so this was most modern 10-Ks rather than a corner case. The check now asks whether the TOC named every item the form defines. Sections are also merged by item rather than by section key, so the same item cannot arrive twice under the two naming conventions the detectors use (`part_ii_item_7` and `mda` are both Item 7). Across the parity corpus this closes seven 10-K filings and one 10-Q, with no filing losing an item and no measurable change in parse time.
@@ -102,8 +106,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.46.0] - 2026-08-07
 
 ### Changed
-
-- **BDC investment parsing now recognizes structured Schedule of Investments labels and normalizes trailing numeric XBRL disambiguators out of `investment_type`.** The original label remains available in `identifier`, so separate tranches remain distinguishable while grouping by investment type is stable.
 
 - **On a multi-filer filing, `Filing.cik` and `Filing.company` now name the issuer rather than whichever filer the quarterly index listed first.** Accession lookups go through EDGAR full-text search before falling back to the quarterly index, and the two order a filing's filers differently. `find("0001918704-25-005439")` was `(70858, 'BANK OF AMERICA CORP /DE/')` and is now `(1682472, 'BofA Finance LLC')`. `all_ciks` and `all_entities` still return every filer; single-filer filings are unaffected.
 


### PR DESCRIPTION
#990 branched from `2df53a2c` on 2026-08-07, when the entries now dated **5.46.0** were still under `[Unreleased]`. It added its own entry to that block, and eight days later the squash merge applied the hunk by context — into a section that had since been released.

Two consequences, both wrong in opposite directions:

- **5.46.0's published changelog claims a feature it does not contain.** That release went out on 2026-08-07; the BDC parsing work merged on 2026-08-15.
- **The next release would ship the BDC work undocumented**, because `[Unreleased]` had no entry for it at all.

Moved to `[Unreleased]` under a `### Changed` heading. I extended the text with the two label-shape fixes and the ticker count, since those are what a reader upgrading actually needs to know, and added the `(GH #990)` reference. 5.46.0 keeps its other 22 entries unchanged, and the entry appears exactly once in the file.

Found while checking whether `[Unreleased]` was ready to be cut as 5.49.0 — it wasn't.

**Worth knowing for any long-lived branch:** a CHANGELOG hunk written against `[Unreleased]` does not follow that heading when a release is cut underneath it. Git matches context lines, and the context is the neighbouring entries, which move into the dated section with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)