### PR TITLE
fix(sgml): classify a document before decoding it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,9 @@ agent_eval_results/
 # Backup this script writes before overwriting the shipped mapping. Anchored and
 # suffixed so it cannot match ct.pq itself — see the hatchling note above.
 /edgar/reference/data/*.bak
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -353,19 +353,29 @@ class Attachment:
             raise ValueError('sequence_number must be digits or an empty string')
         return v
 
+    @property
+    def normalized_extension(self) -> str:
+        """The extension lowercased, for classification.
+
+        EDGAR filenames carry the filer's own casing, so the same document type arrives as
+        ".pdf", ".PDF" or ".Pdf" depending on who filed it. Every predicate below classifies
+        on this rather than on ``extension`` so that casing cannot decide the answer.
+        """
+        return self.extension.lower()
+
     def is_text(self) -> bool:
         """Is this a text document"""
-        return self.extension in text_extensions
+        return self.normalized_extension in text_extensions
 
     def is_xml(self):
-        return self.extension.lower() in [".xsd", ".xml", ".xbrl"]
+        return self.normalized_extension in [".xsd", ".xml", ".xbrl"]
 
     def is_html(self):
-        return self.extension.lower() in [".htm", ".html"]
+        return self.normalized_extension in [".htm", ".html"]
 
     def is_binary(self) -> bool:
         """Is this a binary document"""
-        return self.extension in binary_extensions
+        return self.normalized_extension in binary_extensions
 
     @property
     def empty(self):

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -250,9 +250,13 @@ def decode_content(content: bytes):
         return content.decode('latin-1')
 
 
-text_extensions = (".txt", ".htm", ".html", ".xsd", ".xml", "XML", ".json", ".idx", ".paper")
-binary_extensions = (".pdf", ".jpg", ".jpeg", "png", ".gif", ".tif", ".tiff", ".bmp", ".ico", ".svg", ".webp", ".avif",
-                     ".apng", ".xlsx", ".xls", ".zip", ".docx", ".pptx")
+# Extension tables. Entries MUST be lowercase and dot-prefixed: membership is tested against
+# a normalized extension (see Attachment.is_text/is_binary), so a bare or uppercase entry here
+# can never match. Two such entries ("png", "XML") silently classified nothing for years, which
+# is how a .PDF primary document reached a UTF-8 decode and raised (edgartools-dzwm).
+text_extensions = (".txt", ".htm", ".html", ".xsd", ".xml", ".json", ".idx", ".paper", ".css", ".js")
+binary_extensions = (".pdf", ".jpg", ".jpeg", ".png", ".gif", ".tif", ".tiff", ".bmp", ".ico", ".svg", ".webp",
+                     ".avif", ".apng", ".xlsx", ".xls", ".zip", ".docx", ".pptx")
 
 
 def get_bool(value: Optional[str] = None) -> Optional[bool]:
@@ -383,25 +387,6 @@ def current_year_and_quarter() -> Tuple[int, int]:
     current_year, current_quarter = now_eastern.year, (now_eastern.month - 1) // 3 + 1
 
     return current_year, current_quarter
-
-
-def filter_by_date(data: pa.Table,
-                   date: Union[str, datetime.datetime],
-                   date_col: str) -> pa.Table:
-    # If datetime convert to string
-    if isinstance(date, datetime.date) or isinstance(date, datetime.datetime):
-        date = date.strftime('%Y-%m-%d')
-
-def decode_content(content: bytes):
-    try:
-        return content.decode('utf-8')
-    except UnicodeDecodeError:
-        return content.decode('latin-1')
-
-
-text_extensions = (".txt", ".htm", ".html", ".xsd", ".xml", "XML", ".json", ".idx", ".paper")
-binary_extensions = (".pdf", ".jpg", ".jpeg", "png", ".gif", ".tif", ".tiff", ".bmp", ".ico", ".svg", ".webp", ".avif",
-                     ".apng", ".xlsx", ".xls", ".zip", ".docx", ".pptx")
 
 
 class DataPager:
@@ -585,9 +570,11 @@ def is_probably_html(content: str) -> bool:
     if isinstance(content, bytes):
         content = content.decode('utf-8', errors='ignore')
 
-    # Check for common HTML tags
+    # Check for common HTML tags. Lowercase once: `content` can be hundreds of MB and
+    # doing it inside the generator allocated a fresh copy for every tag tried.
     html_tags = ['<html>', '<body>', '<head>', '<title>', '<div', '<span', '<p>']
-    return any(tag in content.lower() for tag in html_tags)
+    lowered = content.lower()
+    return any(tag in lowered for tag in html_tags)
 
 def has_html_content(content: str) -> bool:
     """

--- a/edgar/sgml/sgml_common.py
+++ b/edgar/sgml/sgml_common.py
@@ -13,7 +13,7 @@ from edgar.httprequests import stream_with_retry
 from edgar.sgml.filing_summary import FilingSummary
 from edgar.sgml.sgml_header import FilingHeader
 from edgar.sgml.sgml_parser import SGMLDocument, SGMLFormatType, SGMLParser, parse_document
-from edgar.sgml.text_extraction import primary_document_text
+from edgar.sgml.text_extraction import decode_document_content, primary_document_text
 from edgar.sgml.tools import is_xml
 
 
@@ -292,12 +292,15 @@ class FilingSGML:
 
 
     def html(self):
+        """The HTML of the primary document, or None when there is no HTML to return.
+
+        None covers a missing, empty or binary primary document. ``primary_html_document``
+        falls back to the first primary document when nothing has an .htm/.html extension,
+        so a PDF-only filing arrives here and must not be decoded as text.
+        """
         html_document = self.attachments.primary_html_document
         if html_document and not html_document.is_binary() and not html_document.empty:
-            html_text = self.get_content(html_document.document)
-            if isinstance(html_text, bytes):
-                html_text = html_text.decode('utf-8')
-            return html_text
+            return decode_document_content(self.get_content(html_document.document))
 
     def text(self) -> Optional[str]:
         """
@@ -343,12 +346,10 @@ class FilingSGML:
         return content
 
     def xml(self):
+        """The XML of the primary document, or None when there is no XML to return."""
         xml_document = self.attachments.primary_xml_document
         if xml_document and not xml_document.is_binary() and not xml_document.empty:
-            xml_text = self.get_content(xml_document.document)
-            if isinstance(xml_text, bytes):
-                xml_text = xml_text.decode('utf-8')
-            return xml_text
+            return decode_document_content(self.get_content(xml_document.document))
 
     def get_content(self, filename: str) -> Optional[str]:
         """

--- a/edgar/sgml/text_extraction.py
+++ b/edgar/sgml/text_extraction.py
@@ -68,6 +68,110 @@ OWNERSHIP_FORMS = frozenset({'3', '3/A', '4', '4/A', '5', '5/A'})
 _TAG_RE = re.compile(r'<[^>]+>')
 _OWNERSHIP_ROOT_RE = re.compile(r'<(?:[\w.-]+:)?ownershipDocument\b')
 
+#: Anything that may legally precede the root element: the XML declaration and other
+#: processing instructions, comments, and a DOCTYPE (with an optional internal subset).
+_XML_PROLOG_RE = re.compile(
+    r'\s*(?:<\?.*?\?>|<!--.*?-->|<!DOCTYPE[^>\[]*(?:\[.*?\])?\s*>)\s*',
+    re.DOTALL | re.IGNORECASE,
+)
+_ROOT_ELEMENT_RE = re.compile(r'<([A-Za-z_][\w.-]*(?::[\w.-]+)?)')
+_XML_DECLARATION_RE = re.compile(r'<\?xml[\s?]', re.IGNORECASE)
+
+# ── Legacy SGML financial-data-schedule dialect (Filer Manual vol 2, 5.2.1.3-5.2.2) ──
+# Pre-1997 filings mark up fixed-width tables with an HTML-3.2-like dialect that the text
+# pipeline used to pass through verbatim. These patterns are deliberately tight: 1990s
+# filings contain bare "<" as an inequality, and blanket angle-bracket deletion would eat
+# real content (edgartools-puhs).
+
+#: Structural markers that occupy a whole line: <TABLE>, </TABLE>, <CAPTION>.
+_FDS_STRUCTURE_LINE_RE = re.compile(r'^\s*</?(?:TABLE|CAPTION)>\s*$', re.IGNORECASE)
+#: A column-type declaration row — only <S> (stub) and <C> (column) markers and whitespace.
+_FDS_COLUMN_LINE_RE = re.compile(r'^\s*<[SC]>(?:\s*<[SC]>)*\s*$', re.IGNORECASE)
+#: Footnote references, inline in cell data: <F1>, <F12>.
+_FDS_FOOTNOTE_RE = re.compile(r'<(F\d+)>', re.IGNORECASE)
+#: SGML page markers, bare or numbered: <PAGE>, <PAGE 1>.
+_PAGE_MARKER_RE = re.compile(r'<PAGE(?:\s+\d+)?>', re.IGNORECASE)
+
+
+def strip_sgml_dialect_markup(text: str) -> str:
+    """Remove the legacy SGML table dialect from fixed-width filing text.
+
+    Fixed-width layout is the whole point of these documents, so nothing here may change
+    the width of a line that carries data:
+
+    * ``<TABLE>``, ``</TABLE>``, ``<CAPTION>`` and the ``<S>``/``<C>`` column-type row each
+      occupy a line of their own, so the entire line is dropped and no column moves.
+    * Footnote references sit *inline* in cell data (``3,615<F2>``), so they are rewritten
+      rather than deleted — ``<F2>`` becomes ``[F2]``. Keeping the ``F`` makes this
+      width-neutral for every footnote number, since only the delimiters change: ``<F1>``
+      and ``[F1]`` are both 4 characters, ``<F10>`` and ``[F10]`` both 5. Dropping the
+      ``F`` would shrink every reference by one character and shift the rest of the line.
+
+    Deleting the references outright was rejected: they point at footnotes that are still
+    in the document, and this codebase decodes what it recognises rather than deleting it.
+    """
+    lines = [
+        line for line in text.split('\n')
+        if not (_FDS_STRUCTURE_LINE_RE.match(line) or _FDS_COLUMN_LINE_RE.match(line))
+    ]
+    text = '\n'.join(lines)
+    text = _FDS_FOOTNOTE_RE.sub(r'[\1]', text)
+    return _PAGE_MARKER_RE.sub('', text)
+
+#: The prolog is read from the head of the document only. Documents here run to hundreds
+#: of MB and the prolog is a few hundred bytes even when a filer is generous with comments.
+_PROLOG_SCAN_LIMIT = 65536
+
+
+def root_element_name(content: Optional[str]) -> Optional[str]:
+    """The local name of the document's root element, or None if there isn't one.
+
+    Skips the XML declaration, processing instructions, comments and DOCTYPE, then reads
+    the first element name and drops any namespace prefix. ``<twe:edgarSubmission>``
+    gives ``edgarSubmission``.
+    """
+    if not content:
+        return None
+    head = content[:_PROLOG_SCAN_LIMIT]
+    pos = 0
+    while True:
+        match = _XML_PROLOG_RE.match(head, pos)
+        if not match or match.end() == pos:
+            break
+        pos = match.end()
+    match = _ROOT_ELEMENT_RE.match(head, pos)
+    if not match:
+        return None
+    return match.group(1).rsplit(':', 1)[-1]
+
+
+def is_xml_document(content: Optional[str]) -> bool:
+    """True when ``content`` is an XML instance rather than an HTML or text document.
+
+    Requires BOTH an XML declaration and a root element that is not ``<html>``. Each half
+    is load-bearing, and dropping either one misclassifies a real filing:
+
+    * The declaration alone is not enough. Modern inline-XBRL primary documents open with
+      ``<?xml version='1.0'?>``, then comments, then ``<html>`` — they are HTML and must
+      keep rendering as HTML (e.g. AAPL's FY2024 10-K).
+    * The root element alone is not enough. Historic fixed-width filings open with the SGML
+      page marker ``<PAGE>``, which reads as a root element named "PAGE" (e.g. the 1994
+      PRE 14A 0000012400-94-000008). Treating those as XML would skip the ``<PAGE>``
+      stripping they need.
+
+    Deliberately NOT decided by ``is_probably_html()``, which asks whether ``<p>``/``<div``/
+    ``<span`` appears *anywhere* in the string: one such substring inside a 143MB NPORT
+    instance classified the whole document as HTML, and ``text()`` then spent ~1.5 hours
+    walking XML through the HTML renderer (accession 0001193125-25-295554; edgartools-t3iq).
+    """
+    if not content:
+        return False
+    # Bounded slice: `content` can be hundreds of MB, so never lstrip() the whole string.
+    if not _XML_DECLARATION_RE.match(content[:_PROLOG_SCAN_LIMIT].lstrip()):
+        return False
+    root = root_element_name(content)
+    return root is not None and root.lower() != 'html'
+
 
 def is_ownership_form(form: Optional[str]) -> bool:
     """True when ``form`` is a Section 16 ownership form (3, 4, 5 and amendments)."""
@@ -223,9 +327,17 @@ def primary_document_text(
         if rendered:
             return html_to_text(rendered, form=form)
 
+    # XML with no offline renderer is returned verbatim (see the module docstring: rendering
+    # these needs the SEC's XSLT endpoint, which FilingSGML has no network access for). The
+    # point of deciding it HERE is to keep it away from html_to_text() below, which would
+    # strip exactly the tags that carry the meaning — an <invstOrSec> instance rendered as
+    # HTML is a wall of undifferentiated numbers — and which walks the whole tree to do it.
+    if is_xml_document(text):
+        return text
+
     if is_probably_html(text):
         return html_to_text(text, form=form)
 
-    # Plain text (and XML with no offline renderer): return as-is, minus the SGML
-    # page-break markers. Fixed-width layout is preserved, not reflowed.
-    return text.replace("<PAGE>", "")
+    # Plain text: fixed-width layout is preserved, not reflowed. Only the SGML markup
+    # itself is removed, and only in ways that cannot move a column.
+    return strip_sgml_dialect_markup(text)

--- a/tests/issues/regression/test_dzwm_binary_document_classification.py
+++ b/tests/issues/regression/test_dzwm_binary_document_classification.py
@@ -1,0 +1,162 @@
+"""
+Regression test for edgartools-dzwm: FilingSGML.html() raised UnicodeDecodeError on
+filings whose primary document is a PDF (reported by M. Gruening from a 1993-2026
+full-corpus crawl; 10 occurrences, all 40-17G / CERT / 40-24B2-A).
+
+The guard was never missing. ``html()`` has always skipped binary primaries, but
+``is_binary()`` compared a raw ``.extension`` against a lowercase tuple, so a document
+named ``goodhaven_40-17g.PDF`` answered False and fell through to a bare
+``.decode('utf-8')``. Three independent ways to fail open lived in that one path:
+
+  1. case-sensitive comparison (``.PDF`` never matched ``.pdf``)
+  2. a malformed table entry (``"png"``, with no leading dot, matched nothing)
+  3. ``binary_extensions`` defined twice in edgar/core.py, so fixing one copy was a no-op
+
+Assertions run offline against a synthetic submission and the tables themselves. The
+real accessions from the report are covered by a network-marked test at the bottom.
+"""
+
+import pytest
+
+from edgar.attachments import Attachment
+from edgar.core import binary_extensions, text_extensions
+from edgar.sgml import FilingSGML
+
+# Modelled on 0000894189-25-002476 (GoodHaven 40-17G): a fidelity bond filed as a PDF
+# whose filename carries an uppercase extension, with the real PDF magic bytes.
+PDF_PRIMARY_SUBMISSION = """<SEC-DOCUMENT>0000894189-25-002476.txt : 20250401
+<SEC-HEADER>0000894189-25-002476.hdr.sgml : 20250401
+ACCESSION NUMBER:\t\t0000894189-25-002476
+CONFORMED SUBMISSION TYPE:\t40-17G
+FILED AS OF DATE:\t\t20250401
+</SEC-HEADER>
+<DOCUMENT>
+<TYPE>40-17G
+<SEQUENCE>1
+<FILENAME>goodhaven_40-17g.PDF
+<DESCRIPTION>FIDELITY BOND
+<TEXT>
+%PDF-1.6
+%\xe2\xe3\xcf\xd3
+1 0 obj
+</TEXT>
+</DOCUMENT>
+</SEC-DOCUMENT>
+"""
+
+# Every accession that raised in the reporter's log.
+REPORTED_ACCESSIONS = [
+    "0001569521-14-000005",
+    "0000894189-17-006543",
+    "0000894189-18-003204",
+    "0001354457-18-000175",
+    "0001354457-18-000200",
+    "0000746601-18-000009",
+    "0000894189-18-004537",
+    "0001354457-20-000186",
+    "0001162044-24-000236",
+    "0000894189-25-002476",
+]
+
+
+def _attachment(document: str) -> Attachment:
+    return Attachment(
+        sequence_number="1",
+        description="",
+        document=document,
+        ixbrl=False,
+        path=f"/Archives/edgar/data/1/{document}",
+        document_type="40-17G",
+        size=None,
+    )
+
+
+# ── The extension tables themselves ────────────────────────────────────────
+
+@pytest.mark.fast
+def test_extension_tables_are_lowercase_and_dot_prefixed():
+    """Entries are matched against a normalized extension, so a bare or uppercase
+    entry can never fire. Two such entries ("png", "XML") shipped for years."""
+    for table, name in ((binary_extensions, "binary_extensions"), (text_extensions, "text_extensions")):
+        for entry in table:
+            assert entry.startswith("."), f"{name} entry {entry!r} is missing its leading dot"
+            assert entry == entry.lower(), f"{name} entry {entry!r} is not lowercase"
+
+
+@pytest.mark.fast
+def test_png_is_classified_as_binary():
+    """The specific casualty of the missing leading dot."""
+    assert ".png" in binary_extensions
+    assert _attachment("chart.png").is_binary()
+
+
+@pytest.mark.fast
+def test_extension_tables_defined_once():
+    """binary_extensions was defined twice in edgar/core.py with the typo in both
+    copies, so a fix applied to one was silently a no-op."""
+    source = (pytest.importorskip("pathlib").Path(__file__).parents[3] / "edgar" / "core.py").read_text()
+    assert source.count("\nbinary_extensions = ") == 1
+    assert source.count("\ntext_extensions = ") == 1
+
+
+# ── Classification is case-insensitive ─────────────────────────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize("document", ["bond.pdf", "bond.PDF", "bond.Pdf"])
+def test_is_binary_ignores_filename_casing(document):
+    assert _attachment(document).is_binary()
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "document,predicate",
+    [
+        ("doc.HTM", "is_html"), ("doc.HTML", "is_html"),
+        ("doc.XML", "is_xml"), ("doc.XSD", "is_xml"),
+        ("doc.TXT", "is_text"), ("doc.PAPER", "is_text"),
+    ],
+)
+def test_predicates_ignore_filename_casing(document, predicate):
+    """is_xml/is_html already lowercased; is_text/is_binary did not. All four now agree."""
+    assert getattr(_attachment(document), predicate)()
+
+
+# ── End to end, offline ────────────────────────────────────────────────────
+
+@pytest.mark.fast
+def test_pdf_primary_is_recognised_as_binary():
+    sgml = FilingSGML.from_text(PDF_PRIMARY_SUBMISSION)
+    primary = sgml.attachments.primary_html_document
+    # primary_html_document falls back to the first primary document when nothing
+    # has an .htm/.html extension, so a PDF legitimately arrives here.
+    assert primary.document == "goodhaven_40-17g.PDF"
+    assert primary.extension == ".PDF"
+    assert primary.is_binary()
+
+
+@pytest.mark.fast
+def test_html_returns_none_for_pdf_primary_instead_of_raising():
+    """The reported crash. None is the contract edgartools-e0hr established for text():
+    a truthful "no HTML here", never U+FFFD mojibake."""
+    sgml = FilingSGML.from_text(PDF_PRIMARY_SUBMISSION)
+    assert sgml.html() is None
+
+
+@pytest.mark.fast
+def test_text_returns_none_for_pdf_primary():
+    """text() was already correct (edgartools-e0hr); pinned so it stays that way."""
+    sgml = FilingSGML.from_text(PDF_PRIMARY_SUBMISSION)
+    assert sgml.text() is None
+
+
+# ── The real filings from the report ───────────────────────────────────────
+
+@pytest.mark.network
+@pytest.mark.parametrize("accession", REPORTED_ACCESSIONS)
+def test_reported_accessions_do_not_raise(accession):
+    from edgar import find
+
+    sgml = find(accession).sgml()
+    # The assertion is that this returns at all — every one of these raised
+    # UnicodeDecodeError on 5.47.0 through 5.49.0.
+    assert sgml.html() is None

--- a/tests/issues/regression/test_puhs_legacy_sgml_dialect.py
+++ b/tests/issues/regression/test_puhs_legacy_sgml_dialect.py
@@ -1,0 +1,168 @@
+"""
+Regression test for edgartools-puhs: FilingSGML.text() passed the legacy SGML
+financial-data-schedule dialect straight through to the caller, so pre-1997 filings
+came back with <TABLE>, <CAPTION>, <S>, <C> and <F1> embedded in their text
+(reported by M. Gruening; Filer Manual vol 2 sections 5.2.1.3, 5.2.1.4, 5.2.2).
+
+The constraint that shapes this fix: these documents ARE their fixed-width layout, and
+the branch that returns them promises to preserve it. So nothing may change the width of
+a line carrying data.
+
+  * <TABLE>, </TABLE>, <CAPTION> and the <S>/<C> column-type row each occupy a whole
+    line -> drop the line, no column moves.
+  * Footnote refs are inline in cell data ("3,615<F2>") -> rewrite, don't delete.
+    <F2> becomes [F2]: only the delimiters change, so it is width-neutral for every
+    footnote number. Dropping the F (-> [2]) would shrink every reference by one
+    character and shift the rest of the line.
+
+The patterns are deliberately tight. 1990s filings use a bare "<" as a less-than sign,
+and blanket angle-bracket deletion would eat real content.
+"""
+
+import re
+
+import pytest
+
+from edgar.sgml.text_extraction import primary_document_text, strip_sgml_dialect_markup
+
+# Shape taken from 0000003673-94-000020 (1994 10-K, Monongahela Power generating table).
+LEGACY_TABLE = """                            - 8 -
+<TABLE>
+<CAPTION>
+                                   System-Owned Stations
+Station             Units    Total     gahela  Edison    Penn   Commenced (b)
+
+Coal-fired:
+     <S>             <C>     <C>       <C>     <C>      <C>        <C>
+     Albright        3       292       292      -        -         1952
+</TABLE>
+"""
+
+# Shape taken from 0000012400-94-000008 (1994 PRE 14A), footnote refs inline in data.
+LEGACY_FOOTNOTES = """        NAME OF BENEFICIAL OWNER            OF BENEFICIAL OWNERSHIP   <F1>
+        Glenn C. Barber                     2,687
+        Bruce B. Brundage                   3,615<F2>
+        Dale E. Clement                     9,597
+        Michael B. Enzi                       998<F3>
+"""
+
+
+# ── Whole-line markers are dropped ─────────────────────────────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize("marker", ["<TABLE>", "</TABLE>", "<CAPTION>", "<table>", "</Table>"])
+def test_structure_markers_on_their_own_line_are_dropped(marker):
+    out = strip_sgml_dialect_markup(f"before\n{marker}\nafter\n")
+    assert out == "before\nafter\n"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "row",
+    [
+        "     <S>             <C>     <C>       <C>",
+        "<S><C>",
+        "  <s>   <c>   <c>  ",
+    ],
+)
+def test_column_type_rows_are_dropped(row):
+    out = strip_sgml_dialect_markup(f"header\n{row}\ndata\n")
+    assert out == "header\ndata\n"
+
+
+@pytest.mark.fast
+def test_a_line_mixing_markers_with_data_is_not_dropped():
+    """Only rows that are PURELY column markers go. A line with real content stays,
+    even if it happens to contain a marker."""
+    line = "     <S>   Albright   292"
+    assert line in strip_sgml_dialect_markup(f"{line}\n")
+
+
+# ── Footnote references are rewritten, width-neutrally ─────────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize("n", [1, 2, 9, 10, 12, 99, 100])
+def test_footnote_rewrite_is_width_neutral(n):
+    """<Fn> and [Fn] are the same length for every n, because only the delimiters
+    change. This is why the F is kept: [n] would be one character shorter."""
+    original = f"3,615<F{n}>"
+    out = strip_sgml_dialect_markup(original)
+    assert out == f"3,615[F{n}]"
+    assert len(out) == len(original)
+
+
+@pytest.mark.fast
+def test_footnote_refs_survive_as_references():
+    """Deleting them was rejected — they point at footnotes still in the document."""
+    out = strip_sgml_dialect_markup(LEGACY_FOOTNOTES)
+    assert "[F1]" in out and "[F2]" in out and "[F3]" in out
+    assert "<F1>" not in out
+
+
+@pytest.mark.fast
+def test_data_line_widths_are_unchanged():
+    out = strip_sgml_dialect_markup(LEGACY_FOOTNOTES)
+    for line in out.split("\n"):
+        restored = re.sub(r"\[(F\d+)\]", r"<\1>", line)
+        assert len(line) == len(restored)
+    # And the columns still line up: every value starts at the same offset.
+    offsets = {line.index("2,687") for line in out.split("\n") if "2,687" in line}
+    assert offsets == {LEGACY_FOOTNOTES.split("\n")[1].index("2,687")}
+
+
+# ── Page markers, bare and numbered ────────────────────────────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize("marker", ["<PAGE>", "<PAGE 1>", "<PAGE 12>", "<page>"])
+def test_page_markers_are_removed(marker):
+    assert "PAGE" not in strip_sgml_dialect_markup(f"text {marker} more").upper().replace("TEXT", "")
+
+
+# ── Conservative: real content with angle brackets survives ────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "content",
+    [
+        "if x < 5 and y > 3 then",
+        "net income < $1,000 in 1993",
+        "ratio of <1.5 to 1",
+        "See Note <reference to be supplied>",
+    ],
+)
+def test_prose_angle_brackets_are_not_touched(content):
+    """The reporter's own scan flagged many '<...>' runs that are not tags at all.
+    Blanket deletion would eat inequalities out of 1990s filings."""
+    assert strip_sgml_dialect_markup(content) == content
+
+
+# ── End to end ─────────────────────────────────────────────────────────────
+
+@pytest.mark.fast
+def test_legacy_table_has_no_dialect_left():
+    out = primary_document_text("10-K", LEGACY_TABLE)
+    assert not re.findall(r"<(?:TABLE|CAPTION|S|C|F\d+)>", out, re.IGNORECASE)
+    # The data itself is untouched.
+    assert "Albright        3       292       292" in out
+
+
+# ── The real filings from the report ───────────────────────────────────────
+
+@pytest.mark.network
+@pytest.mark.parametrize(
+    "accession", ["0000003673-94-000020", "0000012400-94-000008"]
+)
+def test_reported_filings_have_no_dialect_markup(accession):
+    from edgar import find
+
+    text = find(accession).sgml().text()
+    leftover = sorted(set(re.findall(r"<[A-Za-z/][^<>]{0,20}>", text)))
+    assert leftover == [], f"dialect markup survived: {leftover}"
+
+
+@pytest.mark.network
+def test_reported_footnotes_are_rewritten_not_dropped():
+    from edgar import find
+
+    text = find("0000012400-94-000008").sgml().text()
+    assert sorted(set(re.findall(r"\[F\d+\]", text))) == ["[F1]", "[F2]", "[F3]", "[F4]"]

--- a/tests/issues/regression/test_t3iq_xml_document_routing.py
+++ b/tests/issues/regression/test_t3iq_xml_document_routing.py
@@ -1,0 +1,164 @@
+"""
+Regression test for edgartools-t3iq: FilingSGML.text() routed XML instances through the
+HTML renderer, which stripped the tags that carry the meaning and took ~1.5 hours on a
+large instance (reported by M. Gruening).
+
+The misrouting came from `is_probably_html()`, which asks whether '<p>' / '<div' / '<span'
+appears ANYWHERE in the string. Inside a 143MB NPORT instance one such substring is a
+certainty, so the whole document was classified as HTML and walked node by node
+(0001193125-25-295554: 142,667,189 chars, ~1.5h -> ~2s).
+
+Routing is now decided by `is_xml_document()`, which requires BOTH an XML declaration and
+a root element that is not <html>. Both halves are load-bearing — the tests below pin each
+one against the real filing that motivated it:
+
+  * declaration alone is not enough  -> inline-XBRL 10-Ks open with <?xml ...?> then <html>
+  * root element alone is not enough -> 1994 filings open with the SGML marker <PAGE>
+
+What text() RETURNS for unrenderable XML is unchanged: the XML verbatim. Rendering these
+needs the SEC's XSLT endpoint, which FilingSGML has no network access for (see the
+edgar/sgml/text_extraction.py module docstring). Only the routing changed.
+"""
+
+import pytest
+
+from edgar.sgml.text_extraction import is_xml_document, primary_document_text, root_element_name
+
+# Shapes taken from real filings, trimmed to the prolog plus a token of body.
+IXBRL_10K = (
+    "<?xml version='1.0' encoding='ASCII'?>\n"
+    "<!--XBRL Document Created with the Workiva Platform-->\n"
+    "<!--Copyright 2024 Workiva-->\n"
+    '<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL"><body><p>UNITED STATES</p></body></html>'
+)
+NPORT_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">'
+    "<invstOrSec><name>Some Bond</name><pctVal>1.5</pctVal></invstOrSec>"
+    "</edgarSubmission>"
+)
+PREFIXED_ROOT_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<twe:edgarSubmission xmlns:com="http://www.sec.gov/edgar/common">'
+    "<twe:headerData/></twe:edgarSubmission>"
+)
+LEGACY_FIXED_WIDTH = "<PAGE>\nDRAFT                          BLACK HILLS CORPORATION\n<TABLE>\n<S>  <C>\n</TABLE>\n"
+DOCTYPE_HTML = '<!DOCTYPE html>\n<html><body><p>hello</p></body></html>'
+
+
+# ── Root element detection ─────────────────────────────────────────────────
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        (IXBRL_10K, "html"),
+        (NPORT_XML, "edgarSubmission"),
+        (PREFIXED_ROOT_XML, "edgarSubmission"),  # namespace prefix dropped
+        (LEGACY_FIXED_WIDTH, "PAGE"),
+        (DOCTYPE_HTML, "html"),
+        ("SECURITIES AND EXCHANGE COMMISSION\n   plain text, no markup\n", None),
+        ("", None),
+    ],
+)
+def test_root_element_name(content, expected):
+    assert root_element_name(content) == expected
+
+
+# ── The two load-bearing halves of is_xml_document ─────────────────────────
+
+@pytest.mark.fast
+def test_ixbrl_is_not_xml_despite_declaration():
+    """An XML declaration does not mean 'not HTML'. If this regresses, every modern
+    10-K stops rendering and text() returns raw iXBRL markup."""
+    assert not is_xml_document(IXBRL_10K)
+
+
+@pytest.mark.fast
+def test_legacy_page_marker_is_not_an_xml_root():
+    """<PAGE> reads as a root element named PAGE. If this regresses, historic filings
+    are returned verbatim and their page markers stop being stripped."""
+    assert not is_xml_document(LEGACY_FIXED_WIDTH)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("content", [NPORT_XML, PREFIXED_ROOT_XML])
+def test_real_xml_instances_are_detected(content):
+    assert is_xml_document(content)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("content", ["", None, "plain text with no markup at all"])
+def test_non_markup_is_not_xml(content):
+    assert not is_xml_document(content)
+
+
+# ── Routing through primary_document_text ──────────────────────────────────
+
+@pytest.mark.fast
+def test_xml_instance_is_returned_verbatim_not_tag_stripped():
+    """The correctness half: <invstOrSec> content is meaningless once the tags that
+    label it are gone, so the XML must survive intact."""
+    out = primary_document_text("NPORT-P", NPORT_XML)
+    assert out == NPORT_XML
+    assert "<invstOrSec>" in out
+    assert "<pctVal>1.5</pctVal>" in out
+
+
+@pytest.mark.fast
+def test_ixbrl_still_renders_to_text():
+    out = primary_document_text("10-K", IXBRL_10K)
+    assert "UNITED STATES" in out
+    assert "<html" not in out
+    assert "<p>" not in out
+
+
+@pytest.mark.fast
+def test_legacy_page_markers_still_stripped():
+    out = primary_document_text("PRE 14A", LEGACY_FIXED_WIDTH)
+    assert "<PAGE>" not in out
+    assert "BLACK HILLS CORPORATION" in out
+
+
+@pytest.mark.fast
+def test_xml_routing_does_not_scan_the_whole_document():
+    """Guards the performance half. A large XML instance carrying an HTML-looking
+    substring must still route as XML — that substring is what made the 143MB NPORT
+    take ~1.5 hours. Kept small enough to stay a fast test."""
+    big = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">'
+        + "<invstOrSec><name>Bond</name><desc>see <p> note</desc></invstOrSec>" * 2000
+        + "</edgarSubmission>"
+    )
+    assert "<p>" in big  # the substring that fooled is_probably_html
+    assert is_xml_document(big)
+    assert primary_document_text("NPORT-P", big) == big
+
+
+# ── The real filings from the report ───────────────────────────────────────
+
+@pytest.mark.network
+@pytest.mark.parametrize(
+    "accession,form",
+    [("0000002554-26-000006", "X-17A-5"), ("0000002110-26-000003", "24F-2NT")],
+)
+def test_reported_xml_forms_route_as_xml(accession, form):
+    from edgar import find
+
+    text = find(accession).sgml().text()
+    assert is_xml_document(text)
+    # Verbatim, not tag-stripped: the closing root tag survives.
+    assert text.rstrip().endswith(">")
+
+
+@pytest.mark.network
+def test_large_nport_instance_is_not_walked_as_html():
+    """0001193125-25-295554: 142,667,189 chars of <invstOrSec>. Took ~1.5 hours before
+    the routing fix. The assertion is the shape of the output, not a wall-clock bound —
+    a tag-stripped result is the failure this pins."""
+    from edgar import find
+
+    text = find("0001193125-25-295554").sgml().text()
+    assert root_element_name(text) == "edgarSubmission"
+    assert "<invstOrSec>" in text


### PR DESCRIPTION
## Summary

Three bugs from a 1993–2026 full-corpus crawl reported by Michael Gruening, all the same shape: `FilingSGML.text()`/`html()` decided what to do with a payload without first establishing what the payload was.

- **`FilingSGML.html()` raised `UnicodeDecodeError` on PDF primaries** (10 filings, 40-17G/CERT/40-24B2/A). `is_binary()` compared a raw `.extension` against a lowercase tuple, so `*.PDF` answered False and fell through to a bare `.decode('utf-8')`. Classification now goes through `Attachment.normalized_extension`, and `html()`/`xml()` route through `decode_document_content()`, which already had the right contract (including a NUL-byte sniff). Also removed a duplicated `binary_extensions` block in `core.py` — and with it a dead, return-less `filter_by_date()` the paste-in had broken (every caller imports the real one from `edgar.filtering`).
- **`text()` returned raw XML for XML-primary forms beyond ownership** (X-17A-5, 24F-2NT, NPORT-P). `is_probably_html()` scans for `<p>`/`<div`/`<span` anywhere in the string — inside a 143MB NPORT instance that's a certainty, so one filing was walked node-by-node for ~1.5 hours (now 2.4s), while a scan miss returned markup verbatim. XML now gets its own branch via `is_xml_document()` (XML declaration **and** non-`<html>` root — both halves load-bearing: iXBRL 10-Ks open `<?xml` then `<html>`; 1994 filings open with `<PAGE>`).
- **`text()` leaked pre-1997 SGML financial-data-schedule markup** (`<TABLE>`, `<CAPTION>`, `<S>`/`<C>` rows, `<F1>`…). Whole-line dialect tags are dropped whole (no column movement); inline footnote refs are rewritten width-neutrally (`<F2>` → `[F2]`). Patterns are deliberately tight — 1990s filings use bare `<` as less-than, so blanket angle-bracket deletion would eat real content.

All changes are additive inside `FilingSGML` / `edgar.documents`; `Filing.text()` and `Filing.html()` are untouched, per d216a934.

Beads: edgartools-dzwm, edgartools-t3iq, edgartools-puhs (all closed against 821879b7).

## Verification

- 5166 fast, 2540 regression (incl. network), 0 failures at commit time
- 76 new regression tests across three files in `tests/issues/regression/` (`test_dzwm_binary_document_classification.py`, `test_t3iq_xml_document_routing.py`, `test_puhs_legacy_sgml_dialect.py`), re-run green today

🤖 Generated with [Claude Code](https://claude.com/claude-code)