### PR TITLE
fix(cache): stop the import-time cache clears from wiping the HTTP cache on every import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The HTTP cache was wiped twice on every `import edgar`, so it never survived a process.** The two "one-time" import-time cache clears (#457 locale fix, #672 empty-response fix) each kept their marker file inside `_tcache` — the directory the other one `rmtree`s — so each import deleted the other's marker and both clears fired forever, from v5.20.1 onward. Short-lived processes re-downloaded everything from SEC each run, and a wipe landing on a concurrent edgar process's in-flight cache write crashed it with `FileNotFoundError`. Markers now live in `<edgar-data-dir>/.migrations`, outside the cleared directory, and all migrations run as a single pass that clears at most once; the legacy in-cache marker is honored, so upgrading performs at most one final clear. (GH #1051)
+
 ## [5.50.0] - 2026-08-18
 
 ### Fixed

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -129,21 +129,15 @@ from edgar.xbrl import XBRL
 # which is especially harmful in MCP / stdio environments.
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-# Fix for Issue #457: Clear locale-corrupted cache files on first import
-# This is a one-time operation that only runs if the marker file doesn't exist
+# One-time cache clears on first import (#457 locale-corrupted entries, #672 stale
+# empty responses). Run as a single migration pass so the cache is wiped at most
+# once, with markers kept outside the cache directory — one clear can never delete
+# another's marker (#1051).
 try:
-    from edgar.httpclient import clear_locale_corrupted_cache
-    clear_locale_corrupted_cache()
+    from edgar.httpclient import _run_import_time_cache_migrations
+    _run_import_time_cache_migrations()
 except Exception:
     # Silently continue if cache clearing fails - it's not critical
-    pass
-
-# Fix for Issue #672: Clear potentially stale empty cached responses on first import
-# The cache-forever rule could have permanently cached empty SEC responses from transient outages
-try:
-    from edgar.httpclient import clear_empty_cached_responses
-    clear_empty_cached_responses()
-except Exception:
     pass
 
 # Another name for get_current_filings

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -434,6 +434,86 @@ def get_http_config() -> dict:
 HTTP_MGR = get_http_mgr(request_per_sec_limit=get_edgar_rate_limit_per_sec())
 
 
+# One-time cache-clear migrations (#457, #672).
+#
+# Marker files are kept in <edgar-data-dir>/.migrations — OUTSIDE the cache
+# directory — so that clearing the cache for one migration can never delete
+# another migration's marker (Issue #1051: both markers used to live inside
+# _tcache, so each import wiped the cache twice, forever).
+#
+# Maps migration id (the marker filename in .migrations) to the legacy marker
+# filename that older versions kept inside the cache directory. A legacy marker
+# means the migration already ran under an older version, so it is recorded in
+# the new location without clearing again.
+_CACHE_CLEAR_MIGRATIONS = {
+    "locale_fix_457": ".locale_fix_457_applied",
+    "empty_response_fix_672": ".empty_response_fix_672_applied",
+}
+
+
+def _apply_cache_clear_migrations(migrations: dict) -> bool:
+    """
+    Clear the HTTP cache at most once for whichever of `migrations` are pending.
+
+    All pending/satisfied decisions are made up front, then the cache directory
+    is removed at most once, then every marker is written — so a single pass
+    over multiple migrations performs one clear, not one per migration.
+
+    Returns:
+        bool: True if the cache directory was cleared, False otherwise
+    """
+    import logging
+    import shutil
+    from pathlib import Path
+
+    try:
+        cache_dir = Path(get_cache_directory())
+        migrations_dir = cache_dir.parent / ".migrations"
+
+        # Decide what is pending BEFORE touching anything. A legacy marker
+        # inside the cache directory counts as already applied (#1051).
+        pending, already_applied = [], []
+        for migration, legacy_name in migrations.items():
+            marker_file = migrations_dir / migration
+            try:
+                if marker_file.exists():
+                    continue
+            except (PermissionError, OSError):
+                # If we can't check the marker file, assume we need to proceed
+                pass
+            if (cache_dir / legacy_name).exists():
+                already_applied.append(marker_file)
+            else:
+                pending.append(marker_file)
+
+        if not pending and not already_applied:
+            return False
+
+        migrations_dir.mkdir(parents=True, exist_ok=True)
+
+        cleared = False
+        if pending and cache_dir.exists():
+            shutil.rmtree(cache_dir)
+            cleared = True
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        for marker_file in pending + already_applied:
+            marker_file.touch()
+        return cleared
+
+    except Exception as e:
+        # Log error but don't fail - worst case user still has cache issues
+        logging.getLogger(__name__).warning(
+            "Failed to clear stale cache entries: %s. "
+            "You may need to manually delete ~/.edgar/_tcache directory.", e
+        )
+        return False
+
+
+def _run_import_time_cache_migrations() -> bool:
+    """Run all one-time cache-clear migrations as a single pass (at most one clear)."""
+    return _apply_cache_clear_migrations(_CACHE_CLEAR_MIGRATIONS)
+
+
 def clear_empty_cached_responses():
     """
     One-time cache clearing function to remove potentially stale empty responses (Issue #672).
@@ -449,38 +529,9 @@ def clear_empty_cached_responses():
     Returns:
         bool: True if cache was cleared, False if already cleared previously
     """
-    import logging
-    import shutil
-    from pathlib import Path
-
-    try:
-        cache_dir = Path(get_cache_directory())
-        marker_file = cache_dir / ".empty_response_fix_672_applied"
-
-        # If marker exists, cache was already cleared
-        try:
-            if marker_file.exists():
-                return False
-        except (PermissionError, OSError):
-            pass
-
-        # Clear the cache directory if it exists
-        if cache_dir.exists():
-            shutil.rmtree(cache_dir)
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            marker_file.touch()
-            return True
-        else:
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            marker_file.touch()
-            return False
-
-    except Exception as e:
-        logging.getLogger(__name__).warning(
-            f"Failed to clear stale cache entries (Issue #672): {e}. "
-            "You may need to manually delete ~/.edgar/_tcache directory."
-        )
-        return False
+    return _apply_cache_clear_migrations(
+        {"empty_response_fix_672": _CACHE_CLEAR_MIGRATIONS["empty_response_fix_672"]}
+    )
 
 
 def clear_locale_corrupted_cache():
@@ -492,50 +543,15 @@ def clear_locale_corrupted_cache():
     the locale fix was applied in v4.19.0.
 
     The function:
-    1. Checks for a marker file to avoid repeated clearing
-    2. Clears the HTTP cache directory if marker doesn't exist
-    3. Creates a marker file to prevent future clearing
+    1. Checks for a marker file (kept outside the cache directory) to avoid repeated clearing
+    2. Clears the HTTP cache directory if the migration is pending
+    3. Creates the marker file to prevent future clearing
 
     This is safe to call multiple times - it will only clear cache once per installation.
 
     Returns:
         bool: True if cache was cleared, False if already cleared previously
     """
-    import logging
-    import shutil
-    from pathlib import Path
-
-    try:
-        cache_dir = Path(get_cache_directory())
-        marker_file = cache_dir / ".locale_fix_457_applied"
-
-        # If marker exists, cache was already cleared
-        try:
-            if marker_file.exists():
-                return False
-        except (PermissionError, OSError):
-            # If we can't check marker file, assume we need to proceed
-            pass
-
-        # Clear the cache directory if it exists
-        if cache_dir.exists():
-            # Remove all cache files
-            shutil.rmtree(cache_dir)
-            # Recreate the directory
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            # Create marker file
-            marker_file.touch()
-            return True
-        else:
-            # No cache exists, just create marker
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            marker_file.touch()
-            return False
-
-    except Exception as e:
-        # Log error but don't fail - worst case user still has cache issues
-        logging.getLogger(__name__).warning(
-            f"Failed to clear locale-corrupted cache: {e}. "
-            "You may need to manually delete ~/.edgar/_tcache directory."
-        )
-        return False
+    return _apply_cache_clear_migrations(
+        {"locale_fix_457": _CACHE_CLEAR_MIGRATIONS["locale_fix_457"]}
+    )

--- a/tests/issues/regression/test_issue_1051.py
+++ b/tests/issues/regression/test_issue_1051.py
@@ -1,0 +1,125 @@
+"""
+Regression test for Issue #1051: both import-time cache clears fired on every
+import because each one's marker file lived inside the directory the other one
+shutil.rmtree'd.
+
+edgar/__init__.py runs two "one-time" cache clears at import:
+  1. clear_locale_corrupted_cache()  (#457) - marker was _tcache/.locale_fix_457_applied
+  2. clear_empty_cached_responses()  (#672) - marker was _tcache/.empty_response_fix_672_applied
+
+The second clear's rmtree deleted the marker the first clear had just written,
+so on the next import the first clear fired again (deleting the second's
+marker), forever. The HTTP cache was wiped twice on every process start, and a
+wipe landing on a concurrent edgar process's in-flight cache write crashed it.
+
+The fix keeps migration markers in <data-dir>/.migrations, OUTSIDE the cache
+directory, and runs all migrations as a single pass that clears at most once.
+Legacy in-cache markers written by older versions are honored so upgrading
+performs at most one final clear.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1051
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from edgar.httpclient import (
+    _run_import_time_cache_migrations,
+    clear_empty_cached_responses,
+    clear_locale_corrupted_cache,
+)
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    d = tmp_path / "_tcache"
+    d.mkdir()
+    with patch("edgar.httpclient.get_cache_directory", return_value=str(d)):
+        yield d
+
+
+class TestMarkersSurviveBothClears:
+    """The core #1051 scenario: the two clears must not delete each other's markers."""
+
+    def test_second_import_does_not_clear_again(self, tmp_path, cache_dir):
+        # First "import": both clears run, in the same order as edgar/__init__.py
+        clear_locale_corrupted_cache()
+        clear_empty_cached_responses()
+
+        # Both markers must be present after the first pass
+        migrations_dir = tmp_path / ".migrations"
+        assert (migrations_dir / "locale_fix_457").exists()
+        assert (migrations_dir / "empty_response_fix_672").exists()
+
+        # Cache content created between "imports" (the reporter's canary)
+        canary = cache_dir / "CANARY"
+        canary.write_text("cached response")
+
+        # Second "import": neither clear may fire
+        assert clear_locale_corrupted_cache() is False
+        assert clear_empty_cached_responses() is False
+        assert canary.exists(), "cache was wiped on a subsequent import (#1051)"
+
+    def test_single_pass_clears_at_most_once(self, tmp_path, cache_dir):
+        (cache_dir / "stale_entry").write_text("stale")
+
+        assert _run_import_time_cache_migrations() is True
+        assert not (cache_dir / "stale_entry").exists()
+
+        canary = cache_dir / "CANARY"
+        canary.write_text("cached response")
+
+        # Second pass is a no-op
+        assert _run_import_time_cache_migrations() is False
+        assert canary.exists()
+
+
+class TestLegacyMarkersHonored:
+    """Markers written inside _tcache by older versions count as already applied."""
+
+    def test_legacy_672_marker_prevents_wipe_on_upgrade(self, tmp_path, cache_dir):
+        # Steady state under the bug: only the 672 marker survives in _tcache
+        (cache_dir / ".empty_response_fix_672_applied").touch()
+        canary = cache_dir / "CANARY"
+        canary.write_text("cached response")
+
+        # 672 is satisfied by the legacy marker; only 457 is pending, so the
+        # upgrade performs exactly one final clear...
+        assert _run_import_time_cache_migrations() is True
+        migrations_dir = tmp_path / ".migrations"
+        assert (migrations_dir / "locale_fix_457").exists()
+        assert (migrations_dir / "empty_response_fix_672").exists()
+
+        # ...and never clears again
+        canary.write_text("cached response")
+        assert _run_import_time_cache_migrations() is False
+        assert canary.exists()
+
+    def test_both_legacy_markers_mean_no_wipe_at_all(self, cache_dir):
+        (cache_dir / ".locale_fix_457_applied").touch()
+        (cache_dir / ".empty_response_fix_672_applied").touch()
+        canary = cache_dir / "CANARY"
+        canary.write_text("cached response")
+
+        assert _run_import_time_cache_migrations() is False
+        assert canary.exists()
+
+
+class TestReturnValueContract:
+    """The public functions keep their documented return semantics."""
+
+    def test_first_call_with_cache_returns_true(self, cache_dir):
+        (cache_dir / "entry").write_text("x")
+        assert clear_empty_cached_responses() is True
+
+    def test_no_cache_dir_returns_false_and_creates_marker(self, tmp_path):
+        cache_dir = tmp_path / "_tcache"  # does not exist
+        with patch("edgar.httpclient.get_cache_directory", return_value=str(cache_dir)):
+            assert clear_empty_cached_responses() is False
+        assert cache_dir.exists()
+        assert (tmp_path / ".migrations" / "empty_response_fix_672").exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/issues/regression/test_issue_457_locale_cache_fix.py
+++ b/tests/issues/regression/test_issue_457_locale_cache_fix.py
@@ -72,8 +72,8 @@ class TestLocaleCacheFix:
         assert not (test_cache_dir / "cache_file_1").exists()
         assert not (test_cache_dir / "cache_file_2").exists()
 
-        # Marker file should exist
-        marker_file = test_cache_dir / ".locale_fix_457_applied"
+        # Marker file should exist, OUTSIDE the cache directory (#1051)
+        marker_file = tmp_path / ".migrations" / "locale_fix_457"
         assert marker_file.exists()
 
     def test_clear_locale_corrupted_cache_subsequent_run(self, tmp_path):
@@ -81,7 +81,8 @@ class TestLocaleCacheFix:
         # Create a temporary cache directory with marker file
         test_cache_dir = tmp_path / "_tcache"
         test_cache_dir.mkdir()
-        marker_file = test_cache_dir / ".locale_fix_457_applied"
+        marker_file = tmp_path / ".migrations" / "locale_fix_457"
+        marker_file.parent.mkdir()
         marker_file.touch()
 
         # Create some cache files (should NOT be deleted)
@@ -115,8 +116,8 @@ class TestLocaleCacheFix:
         # Cache directory should now exist (created by function)
         assert test_cache_dir.exists()
 
-        # Marker file should exist
-        marker_file = test_cache_dir / ".locale_fix_457_applied"
+        # Marker file should exist, OUTSIDE the cache directory (#1051)
+        marker_file = tmp_path / ".migrations" / "locale_fix_457"
         assert marker_file.exists()
 
     def test_clear_locale_corrupted_cache_error_handling(self, tmp_path):
@@ -250,8 +251,8 @@ class TestIssuereproduction:
         assert cleared is True
         assert not (test_cache_dir / "old_cache_file").exists()
 
-        # Marker should exist
-        marker_file = test_cache_dir / ".locale_fix_457_applied"
+        # Marker should exist, OUTSIDE the cache directory (#1051)
+        marker_file = tmp_path / ".migrations" / "locale_fix_457"
         assert marker_file.exists()
 
         # Subsequent imports should not clear cache again

--- a/tests/issues/regression/test_public_api_surface.py
+++ b/tests/issues/regression/test_public_api_surface.py
@@ -43,9 +43,11 @@ INTERNAL = {
     "get_data_directory", "get_search_cache_directory", "get_test_directory",
     "set_cache_directory", "set_claude_skills_directory", "set_data_directory",
     "set_test_directory",
-    # internal cache management; clear_cache() is the supported entry point
-    "clear_company_facts_cache", "clear_empty_cached_responses",
-    "clear_locale_corrupted_cache",
+    # internal cache management; clear_cache() is the supported entry point.
+    # clear_empty_cached_responses / clear_locale_corrupted_cache left this
+    # boundary in the #1051 fix: __init__.py now runs the migrations via
+    # _run_import_time_cache_migrations, so they live only in edgar.httpclient.
+    "clear_company_facts_cache",
     # helpers and protocols used inside the package
     "listify", "matches_form", "edgar_mode", "get_obj_info",
     "HasContext", "compose_context",


### PR DESCRIPTION
Fixes #1051

The two "one-time" import-time cache clears (#457 locale fix, #672 empty-response fix) each kept their marker file inside `_tcache` — the directory the other one `shutil.rmtree`s. The second clear's rmtree deleted the marker the first had just written, so on the next import the first clear fired again (deleting the second's marker), forever. Net effect since v5.20.1: the HTTP cache was wiped twice on every `import edgar`, never survived a process, and a wipe landing on a concurrent process's in-flight cache write crashed it with `FileNotFoundError`.

### Changes

- Migration markers move to `<edgar-data-dir>/.migrations/`, **outside** the cleared directory, so one clear can never delete another's marker.
- `edgar/__init__.py` now runs all migrations as a single `_run_import_time_cache_migrations()` pass: pending/satisfied decisions are made up front, the cache is rmtree'd **at most once**, then all markers are written.
- Legacy in-cache markers written by older versions are honored — for upgrading users (who today have `.empty_response_fix_672_applied` surviving in `_tcache`) that means at most one final clear, not two.
- `clear_locale_corrupted_cache()` / `clear_empty_cached_responses()` keep their signatures and return semantics in `edgar.httpclient`; they are no longer accidentally re-exported from `edgar` (they were INTERNAL, not in `__all__`; `clear_cache()` remains the supported entry point).

### Verification

- New regression test `tests/issues/regression/test_issue_1051.py`: both clears run twice leave both markers and a canary cache file intact; a single pass clears at most once; legacy markers prevent re-wiping; return-value contract preserved.
- Updated `test_issue_457_locale_cache_fix.py` marker-path assertions to the new location.
- Reporter's canary repro run end-to-end against this branch, upgrade path included (legacy 672 marker pre-seeded): exactly one final wipe, then canaries survive across subsequent imports and both markers persist in `.migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)