### PR TITLE
chore(release): 5.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BDC investment parsing now recognizes structured Schedule of Investments labels and normalizes trailing numeric XBRL disambiguators out of `investment_type`.** The original label remains available in `identifier`, so separate tranches remain distinguishable while grouping by investment type is stable. Fourteen more BDC tickers parse their investment types, and two label shapes that previously yielded a company name of `'Specialty finance'` or `'Class AA'` now return the issuer. (GH #990)
+
 ### Fixed
 
 - **`Item 1C` (Cybersecurity) and `Item 16` were missing from filings whose table of contents omitted them.** A TOC is something the filer wrote, not a manifest, and items go missing from it routinely — Part III when it is incorporated by reference from the proxy, Item 16 because it is optional and usually empty, Item 1C because it was new in 2023 and templates lagged. The parser already handled this by augmenting a successful TOC result with items found in the body, but the check deciding whether that pass was worth running asked only whether Part III was complete. Part III is complete on nearly every filing, so the pass was skipped nearly always, and the items a TOC actually omits were the ones nobody got: `TenK.items` on Bank of America, JPMorgan and Tesla listed no Item 1C, and American Express, Chevron and Johnson & Johnson no Item 16, on filings where the parser had already found them and thrown the result away. Item 1C has been mandatory since December 2023, so this was most modern 10-Ks rather than a corner case. The check now asks whether the TOC named every item the form defines. Sections are also merged by item rather than by section key, so the same item cannot arrive twice under the two naming conventions the detectors use (`part_ii_item_7` and `mda` are both Item 7). Across the parity corpus this closes seven 10-K filings and one 10-Q, with no filing losing an item and no measurable change in parse time.
@@ -102,8 +106,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.46.0] - 2026-08-07
 
 ### Changed
-
-- **BDC investment parsing now recognizes structured Schedule of Investments labels and normalizes trailing numeric XBRL disambiguators out of `investment_type`.** The original label remains available in `identifier`, so separate tranches remain distinguishable while grouping by investment type is stable.
 
 - **On a multi-filer filing, `Filing.cik` and `Filing.company` now name the issuer rather than whichever filer the quarterly index listed first.** Accession lookups go through EDGAR full-text search before falling back to the quarterly index, and the two order a filing's filers differently. `find("0001918704-25-005439")` was `(70858, 'BANK OF AMERICA CORP /DE/')` and is now `(1682472, 'BofA Finance LLC')`. `all_ciks` and `all_entities` still return every filer; single-filer filings are unaffected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.49.0] - 2026-08-15
+
 ### Changed
 
 - **BDC investment parsing now recognizes structured Schedule of Investments labels and normalizes trailing numeric XBRL disambiguators out of `investment_type`.** The original label remains available in `identifier`, so separate tranches remain distinguishable while grouping by investment type is stable. Fourteen more BDC tickers parse their investment types, and two label shapes that previously yielded a company name of `'Specialty finance'` or `'Class AA'` now return the issuer. (GH #990)

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.48.0'
+__version__ = '5.49.0'


### PR DESCRIPTION
Seven entries — one Changed, six Fixed. Version `5.48.0` → `5.49.0` (minor: user-visible behaviour changes).

## What users get

**Section extraction is the headline, and the change is large.** Across the parity corpus the new parser moved from level with the deprecated `ChunkedDocument` to ahead of it on 10-K:

| form | legacy-only items, before → after | coverage vs legacy |
|---|---|---|
| 10-K | 46 → 7 | +0.1% → **+3.4%** |
| 10-Q | 3 → 2 | −0.5% → +0.0% |

- **Colon-separated item headers.** A 10-K written `Item 1:  Business` returned *one* section where the legacy parser found fifteen — the vocabulary accepted a period or nothing, and a filer picks one separator for the whole document, so all 23 item patterns failed together. `TenK.items` was `['Item 8']` on real filings.
- **Item 1C and Item 16 on filings whose TOC omits them.** Bank of America, JPMorgan and Tesla listed no Item 1C; American Express, Chevron and Johnson & Johnson no Item 16 — on filings where the parser had already found them and discarded the result. Item 1C has been mandatory since December 2023.
- **20-F**, `TwentyF.items`, and two deprecation-warning defects round out the Fixed section.
- **BDC investment parsing** (Changed) — 14 more tickers, plus two label shapes that returned an industry or a share class where the company name belonged.

## Also folded in

#990's changelog entry had landed under `## [5.46.0] - 2026-08-07`, a release published eight days before that PR merged: its branch predated the release, so the squash merge matched the hunk by context into a section that had since been dated. So 5.46.0 claimed a feature it does not contain, and this release would have shipped the BDC work undocumented. Moved to the 5.49.0 section here, which supersedes #1044.

## Fold checks (per the runbook)

```
[Unreleased]        empty
[5.49.0] bullets    7   (### Changed 1, ### Fixed 6)
stranded bullets    none
[5.48.0]            10 bullets, unchanged
edgar/__about__.py  5.49.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)