### PR TITLE
perf(documents): slot the table cell classes, gate original_html retention

### DIFF
--- a/edgar/documents/parser.py
+++ b/edgar/documents/parser.py
@@ -144,8 +144,12 @@ class HTMLParser:
             metadata.preserve_whitespace = self.config.preserve_whitespace
 
             # Store ORIGINAL unmodified HTML for section extraction (TOC analysis)
-            # Must be the raw HTML before preprocessing
-            metadata.original_html = original_html
+            # Must be the raw HTML before preprocessing. Only the section/TOC
+            # extractors read it, and they all tolerate its absence, so a parse
+            # with detect_sections=False need not keep the input alive for the
+            # life of the Document (edgartools-2248).
+            if self.config.detect_sections:
+                metadata.original_html = original_html
 
             # Add XBRL facts to metadata if found
             if xbrl_facts:

--- a/edgar/documents/table_nodes.py
+++ b/edgar/documents/table_nodes.py
@@ -63,7 +63,10 @@ def _clean_numeric_text(text: str) -> str:
     return clean.replace('(', '-').replace(')', '')
 
 
-@dataclass
+# slots=True: table-heavy filings materialise millions of these (a 25MB
+# ABS-15G held ~3.2M at peak), so the per-instance __dict__ alone was
+# hundreds of MB (edgartools-2248).
+@dataclass(slots=True)
 class Cell:
     """Table cell representation."""
     content: Union[str, Node]

--- a/edgar/documents/utils/table_matrix.py
+++ b/edgar/documents/utils/table_matrix.py
@@ -11,7 +11,9 @@ from edgar.documents.table_nodes import Cell, Row
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+# slots=True: one of these exists per grid position (rows x cols), a second
+# full materialisation of the table on top of Cell (edgartools-2248).
+@dataclass(slots=True)
 class MatrixCell:
     """Cell in the matrix with reference to original cell"""
     original_cell: Optional[Cell] = None


### PR DESCRIPTION
## Summary

The cheap half of **edgartools-2248** (`FilingSGML.text()` peaks at ~60x input RSS on table-heavy filings). Profiling a representative filing (FNMA ABS-15G/A `0000310522-18-000070`, 25.2MB SGML, one 67k-row / 1.6M-cell HTML table) attributed the blowup entirely to the render path: the grid is materialized as millions of unslotted dataclass instances — `Cell` at parse, a second full `MatrixCell` grid, then list-of-lists copies in the renderer — each paying 296B of `__dict__` on top of a 56B shell. The SGML parser itself is not implicated (the Feb rewrite in `e1a763b1` already made parse cost ~zero: 9ms / ~0MB growth on this filing).

Two contained changes:

- **`Cell` and `MatrixCell` become `@dataclass(slots=True)`** (`edgar/documents/table_nodes.py`, `edgar/documents/utils/table_matrix.py`). Neither has subclasses, `cached_property`, or dynamic attribute writes; project floor is Python 3.10, which supports `slots=True`.
- **`metadata.original_html` is retained only when `config.detect_sections` is set** (`edgar/documents/parser.py`). Its only readers are the section/TOC extractors, all of which already tolerate its absence via `getattr(..., None)`, so a `detect_sections=False` parse (e.g. `Document`'s own section re-parse) no longer keeps the raw input alive for the life of the Document.

## Measured

Same script, same filing, both sides of the change (fresh process, `ru_maxrss`):

| | before | after |
|---|---|---|
| peak RSS | 1.51GB (60.0x input) | 1.34GB (53.2x input) |
| wall time | 25.9s | 22.6s |
| text output | 8,563,621 chars | byte-identical |

The remaining ~53x is the repeated grid materialization itself (parse cell list → matrix grid → renderer's 5–7 list-of-lists copies); that algorithmic fix stays open on edgartools-2248 for the 6.0 perf pass, with the full tracemalloc attribution recorded on the bead.

## Verification

- 5102 fast tests pass (4 skipped, 1 xfailed)
- Output equivalence asserted on the profiled filing (byte-identical text before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)