### PR TITLE
Pin the xmltools contract before the lxml port, and fix the three bugs it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A person's name raised `TypeError` whenever they had no middle name.** `Name.full_name` built the middle segment as `(' ' + middle_name) or ''`, so the concatenation ran before the fallback could apply and a missing middle name crashed instead of being skipped. Municipal advisor filings hit this constantly — the parser feeds that field straight from the XML, which simply omits `<middleName>`. Michael NMN Tym Jr. still reads as `Michael NMN Tym Jr.`, since `NMN` is data the SEC writes, not an absence.
+
+- **`str(person)` printed the first name twice** instead of the full name. `repr()` was always correct, which is why Rich tables and notebook output looked right while string interpolation did not.
+
 ## [5.50.0] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`str(person)` printed the first name twice** instead of the full name. `repr()` was always correct, which is why Rich tables and notebook output looked right while string interpolation did not.
 
+- **`SecForms.load()` returned an object that raised a bewildering `SyntaxError` on use.** It wrapped `list_forms()`, which already returns a `SecForms`, so the forms table ended up nested one level too deep and every read of it went through the wrong `__getitem__` into a pandas query expression. `SecForms.load().get_form("1-A")` now returns Form 1-A, the Regulation A Offering Statement.
+
 ## [5.50.0] - 2026-08-18
 
 ### Fixed

--- a/edgar/_party.py
+++ b/edgar/_party.py
@@ -202,7 +202,7 @@ class Person:
         self.relationship_clarification: Optional[str] = relationship_clarification
 
     def __str__(self):
-        return f"{self.first_name} {self.first_name}"
+        return f"{self.first_name} {self.last_name}"
 
     def __repr__(self):
         return f"{self.first_name} {self.last_name}"
@@ -212,9 +212,9 @@ class Name:
 
     def __init__(self,
                  first_name: str,
-                 middle_name: str,
+                 middle_name: Optional[str],
                  last_name: str,
-                 suffix:Optional[str]=None):
+                 suffix: Optional[str] = None):
         self.first_name = first_name
         self.middle_name = middle_name
         self.last_name = last_name
@@ -222,7 +222,12 @@ class Name:
 
     @property
     def full_name(self):
-        return f"{self.first_name}{' ' + self.middle_name or ''} {self.last_name} {self.suffix or ''}".rstrip()
+        # Every part is optional in practice: the XML parsers feed this from
+        # child_text(), which returns None for an absent element — a filer with no
+        # <middleName> is the common case, not an edge case.
+        return " ".join(part for part in
+                        (self.first_name, self.middle_name, self.last_name, self.suffix)
+                        if part)
 
     def __str__(self):
         return self.full_name

--- a/edgar/forms.py
+++ b/edgar/forms.py
@@ -89,7 +89,9 @@ class SecForms:
 
     @classmethod
     def load(cls):
-        return SecForms(list_forms())
+        # list_forms() already returns a SecForms; wrapping it again put a SecForms
+        # in .data where a DataFrame belongs.
+        return list_forms()
 
     def __getitem__(self, item):
         return self.get_form(item)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,6 +300,10 @@ def pytest_collection_modifyitems(config, items):
         'test_frontier', 'test_tier_c_judge', 'test_424b_xbrl',
         'test_unavailable_partition',
         'test_offering_consumers', 'test_correspondence',
+        # Classified 2026-08-18 (edgartools-07lk.11.1). Characterization tests for
+        # the bs4 to lxml port; both parse inline XML strings and touch no fetch
+        # path. Verified with outbound sockets blocked before being called fast.
+        'test_party', 'test_forms_listing',
     ]
 
     # Files that need network (fetch from SEC)

--- a/tests/fixtures/forms/sec_forms_page0.html
+++ b/tests/fixtures/forms/sec_forms_page0.html
@@ -1,0 +1,319 @@
+<!--
+  Captured from https://www.sec.gov/forms?page=0 on 2026-08-18 for edgartools-07lk.11.1.
+  Trimmed to the <table> element, which is all list_forms() reads (edgar/forms.py:29).
+  25 rows; page 0 of 7. Regenerate with scripts/ or by re-downloading and re-trimming.
+-->
+<table class="usa-table views-table views-view-table cols-5">
+<caption class="visually-hidden">
+</caption>
+<thead>
+<tr>
+<th aria-sort="ascending" class="views-field views-field-field-release-number is-active" id="view-field-release-number-table-column" scope="col">Number</th>
+<th class="views-field views-field-field-display-title" id="view-field-display-title-table-column" scope="col"><a href="?page=0&amp;populate=&amp;field_audience_target_id=All&amp;field_act_target_id=All&amp;order=field_display_title&amp;sort=asc" rel="nofollow" title="sort by Description">Description</a></th>
+<th class="views-field views-field-field-date" id="view-field-date-table-column" scope="col"><a href="?page=0&amp;populate=&amp;field_audience_target_id=All&amp;field_act_target_id=All&amp;order=field_date&amp;sort=desc" rel="nofollow" title="sort by Last Updated">Last Updated</a></th>
+<th class="views-field views-field-field-list-page-det-secarticle" id="view-field-list-page-det-secarticle-table-column" scope="col"><a href="?page=0&amp;populate=&amp;field_audience_target_id=All&amp;field_act_target_id=All&amp;order=field_list_page_det_secarticle&amp;sort=asc" rel="nofollow" title="sort by SEC Number">SEC Number</a></th>
+<th class="views-field views-field-term-node-tid" id="view-term-node-tid-table-column" scope="col">Topic(s)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column"> </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/exam-brochure.pdf">Examination Brochure: Information about Examinations (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2023-03-01">March 2023</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC 2389</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column"> </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column"> </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/formsec2866.pdf">Supplemental Information for Persons Requested to Supply Information Voluntarily to the Commission's Examination Staff (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2021-04-13">April 2021</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2866</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Other Forms and Materials            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1.pdf">Application for registration or exemption from registration as a national securities exchange (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="1999-02-01">Feb. 1999</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1935</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Self-Regulatory Organizations            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-A            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1a.pdf">Regulation A Offering Statement (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-01">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC486</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-E            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-e.pdf">Notification under Regulation E (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2001-08-01">Aug. 2001</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1807</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Investment Company Act of 1940, Small Businesses, Investment Companies            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-K            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-k.pdf">Annual Reports and Special Financial Reports (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-01">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2913</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-N            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-n.pdf">Form and amendments for notice of registration as a national securities exchange for the sole purpose of trading security futures products (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2013-12-01">Dec. 2013</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2568</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, Self-Regulatory Organizations, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-SA            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-sa.pdf">Semiannual Report or Special Financial Report Pursuant to Regulation A (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2021-01-01"> Jan. 2021</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2914</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-U            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-u.pdf">Current Report Pursuant to Regulation A (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-01">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2915</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">1-Z            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form1-z.pdf">Exit Report Under Regulation A (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2015-06-14">June 2015</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2916</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Small Businesses            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">10            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form10.pdf">General form for registration of securities pursuant to Section 12(b) or (g) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2021-02-01"> Feb. 2021</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1396</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">10-D            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form10d.pdf">Asset-Backed Issuer Distribution Report Pursuant to Section 13 or 15(d) of the Securities Exchange Act of 1934 (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2019-05-01">May 2019</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2503</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">10-K            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form10-k.pdf">Annual report pursuant to Section 13 or 15(d) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-01">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1673</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Form 10-K, Securities Exchange Act of 1934, Public Companies            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">10-M            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form10-m0.pdf">Irrevocable Appointment of Agent for Service of Process, Pleadings and Other Papers by Non-Resident General Partner of Broker or Dealer (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2012-06-01">June 2012</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC878</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Broker-Dealers            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">10-Q            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form10-q.pdf">General form for quarterly reports under Section 13 or 15(d) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-12">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1296</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, Public Companies            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">11-K            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form11-k.pdf">Annual reports of employee stock purchase, savings and similar plans pursuant to Section 15(d) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2022-07-01"> July 2022</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC617</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, Public Companies            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">12b-25            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form12b-25.pdf">Notification of late filing (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2019-01-01"> Jan. 2019</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1344</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, Public Companies            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">13F            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form13f.pdf">Information required of institutional investment managers pursuant to Section 13(f) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2023-07-18">July 2023</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1685</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">13H            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form13h.pdf">Information Required of Large Traders Pursuant To Section 13(h) of the Securities Exchange Act of 1934 (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2011-11-01">Nov. 2011</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2858</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">144            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form144.pdf">Notice of proposed sale of securities pursuant to Rule 144 (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2022-07-01">July 2022</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1147</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Act of 1933, Investors            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">15            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form15.pdf">Certification and notice of termination of registration under Section 12(g) or suspension of duty to file reports under Sections 13 and 15(d) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2011-08-01">Aug. 2011</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2069</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">15F            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form15f.pdf">Certification of a foreign private issuer’s termination of registration of a class of securities under Section 12(g) or its termination of the duty to file reports under Section 13(a) or Section 15(d) (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2014-01-01">Jan. 2014</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"> </td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">17-H            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form17-h.pdf">Risk Assessment for Brokers &amp; Dealers (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2010-01-01">Jan. 2010</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC2332</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Broker-Dealers            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">18            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form18.pdf">Application for registration pursuant to Section 12(b) &amp; (c) of the Securities Exchange Act of 1934 (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2025-02-01">Feb. 2025</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1421</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, International            </td>
+</tr>
+<tr>
+<td class="release-number-content views-field views-field-field-release-number is-active" headers="view-field-release-number-table-column">18-K            </td>
+<td class="display-title-content views-field views-field-field-display-title" headers="view-field-display-title-table-column">
+<a href="/files/form18-k.pdf">Annual report for foreign governments and political subdivisions thereof (PDF)</a>
+<br/>
+<span class="abstract"></span>
+</td>
+<td class="noFilter views-field views-field-field-date" headers="view-field-date-table-column"><time class="datetime" datetime="2007-04-01">April 2007</time> </td>
+<td class="list-page-detail-content views-field views-field-field-list-page-det-secarticle" headers="view-field-list-page-det-secarticle-table-column"><p>SEC1797</p>
+</td>
+<td class="views-field views-field-term-node-tid" headers="view-term-node-tid-table-column">Securities Exchange Act of 1934, International            </td>
+</tr>
+</tbody>
+</table>

--- a/tests/test_forms_listing.py
+++ b/tests/test_forms_listing.py
@@ -1,0 +1,230 @@
+"""Coverage for `edgar.forms.list_forms()` and `SecForms`, ahead of the lxml port.
+
+`list_forms()` scrapes seven pages of https://www.sec.gov/forms and is the only
+description of what each SEC form *is*. It had no direct coverage: bead
+edgartools-07lk.11.1 calls that out as a silent-regression risk, because
+`edgar/forms.py` parses with BeautifulSoup and Phase 1 of edgartools-07lk.11 replaces
+that with lxml. It is not an `xmltools` dependent — it parses HTML, not XML — so its
+port is independent of edgartools-07lk.11.2, but the failure mode is the same: a
+scraper that quietly returns fewer rows, or empty strings, still returns a DataFrame.
+
+Two fixtures, deliberately:
+
+  * `sec_forms_page0.html` is the real table as SEC served it on 2026-08-18, trimmed
+    to the `<table>` element. It pins what the parser must do against real markup.
+  * `LABELLED_TABLE` below is synthetic, and pins the defensive branches the live
+    page no longer exercises — the `"Number:"`/`"Description:"` label prefixes from
+    SEC's older responsive layout, and a row whose description carries no link.
+
+No network: `download_file` is patched, which is also what keeps `list_forms`'s
+`lru_cache` honest — it is cleared around every test here.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from edgar.config import SEC_BASE_URL
+from edgar.forms import SecForm, SecForms, list_forms
+
+FIXTURES = Path(__file__).parent / "fixtures" / "forms"
+PAGE_0 = (FIXTURES / "sec_forms_page0.html").read_bytes()
+
+# A page with a well-formed but empty table, standing in for pages 1-6.
+EMPTY_PAGE = b"<html><body><table><thead><tr><th>Number</th></tr></thead><tbody></tbody></table></body></html>"
+
+# The older responsive markup, where each cell repeated its column label inline,
+# plus a description with no anchor. Neither shape appears on the live page today.
+LABELLED_TABLE = b"""<html><body><table>
+  <thead><tr><th>Number</th><th>Description</th><th>Last Updated</th><th>SEC Number</th><th>Topic(s)</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>Number: 10-K</td>
+      <td>Description: <a href="/files/form10-k.pdf">Annual Report (PDF)</a></td>
+      <td>Last Updated: Sept. 2024</td>
+      <td>SEC Number: SEC1234</td>
+      <td>Topic(s): Exchange Act Reporting</td>
+    </tr>
+    <tr>
+      <td>  UNLINKED  </td>
+      <td>  A form with no link  </td>
+      <td>  Jan. 2020  </td>
+      <td>  SEC9999  </td>
+      <td>  Other Forms  </td>
+    </tr>
+  </tbody>
+</table></body></html>"""
+
+
+def _serve(page_0: bytes = PAGE_0, others: bytes = EMPTY_PAGE):
+    """Answer the seven page fetches, recording the URLs asked for."""
+    requested = []
+
+    def download(url, *args, **kwargs):
+        requested.append(url)
+        return page_0 if url.endswith("page=0") else others
+
+    download.requested = requested
+    return download
+
+
+@pytest.fixture(autouse=True)
+def _clear_form_cache():
+    """`list_forms` is `lru_cache(maxsize=1)`; a warm entry would leak between tests."""
+    list_forms.cache_clear()
+    yield
+    list_forms.cache_clear()
+
+
+@pytest.fixture
+def forms():
+    download = _serve()
+    with patch("edgar.forms.download_file", download):
+        yield list_forms()
+
+
+# ------------------------------------------------------------------ scraping
+
+
+def test_list_forms_fetches_all_seven_pages():
+    download = _serve()
+    with patch("edgar.forms.download_file", download):
+        list_forms()
+
+    assert download.requested == [f"https://www.sec.gov/forms?page={page}" for page in range(7)]
+
+
+def test_list_forms_parses_every_body_row_and_no_header_row(forms):
+    """25 rows on page 0, and the `<thead>` row is not one of them."""
+    assert len(forms) == 25
+    assert "Number" not in set(forms.data.Form)
+
+
+def test_list_forms_declares_its_columns(forms):
+    assert list(forms.data.columns) == [
+        "Form",
+        "Description",
+        "Url",
+        "LastUpdated",
+        "SECNumber",
+        "Topics",
+    ]
+
+
+def test_list_forms_reads_a_row_end_to_end(forms):
+    """Ground truth: Form 1-A as SEC served it on 2026-08-18."""
+    row = forms.data[forms.data.Form == "1-A"]
+    assert len(row) == 1
+    assert row.Description.item() == "Regulation A Offering Statement (PDF)"
+    assert row.Url.item() == "https://www.sec.gov/files/form1a.pdf"
+    assert row.LastUpdated.item() == "Feb. 2025"
+    assert row.SECNumber.item() == "SEC486"
+    assert row.Topics.item() == "Securities Act of 1933, Small Businesses"
+
+
+def test_list_forms_takes_the_description_text_from_inside_the_link(forms):
+    """The description lives in an `<a>` inside the cell, so cell text extraction has
+    to reach into child elements — the axis a naive lxml `.text` port gets wrong."""
+    assert forms.data[forms.data.Form == "1-A"].Description.item() == "Regulation A Offering Statement (PDF)"
+    assert not forms.data.Description.str.strip().eq("").any()
+
+
+def test_list_forms_builds_absolute_urls_from_relative_hrefs(forms):
+    urls = forms.data.Url[forms.data.Url != ""]
+    assert len(urls) > 0
+    assert urls.str.startswith(f"{SEC_BASE_URL}/").all()
+    assert not urls.str.contains(f"{SEC_BASE_URL}{SEC_BASE_URL}").any()
+
+
+def test_list_forms_keeps_rows_whose_form_number_is_blank(forms):
+    """The first two rows of page 0 are brochures with no form number. They are real
+    rows with real descriptions, and dropping them would lose them silently."""
+    blank = forms.data[forms.data.Form == ""]
+    assert len(blank) == 2
+    assert "Examination Brochure: Information about Examinations (PDF)" in set(blank.Description)
+
+
+def test_list_forms_strips_whitespace_from_every_field(forms):
+    for column in ("Form", "Description", "LastUpdated", "SECNumber", "Topics"):
+        values = forms.data[column]
+        assert values.equals(values.str.strip()), f"{column} carries untrimmed whitespace"
+
+
+def test_list_forms_accepts_bytes_from_download_file():
+    """`download_file` returns `bytes` for this URL, not `str`. Pinned because the
+    port has to keep accepting bytes — passing them to the wrong lxml entry point
+    raises, and passing decoded text to the right one can mangle the encoding."""
+    assert isinstance(PAGE_0, bytes)  # what the fixture feeds, matching production
+    with patch("edgar.forms.download_file", _serve()):
+        assert len(list_forms()) == 25
+
+
+# -------------------------------------------- defensive branches (synthetic)
+
+
+@pytest.fixture
+def labelled_forms():
+    download = _serve(page_0=LABELLED_TABLE)
+    with patch("edgar.forms.download_file", download):
+        yield list_forms()
+
+
+def test_inline_column_labels_are_stripped_from_every_cell(labelled_forms):
+    """SEC's older responsive layout repeated the column label inside each cell."""
+    row = labelled_forms.data.iloc[0]
+    assert row.Form == "10-K"
+    assert row.Description == "Annual Report (PDF)"
+    assert row.LastUpdated == "Sept. 2024"
+    assert row.SECNumber == "SEC1234"
+    assert row.Topics == "Exchange Act Reporting"
+
+
+def test_a_description_with_no_link_gets_an_empty_url_not_a_crash(labelled_forms):
+    row = labelled_forms.data.iloc[1]
+    assert row.Form == "UNLINKED"
+    assert row.Description == "A form with no link"
+    assert row.Url == ""
+
+
+# -------------------------------------------------------------- SecForms API
+
+
+def test_get_form_returns_a_populated_secform(forms):
+    form = forms.get_form("1-A")
+
+    assert isinstance(form, SecForm)
+    assert form.form == "1-A"
+    assert form.description == "Regulation A Offering Statement (PDF)"
+    assert form.url == "https://www.sec.gov/files/form1a.pdf"
+    assert form.sec_number == "SEC486"
+    assert form.topics == "Securities Act of 1933, Small Businesses"
+    assert str(form) == "Form 1-A: Regulation A Offering Statement (PDF)"
+
+
+def test_getitem_is_get_form(forms):
+    assert forms["1-A"] == forms.get_form("1-A")
+
+
+def test_get_form_returns_none_for_an_unknown_form(forms):
+    """Current behavior, pinned. This is a silent `None` of the kind edgartools-07lk.10
+    commits to replacing with a typed exception in 6.0 — when that lands, this test
+    is the one that has to change."""
+    assert forms.get_form("NOT-A-FORM") is None
+
+
+def test_summary_narrows_to_the_readable_columns(forms):
+    summary = forms.summary()
+    assert list(summary.columns) == ["Form", "Description", "Topics"]
+    assert len(summary) == len(forms)
+
+
+def test_repr_renders_without_error(forms):
+    assert "1-A" in repr(forms)
+
+
+@pytest.mark.xfail(strict=True, reason="edgartools-07rg: SecForms.load() double-wraps list_forms()")
+def test_load_returns_usable_forms():
+    download = _serve()
+    with patch("edgar.forms.download_file", download):
+        loaded = SecForms.load()
+    assert loaded.get_form("1-A").sec_number == "SEC486"

--- a/tests/test_forms_listing.py
+++ b/tests/test_forms_listing.py
@@ -22,6 +22,7 @@ No network: `download_file` is patched, which is also what keeps `list_forms`'s
 from pathlib import Path
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 from edgar.config import SEC_BASE_URL
@@ -222,9 +223,14 @@ def test_repr_renders_without_error(forms):
     assert "1-A" in repr(forms)
 
 
-@pytest.mark.xfail(strict=True, reason="edgartools-07rg: SecForms.load() double-wraps list_forms()")
 def test_load_returns_usable_forms():
-    download = _serve()
-    with patch("edgar.forms.download_file", download):
+    """Regression for edgartools-07rg: `load()` used to wrap a `SecForms` in another
+    `SecForms`, so `.data` was not a DataFrame and `summary()`/`repr()` raised a
+    pandas `SyntaxError` that never mentioned forms."""
+    with patch("edgar.forms.download_file", _serve()):
         loaded = SecForms.load()
+
+    assert isinstance(loaded.data, pd.DataFrame)
     assert loaded.get_form("1-A").sec_number == "SEC486"
+    assert list(loaded.summary().columns) == ["Form", "Description", "Topics"]
+    assert "1-A" in repr(loaded)

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -1,0 +1,298 @@
+"""Direct coverage of `edgar/_party.py`, the shared party/address value layer.
+
+`_party` is imported by 18 modules — Form D, Form 144, Form 3/4/5 ownership, 13F,
+Schedule 13D/G, Form C, muni advisors, EFFECT, SGML headers, `_filings` — but until
+now it was only ever exercised *indirectly*, through `FormD.from_xml`. Bead
+edgartools-07lk.11.1 asks for direct coverage before the bs4 to lxml port
+(edgartools-07lk.11.2) touches the one bs4 surface it has: `Issuer.from_xml`.
+
+The port's failure mode is silence: helpers return `None` instead of values, and these
+constructors build objects full of empty fields rather than raising. The assertions
+below are on values, so that silence shows up as a failure.
+
+See tests/test_xmltools_semantics.py for the helper-level contract.
+"""
+from bs4 import BeautifulSoup
+
+from edgar._party import (
+    Address,
+    Contact,
+    Filer,
+    Issuer,
+    Name,
+    Person,
+    get_addresses_as_columns,
+)
+
+# The <primaryIssuer> block from data/D.1685REIT.xml, trimmed to the parsed fields.
+ISSUER_XML = """<?xml version="1.0"?>
+<primaryIssuer>
+    <cik>0001961089</cik>
+    <entityName>1685 38th REIT, L.L.C.</entityName>
+    <issuerAddress>
+        <street1>2029 CENTURY PARK EAST</street1>
+        <street2>SUITE 1370</street2>
+        <city>LOS ANGELES</city>
+        <stateOrCountry>CA</stateOrCountry>
+        <stateOrCountryDescription>CALIFORNIA</stateOrCountryDescription>
+        <zipCode>90067</zipCode>
+    </issuerAddress>
+    <issuerPhoneNumber>424-313-1550</issuerPhoneNumber>
+    <jurisdictionOfInc>DELAWARE</jurisdictionOfInc>
+    <issuerPreviousNameList>
+        <value>None</value>
+    </issuerPreviousNameList>
+    <edgarPreviousNameList>
+        <value>None</value>
+    </edgarPreviousNameList>
+    <entityType>Limited Liability Company</entityType>
+    <yearOfInc>
+        <withinFiveYears>true</withinFiveYears>
+        <value>2022</value>
+    </yearOfInc>
+</primaryIssuer>
+"""
+
+
+def _issuer_element(xml: str = ISSUER_XML):
+    """Parse a `<primaryIssuer>` block the way `FormD.from_xml` does.
+
+    THE ONE LINE THAT CHANGES when `_party` moves to lxml (edgartools-07lk.11.3).
+    """
+    return BeautifulSoup(xml, features="xml").find("primaryIssuer")
+
+
+# ------------------------------------------------------------ Issuer.from_xml
+
+
+def test_issuer_from_xml_reads_every_field():
+    """Ground truth: Form D filed by 1685 38th REIT, L.L.C. (CIK 0001961089)."""
+    issuer = Issuer.from_xml(_issuer_element())
+
+    assert issuer.cik == "0001961089"
+    assert issuer.entity_name == "1685 38th REIT, L.L.C."
+    assert issuer.entity_type == "Limited Liability Company"
+    assert issuer.phone_number == "424-313-1550"
+    assert issuer.jurisdiction == "DELAWARE"
+    assert issuer.year_of_incorporation == "2022"
+    assert issuer.incorporated_within_5_years is True
+
+
+def test_issuer_from_xml_reads_the_full_address():
+    address = Issuer.from_xml(_issuer_element()).primary_address
+
+    assert address.street1 == "2029 CENTURY PARK EAST"
+    assert address.street2 == "SUITE 1370"
+    assert address.city == "LOS ANGELES"
+    assert address.state_or_country == "CA"
+    assert address.state_or_country_description == "CALIFORNIA"
+    assert address.zipcode == "90067"
+    assert not address.empty
+
+
+def test_issuer_previous_name_lists_drop_the_literal_none_placeholder():
+    """SEC writes `<value>None</value>` for "no previous names". It is not a name."""
+    issuer = Issuer.from_xml(_issuer_element())
+    assert issuer.issuer_previous_names == []
+    assert issuer.edgar_previous_names == []
+
+
+def test_issuer_previous_name_lists_keep_real_names_in_order():
+    xml = ISSUER_XML.replace(
+        "<issuerPreviousNameList>\n        <value>None</value>\n    </issuerPreviousNameList>",
+        "<issuerPreviousNameList>"
+        "<value>Old Name One</value>"
+        "<value>None</value>"
+        "<value>Old Name Two</value>"
+        "</issuerPreviousNameList>",
+    )
+    issuer = Issuer.from_xml(_issuer_element(xml))
+    assert issuer.issuer_previous_names == ["Old Name One", "Old Name Two"]
+
+
+def test_issuer_tolerates_missing_previous_name_lists():
+    xml = ISSUER_XML.replace("<issuerPreviousNameList>", "<absentList>").replace(
+        "</issuerPreviousNameList>", "</absentList>"
+    )
+    issuer = Issuer.from_xml(_issuer_element(xml))
+    assert issuer.issuer_previous_names == []
+
+
+def test_issuer_without_an_address_gets_an_empty_address_not_none():
+    """The address is always an `Address`; absence shows up as `.empty`, not `None`."""
+    xml = ISSUER_XML.replace("issuerAddress", "someOtherBlock")
+    issuer = Issuer.from_xml(_issuer_element(xml))
+
+    assert issuer.primary_address is not None
+    assert issuer.primary_address.empty
+    assert issuer.primary_address.street1 is None
+    # The scalar fields are still read.
+    assert issuer.cik == "0001961089"
+
+
+def test_issuer_not_incorporated_within_five_years():
+    xml = ISSUER_XML.replace("<withinFiveYears>true<", "<withinFiveYears>false<")
+    assert Issuer.from_xml(_issuer_element(xml)).incorporated_within_5_years is False
+
+
+def test_issuer_without_a_year_of_incorporation_block_is_falsy_not_a_crash():
+    """`incorporated_within_5_years` is built with `and`, so a missing block yields
+    `None` rather than `False` — falsy either way, and pinned here because the lxml
+    port changes what a missing element evaluates to."""
+    xml = ISSUER_XML.replace("yearOfInc", "someOtherBlock")
+    issuer = Issuer.from_xml(_issuer_element(xml))
+
+    assert not issuer.incorporated_within_5_years
+    assert issuer.year_of_incorporation is None
+
+
+# ------------------------------------------------------------------- Address
+
+
+def test_address_empty_is_true_only_when_every_location_field_is_blank():
+    assert Address().empty
+    assert Address(state_or_country_description="CALIFORNIA").empty  # not a location on its own
+    assert not Address(street1="1 Main St").empty
+    assert not Address(city="Boston").empty
+    assert not Address(zipcode="02101").empty
+
+
+def test_address_from_dict_maps_the_sgml_header_keys():
+    address = Address.from_dict(
+        {"STREET1": "1 Main St", "STREET2": "Floor 3", "CITY": "Boston", "STATE": "MA", "ZIP": "02101"}
+    )
+    assert address.street1 == "1 Main St"
+    assert address.street2 == "Floor 3"
+    assert address.city == "Boston"
+    assert address.state_or_country == "MA"
+    assert address.zipcode == "02101"
+    assert address.state_or_country_description is None
+
+
+def test_address_from_dict_tolerates_missing_keys():
+    assert Address.from_dict({}).empty
+
+
+def test_address_str_renders_two_or_three_lines():
+    one_line = Address(street1="1 Main St", city="Boston", state_or_country="MA", zipcode="02101")
+    assert str(one_line) == "1 Main St\nBoston, MA 02101"
+
+    with_street2 = Address(
+        street1="1 Main St", street2="Floor 3", city="Boston", state_or_country="MA", zipcode="02101"
+    )
+    assert str(with_street2) == "1 Main St\nFloor 3\nBoston, MA 02101"
+
+
+def test_address_str_prefers_the_state_description_over_the_code():
+    address = Address(
+        street1="2029 CENTURY PARK EAST",
+        city="LOS ANGELES",
+        state_or_country="CA",
+        state_or_country_description="CALIFORNIA",
+        zipcode="90067",
+    )
+    assert str(address) == "2029 CENTURY PARK EAST\nLOS ANGELES, CALIFORNIA 90067"
+
+
+def test_address_str_without_a_street_is_empty():
+    assert str(Address(city="Boston", state_or_country="MA")) == ""
+
+
+def test_address_str_without_a_zipcode_does_not_print_none():
+    address = Address(street1="1 Main St", city="Boston", state_or_country="MA")
+    assert str(address) == "1 Main St\nBoston, MA "
+    assert "None" not in str(address)
+
+
+# --------------------------------------------------- get_addresses_as_columns
+
+
+def test_get_addresses_as_columns_includes_only_the_non_empty_addresses():
+    mailing = Address(street1="PO Box 1", city="Boston", state_or_country="MA", zipcode="02101")
+    business = Address(street1="1 Main St", city="Boston", state_or_country="MA", zipcode="02101")
+
+    both = get_addresses_as_columns(mailing_address=mailing, business_address=business)
+    assert len(both.renderables) == 2
+
+    one = get_addresses_as_columns(mailing_address=mailing, business_address=Address())
+    assert len(one.renderables) == 1
+
+    neither = get_addresses_as_columns(mailing_address=None, business_address=None)
+    assert len(neither.renderables) == 0
+
+
+# -------------------------------------------------------------------- Person
+
+
+def test_person_carries_relationships_and_clarification():
+    person = Person(
+        first_name="Daniel",
+        last_name="Belldegrun",
+        address=Address(city="LOS ANGELES", state_or_country="CA"),
+        relationships=["Executive Officer", "Director"],
+        relationship_clarification="Manager of the Managing Member",
+    )
+    assert repr(person) == "Daniel Belldegrun"
+    assert person.relationships == ["Executive Officer", "Director"]
+    assert person.relationship_clarification == "Manager of the Managing Member"
+
+
+def test_person_without_relationships_gets_an_empty_list_not_none():
+    """Contexts that carry no relationship still get a list, so callers can iterate."""
+    assert Person(first_name="Ada", last_name="Lovelace").relationships == []
+
+
+def test_person_str_uses_the_full_name():
+    """Regression: `__str__` used to interpolate `first_name` twice (edgartools-uyhs)."""
+    assert str(Person(first_name="Daniel", last_name="Belldegrun")) == "Daniel Belldegrun"
+
+
+# ---------------------------------------------------------------------- Name
+
+
+def test_name_full_name_joins_the_parts():
+    assert Name(first_name="John", middle_name="Q", last_name="Public").full_name == "John Q Public"
+    assert (
+        Name(first_name="John", middle_name="Q", last_name="Public", suffix="Jr.").full_name
+        == "John Q Public Jr."
+    )
+
+
+def test_name_full_name_without_a_middle_name():
+    """Regression for edgartools-n921: this used to raise TypeError.
+
+    `child_text` returns None for an absent `<middleName>` (edgar/muniadvisors.py:370),
+    so this is the common case for muni advisors, not an edge case.
+    """
+    assert Name(first_name="John", middle_name=None, last_name="Public").full_name == "John Public"
+
+
+def test_name_full_name_with_a_blank_middle_name_does_not_double_space():
+    """The other half of n921: `' ' + ''` was a truthy single space."""
+    assert Name(first_name="John", middle_name="", last_name="Public").full_name == "John Public"
+
+
+def test_name_full_name_keeps_the_nmn_placeholder():
+    """SEC writes the literal 'NMN' for no-middle-name; it is data, not absence.
+
+    Ground truth: muni advisor Michael Tym, tests/test_muni_advisors.py:148.
+    """
+    assert Name(first_name="Michael", middle_name="NMN", last_name="Tym", suffix="Jr.").full_name == (
+        "Michael NMN Tym Jr."
+    )
+
+
+# --------------------------------------------------------- Filer and Contact
+
+
+def test_filer_renders_name_and_cik():
+    filer = Filer(cik="0000320193", entity_name="Apple Inc.", file_number="001-36743")
+    assert str(filer) == "Apple Inc. (0000320193)"
+    assert repr(filer) == "Apple Inc. (0000320193)"
+    assert filer.file_number == "001-36743"
+
+
+def test_contact_renders_name_phone_and_email():
+    contact = Contact(name="Jane Roe", phone_number="617-555-0100", email="jane@example.com")
+    assert str(contact) == "Jane Roe (617-555-0100) jane@example.com"
+    assert repr(contact) == str(contact)

--- a/tests/test_xmltools_semantics.py
+++ b/tests/test_xmltools_semantics.py
@@ -1,0 +1,317 @@
+"""Characterization tests pinning the `edgar.xmltools` contract across the lxml port.
+
+`edgar/xmltools.py` is the shared XML helper layer for 12 parsers (Form D, Form 144,
+Form 3/4/5 ownership, 13F, Schedule 13D/G, muni advisors, EFFECT, filing summaries).
+Bead edgartools-07lk.11.2 moves it from BeautifulSoup to `lxml.etree` with unchanged
+signatures, so ~350 call sites keep compiling whether or not their behavior survives.
+
+That is the risk these tests exist for. Every difference below was verified against the
+bs4 and lxml versions installed in this repo, and every one of them fails *silently* —
+a naive port returns `None` or `""` where it used to return a value, and the parsers go
+on to build objects full of empty fields rather than raising.
+
+    truthiness  bs4 `bool(Tag)` is True even for a childless `<c/>`; lxml
+                `bool(Element)` is False even for `<b>text</b>` (and warns).
+                `child_text`/`child_value`/`value_or_footnote`/`value_with_footnotes`
+                all guard with a bare `if el`, so a direct port makes every one of
+                them return None. Use `el is not None`.
+
+    find depth  bs4 `.find()` searches all descendants; lxml `.find()` searches
+                direct children only. Descendant search needs `.//name`.
+
+    .text       bs4 `.text` concatenates all descendant text; lxml `.text` is only
+                the text before the first child element. Use `"".join(itertext())`.
+
+    whitespace  the two backends do not agree on interior whitespace between
+                elements, which shows up in any helper returning subtree text.
+
+The assertions call the helpers, never the backend, so they must hold unchanged after
+the port. `_root` below is the single line that changes.
+"""
+from decimal import Decimal
+
+from bs4 import BeautifulSoup
+
+from edgar.xmltools import (
+    child_text,
+    child_texts,
+    child_value,
+    extract_child_text,
+    extract_child_value,
+    find_element,
+    get_footnote_ids,
+    optional_decimal,
+    value_or_footnote,
+    value_with_footnotes,
+)
+
+# A Form D <primaryIssuer> block, the shape edgar/_party.py:86-111 documents.
+ISSUER_XML = """<?xml version="1.0"?>
+<edgarSubmission>
+    <primaryIssuer>
+        <cik>0001961089</cik>
+        <entityName>1685 38th REIT, L.L.C.</entityName>
+        <issuerAddress>
+            <street1>2029 CENTURY PARK EAST</street1>
+            <street2>SUITE 1370</street2>
+            <city>LOS ANGELES</city>
+            <stateOrCountry>CA</stateOrCountry>
+            <zipCode>90067</zipCode>
+        </issuerAddress>
+        <issuerPhoneNumber>424-313-1550</issuerPhoneNumber>
+        <edgarPreviousNameList>
+            <value>None</value>
+        </edgarPreviousNameList>
+        <entityType/>
+        <yearOfInc>
+            <withinFiveYears>true</withinFiveYears>
+            <value>2022</value>
+        </yearOfInc>
+    </primaryIssuer>
+</edgarSubmission>
+"""
+
+
+def _root(xml: str, name: str):
+    """Parse `xml` and return the element named `name`.
+
+    THE ONE LINE THAT CHANGES when xmltools moves to lxml (edgartools-07lk.11.2).
+    Everything below asserts on the helpers' return values, not on the backend.
+    """
+    return BeautifulSoup(xml, features="xml").find(name)
+
+
+def issuer():
+    return _root(ISSUER_XML, "primaryIssuer")
+
+
+# ---------------------------------------------------------------- child_text
+
+
+def test_child_text_reads_an_element_that_has_no_element_children():
+    """The truthiness trap, in the single most-called helper.
+
+    `<cik>` holds text and nothing else, so it has zero *element* children. lxml
+    considers such an element false, and `child_text`'s `if el` guard would drop it.
+    """
+    assert child_text(issuer(), "cik") == "0001961089"
+    assert child_text(issuer(), "issuerPhoneNumber") == "424-313-1550"
+
+
+def test_child_text_searches_descendants_not_only_direct_children():
+    """`<city>` is a grandchild of `<primaryIssuer>`, and bs4 `.find()` reaches it.
+
+    lxml `.find("city")` would not — it needs `.//city`. Callers rely on the reach:
+    see edgar/_party.py:157-162, which only descends to `<issuerAddress>` explicitly
+    because the address fields are ambiguous, not because the helper cannot get there.
+    """
+    assert child_text(issuer(), "city") == "LOS ANGELES"
+    assert child_text(issuer(), "zipCode") == "90067"
+
+
+def test_child_text_concatenates_all_descendant_text():
+    """`.text` on a container returns the whole subtree's text, not the head text.
+
+    lxml's `.text` would return only the whitespace before `<street1>`, which strips
+    to `""` — a silent empty string rather than an error.
+    """
+    address = child_text(issuer(), "issuerAddress")
+    for fragment in ("2029 CENTURY PARK EAST", "SUITE 1370", "LOS ANGELES", "CA", "90067"):
+        assert fragment in address
+
+
+def test_child_text_preserves_interior_whitespace_exactly():
+    """Pins the interior spacing of concatenated text, which the backends disagree on.
+
+    bs4 and lxml produce different separators between sibling elements' text. Only the
+    outer edges are stripped, so any change here reaches callers that compare or hash
+    these strings.
+    """
+    xml = "<r><d>  <e>Y</e>  <f>Z</f> </d></r>"
+    assert child_text(_root(xml, "r"), "d") == "Y Z"
+
+
+def test_child_text_of_an_empty_element_is_empty_string_not_none():
+    """`<entityType/>` yields `""`. The distinction matters: `None` means *absent*."""
+    assert child_text(issuer(), "entityType") == ""
+
+
+def test_child_text_of_a_missing_element_is_none():
+    assert child_text(issuer(), "notAnElement") is None
+
+
+def test_child_text_ignores_comments():
+    xml = "<r><b><!-- editorial note --><c>X</c></b></r>"
+    assert child_text(_root(xml, "r"), "b") == "X"
+
+
+def test_child_text_strips_surrounding_whitespace():
+    xml = "<r><a>\n    padded\n  </a></r>"
+    assert child_text(_root(xml, "r"), "a") == "padded"
+
+
+# --------------------------------------------------------------- child_value
+
+
+def test_child_value_unwraps_the_nested_value_element():
+    """`child_value` reaches through a wrapper to its `<value>`, `child_text` does not."""
+    assert child_value(issuer(), "yearOfInc") == "2022"
+    # child_text on the same wrapper returns the whole subtree instead, separator included.
+    assert child_text(issuer(), "yearOfInc") == "true\n2022"
+
+
+def test_child_value_returns_the_default_when_the_child_is_missing():
+    assert child_value(issuer(), "notAnElement") is None
+    assert child_value(issuer(), "notAnElement", default_value="fallback") == "fallback"
+
+
+def test_child_value_of_a_present_child_without_a_value_element_is_empty():
+    """Present-but-valueless is `""`, distinct from the missing-child default.
+
+    A caller passing `default_value` does NOT get it here — the child exists.
+    """
+    xml = "<r><child>bare text</child></r>"
+    assert child_value(_root(xml, "r"), "child", default_value="fallback") == ""
+
+
+def test_child_value_appends_footnote_references():
+    xml = """<r>
+        <underlyingSecurityTitle>
+            <value>Class B Common Stock</value>
+            <footnoteId id="F2"/>
+            <footnoteId id="F3"/>
+        </underlyingSecurityTitle>
+    </r>"""
+    assert child_value(_root(xml, "r"), "underlyingSecurityTitle") == "Class B Common Stock [F2,F3]"
+
+
+# --------------------------------------------------------------- child_texts
+
+
+def test_child_texts_returns_every_match_in_document_order():
+    xml = """<r>
+        <relationship>Executive Officer</relationship>
+        <relationship>Director</relationship>
+        <relationship>Promoter</relationship>
+    </r>"""
+    assert child_texts(_root(xml, "r"), "relationship") == [
+        "Executive Officer",
+        "Director",
+        "Promoter",
+    ]
+
+
+def test_child_texts_of_a_missing_element_is_an_empty_list():
+    assert child_texts(issuer(), "notAnElement") == []
+
+
+def test_child_texts_does_not_strip():
+    """Unlike `child_text`, `child_texts` returns raw text. Pinned because callers
+    downstream do their own stripping and would double-strip or stop stripping."""
+    xml = "<r><a> spaced </a></r>"
+    assert child_texts(_root(xml, "r"), "a") == [" spaced "]
+
+
+# ----------------------------------------------------------- optional_decimal
+
+
+def test_optional_decimal_parses_zero_as_a_decimal():
+    """`"0"` must not be confused with absence — SEC fund tables are full of real zeros."""
+    xml = "<fundInfo><totAssets>0</totAssets><amt>0.018</amt></fundInfo>"
+    fund = _root(xml, "fundInfo")
+    assert optional_decimal(fund, "totAssets") == Decimal("0")
+    assert optional_decimal(fund, "amt") == Decimal("0.018")
+
+
+def test_optional_decimal_treats_na_and_absence_and_emptiness_as_none():
+    xml = "<fundInfo><na>N/A</na><blank/></fundInfo>"
+    fund = _root(xml, "fundInfo")
+    assert optional_decimal(fund, "na") is None
+    assert optional_decimal(fund, "blank") is None
+    assert optional_decimal(fund, "notAnElement") is None
+
+
+# --------------------------------------------------------------- find_element
+
+
+def test_find_element_accepts_a_raw_xml_string():
+    root = find_element(ISSUER_XML, "primaryIssuer")
+    assert root is not None
+    assert child_text(root, "cik") == "0001961089"
+
+
+def test_find_element_accepts_an_already_parsed_element():
+    root = find_element(issuer(), "issuerAddress")
+    assert root is not None
+    assert child_text(root, "city") == "LOS ANGELES"
+
+
+def test_find_element_returns_none_for_a_missing_name_or_a_non_xml_string():
+    assert find_element(ISSUER_XML, "notAnElement") is None
+    assert find_element("not xml at all", "primaryIssuer") is None
+
+
+# ------------------------------------------------- footnotes (Form 3/4/5 tier)
+
+
+def test_get_footnote_ids_joins_on_the_requested_separator():
+    xml = """<r><t><footnoteId id="F2"/><footnoteId id="F3"/></t></r>"""
+    tag = find_element(_root(xml, "r"), "t")
+    assert get_footnote_ids(tag) == "F2,F3"
+    assert get_footnote_ids(tag, sep="|") == "F2|F3"
+
+
+def test_get_footnote_ids_is_empty_when_there_are_none():
+    xml = "<r><t><value>plain</value></t></r>"
+    assert get_footnote_ids(find_element(_root(xml, "r"), "t")) == ""
+
+
+def test_value_with_footnotes_returns_bare_footnotes_when_there_is_no_value():
+    xml = """<r><expirationDate><footnoteId id="F1"/></expirationDate></r>"""
+    assert value_with_footnotes(find_element(_root(xml, "r"), "expirationDate")) == "[F1]"
+
+
+def test_value_with_footnotes_returns_the_bare_value_when_there_are_no_footnotes():
+    xml = "<r><securityTitle><value>Series E Preferred Stock</value></securityTitle></r>"
+    assert value_with_footnotes(find_element(_root(xml, "r"), "securityTitle")) == "Series E Preferred Stock"
+
+
+def test_value_or_footnote_prefers_the_value():
+    xml = """<r><c><value>Music</value><footnoteId id="F1"/></c></r>"""
+    assert value_or_footnote(find_element(_root(xml, "r"), "c")) == "Music"
+
+
+def test_value_or_footnote_falls_back_to_footnote_then_footnote_id():
+    footnote = "<r><c><footnote id=\"F1\"/></c></r>"
+    footnote_id = "<r><c><footnoteId id=\"F9\"/></c></r>"
+    assert value_or_footnote(find_element(_root(footnote, "r"), "c")) == "F1"
+    assert value_or_footnote(find_element(_root(footnote_id, "r"), "c")) == "F9"
+
+
+def test_value_or_footnote_of_an_empty_value_element_is_empty_not_a_footnote():
+    """An empty `<value/>` still wins over the footnote fallback.
+
+    This is the truthiness trap at its sharpest: under lxml `if value_el` is false and
+    the helper would silently return the footnote id instead of the empty value.
+    """
+    xml = """<r><c><value/><footnoteId id="F1"/></c></r>"""
+    assert value_or_footnote(find_element(_root(xml, "r"), "c")) == ""
+
+
+def test_value_or_footnote_is_none_when_there_is_neither():
+    xml = "<r><c/></r>"
+    assert value_or_footnote(find_element(_root(xml, "r"), "c")) is None
+
+
+# ------------------------------------------------------- dict-building helpers
+
+
+def test_extract_child_text_returns_a_key_value_pair():
+    assert extract_child_text(issuer(), "cik", "cik") == ("cik", "0001961089")
+    assert extract_child_text(issuer(), "phone", "issuerPhoneNumber") == ("phone", "424-313-1550")
+    assert extract_child_text(issuer(), "missing", "notAnElement") == ("missing", None)
+
+
+def test_extract_child_value_returns_a_key_value_pair():
+    assert extract_child_value(issuer(), "year", "yearOfInc") == ("year", "2022")
+    assert extract_child_value(issuer(), "missing", "notAnElement") == ("missing", None)


### PR DESCRIPTION
Groundwork for the bs4 → lxml migration (`07lk.11`), plus the defects that writing it exposed.

**Merge order:** this is 1 of 3. `perf/xmltools-dual-backend-adapter` sits on top of it, and `perf/current-filings-lxml` on top of that.

## Why

`edgar/xmltools.py` is the shared XML helper layer under twelve parsers — Form D, Form 144, Form 3/4/5 ownership, 13F, Schedule 13D/G, muni advisors, EFFECT, filing summaries — with roughly 350 call sites reaching it. Phase 1 of the migration rewrites it with unchanged signatures, so every one of those call sites keeps compiling whether or not its behavior survives. Nothing in the suite would have told us which.

Four differences between the backends, each verified against the versions installed in this repo, and each one **silent** — a naive port returns `None` or `""` where a value used to be, and the parsers go on to build objects full of empty fields rather than raising:

| | bs4 | lxml |
|---|---|---|
| `bool(el)` | True even for a childless `<c/>` | **False even for `<b>text</b>`** |
| `.find(name)` | all descendants | direct children only |
| `.text` | whole subtree | stops at the first child |
| interior whitespace | `'Y Z'` | `'Y  Z'` |

The first is the dangerous one: every guard in `xmltools` reads `if el and isinstance(el, Tag)`, so a direct translation makes **every `child_text()` return `None`**.

## What is here

- **`tests/test_xmltools_semantics.py`** — the contract of all ten helpers, organized by those four axes. Each axis has at least one test a naive port turns red. The sharpest is `value_or_footnote` on an empty `<value/>`: under lxml it silently returns the footnote id instead of `""`.
- **`tests/test_party.py`** — direct coverage of `edgar/_party.py`, imported by 18 modules but until now exercised only indirectly through `FormD.from_xml`. Ground truth is the Form D filed by 1685 38th REIT, L.L.C. (CIK 0001961089).
- **`tests/test_forms_listing.py`** and its fixture — `list_forms()` against the real SEC forms table captured 2026-08-18, trimmed to the `<table>` the parser actually reads (25KB rather than the 108KB page). A second, synthetic fixture pins the defensive branches the live page no longer exercises: the `Number:` / `Description:` inline label prefixes from SEC's older responsive layout, and a description cell with no link.

Each file routes parsing through a single helper marked as the line that changes at port time, and every assertion is on helper return values, so the suite must survive the port unchanged.

## Three defects found while writing it

- **`Name.full_name` raised `TypeError` when `middle_name` was `None`.** Precedence bug: `(' ' + middle_name) or ''` concatenates before the fallback can fire. `edgar/muniadvisors.py:370` feeds it `child_text` output, so every municipal advisor whose XML omits `<middleName>` crashed — the common case, not an edge case.
- **`str(person)` printed the first name twice.** `__repr__` was always correct, which is why Rich tables and notebook output looked right while string interpolation did not.
- **`SecForms.load()` double-wrapped `list_forms()`**, putting a `SecForms` in `.data` where a DataFrame belongs. `summary()` and `repr()` then raised a pandas `SyntaxError: invalid syntax` that never mentions forms.

All three are fixed here with regression tests, and `middle_name`'s type hint is corrected to `Optional[str]` — it claimed `str` while every caller feeds it `child_text` output, and `py.typed` now ships that claim to downstream type checkers.

## Verification

72 tests across the three files, all passing with **outbound sockets blocked** (`pytest -p tests._offline_harness`) — measured, not assumed, per the repo's own classification rule. Full fast suite green at 5247. `test_party` and `test_forms_listing` are registered in `FAST_PATTERNS` so they actually run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
