### PR TITLE
test(conftest): tests/test_statement_view.py is a network file, not a fast one

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,6 +334,16 @@ def pytest_collection_modifyitems(config, items):
         'test_ncen', 'test_ncsr',
         # XBRL tests that need network (use Company() or XBRL.from_filing)
         'test_xbrl_periods',
+        # Classified 2026-08-19. Every fixture in tests/test_statement_view.py is
+        # `Company("AAPL").get_filings(form="10-K").latest().xbrl()` — three live
+        # fetches. It matched FAST_PATTERNS' 'test_statement' substring and so ran
+        # in the fast job, where it passed only for as long as the CI HTTP cache
+        # stayed warm; on a cold cache all 13 tests error with ConnectError and
+        # the required check fails for a reason unrelated to the pull request that
+        # happens to be running. Measured under tests/_offline_harness.py: 13
+        # errors offline, all 13 pass on the network. NETWORK_PATTERNS is matched
+        # first, so this entry wins over the 'test_statement' fast match.
+        'test_statement_view',
         # Classified 2026-08-04 (see the note in FAST_PATTERNS). These fail with
         # outbound sockets blocked, so they are network by measurement.
         'test_registration_s1', 'test_registration_s4', 'test_prospectus497k',


### PR DESCRIPTION
Every fixture in `tests/test_statement_view.py` is

```python
filing = Company("AAPL").get_filings(form="10-K").latest()
return filing.xbrl()
```

— three live fetches. The file matched `FAST_PATTERNS`' `test_statement` substring, so it ran in the **fast** job, where it passed only for as long as the CI HTTP cache stayed warm.

On a cold cache all 13 of its fixture-backed tests error with `httpx.ConnectError: [Errno 111] Connection refused`, and **`test-fast (3.13)` — a required check — fails for a reason that has nothing to do with the pull request that happens to be running.** That is what it did to #1065 ([run](https://github.com/dgunning/edgartools/actions/runs/32213749729)): 5314 passed, 13 errors, all in this one file, on a PR that does not touch it.

## Measured, not guessed

This is what the note above `FAST_PATTERNS` asks for — "Decide fast vs network by RUNNING the file with outbound sockets blocked, not by reading its name":

| run | result |
|---|---|
| `pytest -p tests._offline_harness tests/test_statement_view.py` | 7 passed, **13 errors** |
| `pytest -m network tests/test_statement_view.py` | **20 passed** |
| `pytest -m fast tests/test_statement_view.py` (after this change) | 20 deselected |

`NETWORK_PATTERNS` is matched before `FAST_PATTERNS`, so the new entry wins over the `test_statement` match.

Refs: edgartools-07lk.11.3