### PR TITLE
fix(xmltools): recover from malformed XML the way bs4 did (07lk.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Form 4 whose XML the SEC did not write quite correctly came back as raw markup instead of a rendered form.** `BeautifulSoup(xml, "xml")` parses with `recover=True`, so for years edgartools read filings like AAR CORP's 2004-02-04 Form 4 — which carries a mangled `<nonDerivativeTable ativeTable>` attribute — without anyone noticing they were malformed. The move to lxml made parsing strict, and `filing.sgml().text()` on those filings went back to dumping `<ownershipDocument>` tags. `xmltools.parse_xml` now recovers exactly as bs4 did, which restores the behaviour for every form migrated so far, not just Forms 3/4/5. A document with no markup at all is still an error.
+
 - **A person's name raised `TypeError` whenever they had no middle name.** `Name.full_name` built the middle segment as `(' ' + middle_name) or ''`, so the concatenation ran before the fallback could apply and a missing middle name crashed instead of being skipped. Municipal advisor filings hit this constantly — the parser feeds that field straight from the XML, which simply omits `<middleName>`. Michael NMN Tym Jr. still reads as `Michael NMN Tym Jr.`, since `NMN` is data the SEC writes, not an absence.
 
 - **`str(person)` printed the first name twice** instead of the full name. `repr()` was always correct, which is why Rich tables and notebook output looked right while string interpolation did not.

--- a/edgar/xmltools.py
+++ b/edgar/xmltools.py
@@ -189,20 +189,37 @@ def parse_xml(xml: Union[str, bytes]) -> etree._Element:
                      overrides the declaration, which is correct because the `str`
                      was decoded by whoever produced it.
 
+      recovery     SEC's own XML is not always well-formed, and bs4 hid that for
+                   years: `BeautifulSoup(xml, "xml")` builds its parser with
+                   `recover=True`, so a document carrying an attribute like
+                   `<nonDerivativeTable ativeTable>` parsed fine. A strict parser
+                   rejects it outright. That is not hypothetical — AAR CORP's
+                   2004-02-04 Form 4 (0000001750-04-000011) is exactly this shape,
+                   and strictness turned it from a rendered Form 4 into a dump of
+                   raw markup. Recovery is what makes bs4's behavior the contract
+                   rather than an aspiration.
+
     `bytes` are passed through with their declaration intact — those came off the
     wire undecoded, so the declaration is the only encoding information there is.
 
-    Unlike bs4, this raises `etree.XMLSyntaxError` on a document that is not XML at
-    all instead of returning a near-empty tree. Callers that must tolerate SEC
-    serving something else (an HTML error page, say) should parse with
-    `etree.XMLParser(recover=True)` themselves and say why.
+    A document that is not XML at all is still an error, just a different one. An
+    HTML error page recovers to an `<html>` root, which every caller's root check
+    rejects with a clear "expected <edgarSubmission>" — a better message than a
+    parse error at this level. Content with no markup at all recovers to nothing,
+    and lxml signals that by returning None from `fromstring`; that is re-raised
+    here as `XMLSyntaxError`, because a caller handed None fails several frames
+    later with an AttributeError naming the wrong thing.
     """
     if isinstance(xml, str):
         # A fresh parser per call: lxml parsers hold mutable state and must not be
         # shared across threads, and edgartools parses on worker threads.
-        return etree.fromstring(xml.lstrip('\ufeff \t\r\n').encode('utf-8'),
-                                parser=etree.XMLParser(encoding='utf-8'))
-    return etree.fromstring(xml.lstrip())
+        root = etree.fromstring(xml.lstrip('\ufeff \t\r\n').encode('utf-8'),
+                                parser=etree.XMLParser(encoding='utf-8', recover=True))
+    else:
+        root = etree.fromstring(xml.lstrip(), parser=etree.XMLParser(recover=True))
+    if root is None:
+        raise etree.XMLSyntaxError("Document is not XML: nothing recoverable", None, 1, 1)
+    return root
 
 
 def find_element(

--- a/tests/test_insider_parse_contract.py
+++ b/tests/test_insider_parse_contract.py
@@ -96,3 +96,37 @@ def test_a_transaction_footnote_id_is_read_from_an_empty_element():
     assert transaction_footnote_id(find_element(root, "footnoteId")) == ('footnote', 'F1')
     # Deduped, first-seen order preserved, collected from the whole transaction.
     assert get_footnotes(root) == "F1\nF2"
+
+
+def test_malformed_ownership_xml_still_parses():
+    """SEC's own Forms 4 are not always well-formed, and bs4 recovered from that.
+
+    AAR CORP's 2004-02-04 Form 4 (0000001750-04-000011) carries a mangled attribute
+    — `<nonDerivativeTable ativeTable>`, reproduced here — which a strict parser
+    rejects outright. bs4 built its XML parser with `recover=True` and read the
+    filing fine for years, so `xmltools.parse_xml` does too.
+
+    This is pinned at the ownership layer as well as in the adapter contract
+    because of how it failed: `edgar/sgml/text_extraction.ownership_xml_to_html`
+    catches every exception and returns None, so a raising parse did not surface as
+    an error — `filing.sgml().text()` quietly went back to dumping raw markup, and
+    only the network regression lane noticed (edgartools-07lk.11.3).
+    """
+    root = parse_xml(
+        "<ownershipDocument><schemaVersion>X0201</schemaVersion>"
+        "<documentType>4</documentType><periodOfReport>2004-01-07</periodOfReport>"
+        "<issuer><issuerCik>0000001750</issuerCik><issuerName>AAR CORP</issuerName>"
+        "<issuerTradingSymbol>AIR</issuerTradingSymbol></issuer>"
+        "<nonDerivativeTable ativeTable>"
+        "<nonDerivativeTransaction><securityTitle><value>Common Stock</value>"
+        "</securityTitle></nonDerivativeTransaction>"
+        "</nonDerivativeTable></ownershipDocument>")
+
+    from edgar.xmltools import child_text, local_name
+
+    assert local_name(root) == "ownershipDocument"
+    assert child_text(root, "documentType") == "4"
+    assert child_text(root, "issuerTradingSymbol") == "AIR"
+    # The content *after* the malformed attribute survives recovery too, which is
+    # the part that decides whether the rendered form has any rows in it.
+    assert child_text(root, "value") == "Common Stock"

--- a/tests/test_xmltools_semantics.py
+++ b/tests/test_xmltools_semantics.py
@@ -478,11 +478,41 @@ def test_parse_xml_honors_the_encoding_declaration_on_bytes():
     assert child_text(parse_xml(xml.encode("ISO-8859-1")), "entityName") == "Café"
 
 
-def test_parse_xml_raises_on_a_document_that_is_not_xml():
-    """The one place the port is deliberately stricter than bs4, which returned a
-    near-empty tree and let the failure surface as `None` several frames later."""
+def test_parse_xml_recovers_from_malformed_markup_exactly_as_bs4_did():
+    """`BeautifulSoup(xml, "xml")` parses with `recover=True`, so this has to too.
+
+    SEC's own XML is not always well-formed. AAR CORP's 2004-02-04 Form 4
+    (0000001750-04-000011) carries a mangled attribute — the shape reproduced here —
+    and bs4 absorbed it for years. A strict parser rejects the whole document, and
+    because `ownership_xml_to_html` catches every exception, the failure showed up
+    not as an error but as a filing's text turning back into raw markup
+    (edgartools-07lk.11.3). Recovery is part of the contract, not a leniency.
+    """
+    root = parse_xml('<ownershipDocument><documentType>4</documentType>'
+                     '<nonDerivativeTable ativeTable><x>y</x></nonDerivativeTable>'
+                     '</ownershipDocument>')
+    assert local_name(root) == "ownershipDocument"
+    assert child_text(root, "documentType") == "4"
+
+
+def test_parse_xml_leaves_a_non_xml_document_for_the_caller_to_reject():
+    """An HTML error page is not a parse failure any more — it is a wrong document.
+
+    It recovers to an `<html>` root, which every dependent's `local_name(root) !=
+    ...` check rejects by name. That is a better message than a parse error, and it
+    is what bs4 did.
+    """
+    assert local_name(parse_xml("<html><body>503 Service Unavailable</body>")) == "html"
+
+
+def test_parse_xml_still_raises_when_there_is_no_markup_to_recover():
+    """Recovery has a floor. lxml returns None rather than raising for content with
+    no markup at all, and a caller handed None fails several frames later with an
+    AttributeError naming the wrong thing — so it is re-raised here."""
     with pytest.raises(etree.XMLSyntaxError):
-        parse_xml("<html><body>503 Service Unavailable</body>")
+        parse_xml("Your request rate has exceeded the SEC limit.")
+    with pytest.raises(etree.XMLSyntaxError):
+        parse_xml("")
 
 
 def test_parse_xml_keeps_a_namespaced_root_addressable_by_local_name():


### PR DESCRIPTION
## What broke

`BeautifulSoup(xml, "xml")` builds its parser with `recover=True`. That is not incidental — it is why edgartools has read SEC's less well-formed documents for years without anyone noticing they were malformed. The lxml port made `parse_xml` strict, so those documents started failing.

**AAR CORP's 2004-02-04 Form 4** ([`0000001750-04-000011`](https://www.sec.gov/Archives/edgar/data/1750/000000175004000011/)) is the filing that surfaced it. Its XML carries a mangled attribute — `<nonDerivativeTable ativeTable>` — which a strict parser rejects outright:

```
lxml.etree.XMLSyntaxError: Specification mandates value for attribute ativeTable, line 2, column 11
```

## Why nobody saw it

`edgar/sgml/text_extraction.ownership_xml_to_html` catches every exception and returns `None`. So a raising parse did not surface as an error — `filing.sgml().text()` quietly went back to dumping `<ownershipDocument>` markup instead of a rendered Form 4, which is exactly the bug `edgartools-rck1` had already fixed once.

The only thing that caught it was `tests/issues/regression/test_issue_rck1_sgml_text_ownership_xml.py` in the **advisory** network regression lane — not a required check. It has been failing since #1058 merged:

| PR | regression lane |
|---|---|
| #1055 adapter | success |
| #1056 current_filings | success |
| #1057 effect | success |
| **#1058 ownership** | **failure** ← first |
| #1059 filing_summary | failure |
| #1060 13F | failure |
| **main** | **failure** |

## The fix

In the adapter, not at the ownership call site. The adapter's stated contract is bs4's behavior — "bs4's behavior is the contract, because ~350 call sites were written against it" — and strictness was a deviation from it. Every one of the nine migrated units had the same latent exposure to any malformed document; ownership is simply where a real filing happened to hit it first.

Recovery costs no error quality:

- an **HTML error page** recovers to an `<html>` root, which every dependent's `local_name(root) != ...` check rejects by name — a better message than a parse error at this level
- **content with no markup at all** recovers to nothing, and lxml signals that by returning `None` from `fromstring` rather than raising; that is re-raised here as `XMLSyntaxError`, because a caller handed `None` fails several frames later with an `AttributeError` naming the wrong thing
- an **empty document** still raises, as before

This reverses the "deliberately stricter than bs4" note in `parse_xml`'s docstring. That decision predates any evidence of malformed SEC documents; this PR is that evidence.

## Verification

Three tests, each verified to **fail** without the change and pass with it:

- `test_parse_xml_recovers_from_malformed_markup_exactly_as_bs4_did`
- `test_parse_xml_leaves_a_non_xml_document_for_the_caller_to_reject`
- `test_malformed_ownership_xml_still_parses` — at the ownership layer, since that is where the swallowed exception made the failure silent

`tests/issues/regression/test_issue_rck1_sgml_text_ownership_xml.py` goes from 2 failed to **5 passed, 1 xfailed** (the xfail is its documented `Filing.html()` limitation, unrelated).

Refs: edgartools-07lk.11.3, edgartools-rck1