### PR TITLE
chore(release): 5.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.50.1] - 2026-08-18
+
 ### Fixed
 
 - **The HTTP cache was wiped twice on every `import edgar`, so it never survived a process.** The two "one-time" import-time cache clears (#457 locale fix, #672 empty-response fix) each kept their marker file inside `_tcache` — the directory the other one `rmtree`s — so each import deleted the other's marker and both clears fired forever, from v5.20.1 onward. Short-lived processes re-downloaded everything from SEC each run, and a wipe landing on a concurrent edgar process's in-flight cache write crashed it with `FileNotFoundError`. Markers now live in `<edgar-data-dir>/.migrations`, outside the cleared directory, and all migrations run as a single pass that clears at most once; the legacy in-cache marker is honored, so upgrading performs at most one final clear. (GH #1051)

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.50.0'
+__version__ = '5.50.1'


### PR DESCRIPTION
Patch release carrying the #1051 fix (merged in #1052): the two import-time cache clears wiped the HTTP cache twice on every `import edgar` from v5.20.1 onward, so the cache never survived a process and concurrent processes could crash mid-write. Markers now live outside the cleared directory and migrations run as a single at-most-once pass.

- Bump `__about__.py` to 5.50.1
- Date the CHANGELOG section

Wheel + sdist built locally as `dist/edgartools-5.50.1*` and verified to contain the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)