### PR TITLE
fix: five silent-wrong-output bugs found by the bs4->lxml migration corpus sweeps (MA-I, Form 144, Form D)

### DIFF
--- a/edgar/_party.py
+++ b/edgar/_party.py
@@ -80,6 +80,28 @@ def get_addresses_as_columns(*,
     return Columns(addresses, equal=True, expand=True)
 
 
+def _previous_names(previous_name_list_el: Optional[XmlNode]) -> List[str]:
+    """The previous-name entries of an `<...PreviousNameList>` element.
+
+    SEC writes these as `<value>` in most filings but `<previousName>` in others;
+    both spellings are collected, in document order, filtering the literal `'None'`
+    placeholder SEC writes for "no previous names" and any element that appears
+    under both spellings.
+    """
+    if previous_name_list_el is None:
+        return []
+    names = []
+    seen = set()
+    for el in (find_all_elements(previous_name_list_el, "value")
+              + find_all_elements(previous_name_list_el, "previousName")):
+        text = element_text(el)
+        if text == 'None' or text in seen:
+            continue
+        seen.add(text)
+        names.append(text)
+    return names
+
+
 class Issuer:
     """
      <primaryIssuer>
@@ -136,15 +158,11 @@ class Issuer:
     def from_xml(cls, issuer_el: XmlNode):
         # edgar previous names
         edgar_previous_names_el = find_element(issuer_el, "edgarPreviousNameList")
-        edgar_previous_names = [element_text(el)
-                                for el in find_all_elements(edgar_previous_names_el, "value")
-                                if element_text(el) != 'None'] if edgar_previous_names_el is not None else []
+        edgar_previous_names = _previous_names(edgar_previous_names_el)
 
         # issuer previous names
         issuer_previous_names_el = find_element(issuer_el, "issuerPreviousNameList")
-        issuer_previous_names = [element_text(el)
-                                 for el in find_all_elements(issuer_previous_names_el, "value")
-                                 if element_text(el) != 'None'] if issuer_previous_names_el is not None else []
+        issuer_previous_names = _previous_names(issuer_previous_names_el)
 
         year_of_inc_el = find_element(issuer_el, "yearOfInc")
 

--- a/edgar/form144.py
+++ b/edgar/form144.py
@@ -819,12 +819,14 @@ class Form144:
             file_number=child_text(filer_credentials_el, 'secFileNumber')
         )
 
-        # Contact info
-        contact_el = find_element(filer_el, 'contact')
+        # Contact info. <contact> is a sibling of <filer> under <filerInfo>,
+        # not a child of <filer> (edgartools-wsdm), and its children are
+        # contactName / contactPhoneNumber / contactEmailAddress.
+        contact_el = find_element(filer_info_el, 'contact')
         form144['contact'] = Contact(
-            name=child_text(contact_el, 'name'),
-            phone_number=child_text(contact_el, 'phone'),
-            email=child_text(contact_el, 'email')
+            name=child_text(contact_el, 'contactName'),
+            phone_number=child_text(contact_el, 'contactPhoneNumber'),
+            email=child_text(contact_el, 'contactEmailAddress')
         ) if contact_el is not None else None
 
         form_data = find_element(root, 'formData')

--- a/edgar/muniadvisors.py
+++ b/edgar/muniadvisors.py
@@ -15,7 +15,6 @@ from edgar.richtools import repr_rich
 from edgar.xmltools import (
     child_text,
     child_texts,
-    child_value,
     element_text,
     find_all_elements,
     find_element,
@@ -431,7 +430,9 @@ class MunicipalAdvisorForm:
             municipal_advisor_office = MunicipalAdvisorOffice(
                 cik=element_text(filer_el) if filer_el is not None else "",
                 firm_name=child_text(municipal_firm_el, 'municipalFirmName'),
-                is_independent_relationship=child_text(municipal_firm_el, 'isIndependentRelationship') == 'Y',
+                # 'isIndependentRelatioship' is the SEC schema's own misspelling
+                # (verified in 40/40 sampled MA-I filings) -- do not "fix" it back.
+                is_independent_relationship=child_text(municipal_firm_el, 'isIndependentRelatioship') == 'Y',
                 recent_employment_commenced_date=child_text(municipal_firm_el, 'recentEmploymentCommencedDate'),
                 file_number=file_number,
                 offices=offices
@@ -492,15 +493,15 @@ class MunicipalAdvisorForm:
         criminal_disclosure_el = find_element(disclosure_questions_el, 'criminalDisclosure')
         criminal_disclosure_common_el = find_element(criminal_disclosure_el, 'criminalDisclosureCommonQuestion')
         criminal_disclosure = CriminalDisclosure(
-            is_convicted_of_felony=child_value(criminal_disclosure_common_el, 'isConvictedOfFelony') == "Y",
-            is_charged_with_felony=child_value(criminal_disclosure_common_el, 'isChargedWithFelony') == "Y",
-            is_org_convicted_of_felony=child_value(criminal_disclosure_common_el, 'isOrgConvictedOfFelony') == "Y",
-            is_org_charged_with_felony=child_value(criminal_disclosure_common_el, 'isOrgChargedWithFelony') == "Y",
-            is_convicted_of_misdemeanor=child_value(criminal_disclosure_el, 'isConvictedOfMisdemeanor') == "Y",
-            is_charged_with_misdemeanor=child_value(criminal_disclosure_el, 'isChargedWithMisdemeanor') == "Y",
-            is_org_charged_with_misdemeanor=child_value(criminal_disclosure_el,
+            is_convicted_of_felony=child_text(criminal_disclosure_common_el, 'isConvictedOfFelony') == "Y",
+            is_charged_with_felony=child_text(criminal_disclosure_common_el, 'isChargedWithFelony') == "Y",
+            is_org_convicted_of_felony=child_text(criminal_disclosure_common_el, 'isOrgConvictedOfFelony') == "Y",
+            is_org_charged_with_felony=child_text(criminal_disclosure_common_el, 'isOrgChargedWithFelony') == "Y",
+            is_convicted_of_misdemeanor=child_text(criminal_disclosure_el, 'isConvictedOfMisdemeanor') == "Y",
+            is_charged_with_misdemeanor=child_text(criminal_disclosure_el, 'isChargedWithMisdemeanor') == "Y",
+            is_org_charged_with_misdemeanor=child_text(criminal_disclosure_el,
                                                         'isOrgChargedWithMisdemeanor') == "Y",
-            is_org_convicted_of_misdemeanor=child_value(criminal_disclosure_el,
+            is_org_convicted_of_misdemeanor=child_text(criminal_disclosure_el,
                                                         'isOrgConvictedOfMisdemeanor') == "Y",
         )
         criminal_disclosure = criminal_disclosure
@@ -510,37 +511,37 @@ class MunicipalAdvisorForm:
         regulatory_disclosure_common_el = find_element(regulatory_disclosure_el,
                                                        'regulatoryDisclosureCommonQuestion')
         regulatory_disclosure = RegulatoryDisclosure(
-            is_made_false_statement=child_value(regulatory_disclosure_common_el, 'isMadeFalseStatement') == "Y",
-            is_violated_regulation=child_value(regulatory_disclosure_common_el, 'isViolatedRegulation') == "Y",
-            is_cause_of_denial=child_value(regulatory_disclosure_common_el, 'isCauseOfDenial') == "Y",
-            is_order_against=child_value(regulatory_disclosure_common_el, 'isOrderAgainst') == "Y",
-            is_imposed_penalty=child_value(regulatory_disclosure_common_el, 'isImposedPenalty') == "Y",
-            is_un_ethical=child_value(regulatory_disclosure_common_el, 'isUnEthical') == "Y",
-            is_found_in_violation_of_regulation=child_value(regulatory_disclosure_common_el,
+            is_made_false_statement=child_text(regulatory_disclosure_common_el, 'isMadeFalseStatement') == "Y",
+            is_violated_regulation=child_text(regulatory_disclosure_common_el, 'isViolatedRegulation') == "Y",
+            is_cause_of_denial=child_text(regulatory_disclosure_common_el, 'isCauseOfDenial') == "Y",
+            is_order_against=child_text(regulatory_disclosure_common_el, 'isOrderAgainst') == "Y",
+            is_imposed_penalty=child_text(regulatory_disclosure_common_el, 'isImposedPenalty') == "Y",
+            is_un_ethical=child_text(regulatory_disclosure_common_el, 'isUnEthical') == "Y",
+            is_found_in_violation_of_regulation=child_text(regulatory_disclosure_common_el,
                                                             'isFoundInViolationOfRegulation') == "Y",
-            is_found_in_violation_of_rules=child_value(regulatory_disclosure_common_el,
+            is_found_in_violation_of_rules=child_text(regulatory_disclosure_common_el,
                                                        'isFoundInViolationOfRules') == "Y",
-            is_found_in_cause_of_denial=child_value(regulatory_disclosure_common_el,
+            is_found_in_cause_of_denial=child_text(regulatory_disclosure_common_el,
                                                     'isFoundInCauseOfDenial') == "Y",
-            is_order_against_activity=child_value(regulatory_disclosure_common_el,
+            is_order_against_activity=child_text(regulatory_disclosure_common_el,
                                                   'isOrderAgainstActivity') == "Y",
-            is_denied_license=child_value(regulatory_disclosure_common_el, 'isDeniedLicense') == "Y",
-            is_found_in_cause_of_suspension=child_value(regulatory_disclosure_common_el,
+            is_denied_license=child_text(regulatory_disclosure_common_el, 'isDeniedLicense') == "Y",
+            is_found_in_cause_of_suspension=child_text(regulatory_disclosure_common_el,
                                                         'isFoundInCauseOfSuspension') == "Y",
-            is_discipliend=child_value(regulatory_disclosure_common_el, 'isDiscipliend') == "Y",
-            is_authorized_to_act_attorney=child_value(regulatory_disclosure_common_el,
+            is_discipliend=child_text(regulatory_disclosure_common_el, 'isDiscipliend') == "Y",
+            is_authorized_to_act_attorney=child_text(regulatory_disclosure_common_el,
                                                       'isAuthorizedToActAttorney') == "Y",
-            is_regulatory_complaint=child_value(regulatory_disclosure_common_el, 'isRegulatoryComplaint') == "Y",
-            is_violated_security_act=child_value(regulatory_disclosure_el, 'isViolatedSecurityAct') == "Y",
-            is_will_fully_aided=child_value(regulatory_disclosure_el, 'isWillFullyAided') == "Y",
-            is_failed_to_supervise=child_value(regulatory_disclosure_el, 'isFailedToSupervise') == "Y",
-            is_found_will_fully_aided=child_value(regulatory_disclosure_el, 'isFoundWillFullyAided') == "Y",
-            is_association_bared=child_value(regulatory_disclosure_el, 'isAssociationBared') == "Y",
-            is_final_order=child_value(regulatory_disclosure_el, 'isFinalOrder') == "Y",
-            is_will_fully_violated_security_act=child_value(regulatory_disclosure_el,
+            is_regulatory_complaint=child_text(regulatory_disclosure_common_el, 'isRegulatoryComplaint') == "Y",
+            is_violated_security_act=child_text(regulatory_disclosure_el, 'isViolatedSecurityAct') == "Y",
+            is_will_fully_aided=child_text(regulatory_disclosure_el, 'isWillFullyAided') == "Y",
+            is_failed_to_supervise=child_text(regulatory_disclosure_el, 'isFailedToSupervise') == "Y",
+            is_found_will_fully_aided=child_text(regulatory_disclosure_el, 'isFoundWillFullyAided') == "Y",
+            is_association_bared=child_text(regulatory_disclosure_el, 'isAssociationBared') == "Y",
+            is_final_order=child_text(regulatory_disclosure_el, 'isFinalOrder') == "Y",
+            is_will_fully_violated_security_act=child_text(regulatory_disclosure_el,
                                                             'isWillFullyViolatedSecurityAct') == "Y",
-            is_failed_resonably=child_value(regulatory_disclosure_el, 'isFailedResonably') == "Y",
-            is_found_made_false_statement=child_value(regulatory_disclosure_el,
+            is_failed_resonably=child_text(regulatory_disclosure_el, 'isFailedResonably') == "Y",
+            is_found_made_false_statement=child_text(regulatory_disclosure_el,
                                                       'isFoundMadeFalseStatement') == "Y"
         )
         regulatory_disclosure = regulatory_disclosure
@@ -553,44 +554,53 @@ class MunicipalAdvisorForm:
         # Civil Disclosure
         civil_disclosure_el = find_element(disclosure_questions_el, 'civilDisclosure')
         civil_disclosure = CivilDisclosure(
-            is_enjoined=child_value(civil_disclosure_el, 'isEnjoined') == "Y",
-            is_found_violation_of_regulation=child_value(civil_disclosure_el,
-                                                         'isFoundViolationOfRegulation') == "Y",
-            is_dismissed=child_value(civil_disclosure_el, 'isDismissed') == "Y",
-            is_named_in_civil_proceeding=child_value(civil_disclosure_el,
+            is_enjoined=child_text(civil_disclosure_el, 'isEnjoined') == "Y",
+            # The element is 'isFoundInViolationOfRegulation', not
+            # 'isFoundViolationOfRegulation' -- verified in 40/40 sampled MA-I filings.
+            is_found_violation_of_regulation=child_text(civil_disclosure_el,
+                                                         'isFoundInViolationOfRegulation') == "Y",
+            is_dismissed=child_text(civil_disclosure_el, 'isDismissed') == "Y",
+            is_named_in_civil_proceeding=child_text(civil_disclosure_el,
                                                      'isNamedInCivilProceeding') == "Y")
 
         # Complaint Disclosure
         complaint_disclosure_el = find_element(disclosure_questions_el, 'complaintDisclosure')
         complaint_disclosure = ComplaintDisclosure(
-            is_complaint_pending=child_value(complaint_disclosure_el, 'isComplaintPending') == "Y",
-            is_complaint_settled=child_value(complaint_disclosure_el, 'isComplaintSettled') == "Y",
-            is_fraud_case_pending=child_value(complaint_disclosure_el, 'isFraudCasePending') == "Y",
-            is_fraud_case_resulting_award=child_value(complaint_disclosure_el,
-                                                      'isFraudCaseResultingAward') == "Y",
-            is_fraud_case_settled=child_value(complaint_disclosure_el, 'isFraudCaseSettled') == "Y"
+            is_complaint_pending=child_text(complaint_disclosure_el, 'isComplaintPending') == "Y",
+            is_complaint_settled=child_text(complaint_disclosure_el, 'isComplaintSettled') == "Y",
+            is_fraud_case_pending=child_text(complaint_disclosure_el, 'isFraudCasePending') == "Y",
+            # The element is 'isFraudCaseResultedAward', not
+            # 'isFraudCaseResultingAward' -- the SEC schema's own spelling
+            # (verified in 40/40 sampled MA-I filings) -- do not "fix" it back.
+            is_fraud_case_resulting_award=child_text(complaint_disclosure_el,
+                                                      'isFraudCaseResultedAward') == "Y",
+            is_fraud_case_settled=child_text(complaint_disclosure_el, 'isFraudCaseSettled') == "Y"
         )
 
         # Termination Disclosure
         termination_disclosure_el = find_element(disclosure_questions_el, 'terminationDisclosure')
         termination_disclosure = TerminationDisclosure(
-            is_violated_industry_standards=child_value(termination_disclosure_el,
-                                                       'isViolatedIndustryStandards') == "Y",
-            is_involved_in_fraud=child_value(termination_disclosure_el, 'isInvolvedInFraud') == "Y",
-            is_failed_to_supervise=child_value(termination_disclosure_el, 'isFailedToSupervise') == "Y"
+            # 'isViloatedIndustryStandard' is the SEC schema's own misspelling
+            # (verified in 40/40 sampled MA-I filings) -- do not "fix" it back.
+            is_violated_industry_standards=child_text(termination_disclosure_el,
+                                                       'isViloatedIndustryStandard') == "Y",
+            is_involved_in_fraud=child_text(termination_disclosure_el, 'isInvolvedInFraud') == "Y",
+            is_failed_to_supervise=child_text(termination_disclosure_el, 'isFailedToSupervise') == "Y"
         )
         # Financial Disclosure
         financial_disclosure_el = find_element(disclosure_questions_el, 'financialDisclosure')
         financial_disclosure = FinancialDisclosure(
-            is_compromised=child_value(financial_disclosure_el, 'isCompromised') == "Y",
-            is_bankruptcy_petition=child_value(financial_disclosure_el, 'isBankruptcyPetition') == "Y",
-            is_trustee_appointed=child_value(financial_disclosure_el, 'isTrusteeAppointed') == "Y",
-            is_bond_revoked=child_value(financial_disclosure_el, 'isBondRevoked') == "Y"
+            is_compromised=child_text(financial_disclosure_el, 'isCompromised') == "Y",
+            is_bankruptcy_petition=child_text(financial_disclosure_el, 'isBankruptcyPetition') == "Y",
+            # 'isTrusteeApointed' is the SEC schema's own misspelling
+            # (verified in 40/40 sampled MA-I filings) -- do not "fix" it back.
+            is_trustee_appointed=child_text(financial_disclosure_el, 'isTrusteeApointed') == "Y",
+            is_bond_revoked=child_text(financial_disclosure_el, 'isBondRevoked') == "Y"
         )
         # Judgement Lien Disclosure
         judgement_lien_disclosure_el = find_element(disclosure_questions_el, 'judgmentLienDisclosure')
         judgement_lien_disclosure = JudgementLienDisclosure(
-            is_lien_against=child_value(judgement_lien_disclosure_el, 'isLienAgainst') == "Y"
+            is_lien_against=child_text(judgement_lien_disclosure_el, 'isLienAgainst') == "Y"
         )
 
         # Signature

--- a/edgar/offerings/exempt/formd.py
+++ b/edgar/offerings/exempt/formd.py
@@ -117,7 +117,7 @@ class SalesCompensationRecipient:
                  states_of_solicitation: Optional[List[str]] = None):
         self.name: str = name
         self.crd: str = crd
-        self.associated_bd_name: associated_bd_name
+        self.associated_bd_name: str = associated_bd_name
         self.associated_bd_crd: str = associated_bd_crd
         self.address: Address = address
         self.states_of_solicitation: List[str] = states_of_solicitation

--- a/tests/test_144_notice_contract.py
+++ b/tests/test_144_notice_contract.py
@@ -99,25 +99,27 @@ def test_the_amendment_sample_parses_too():
     assert amendment['securities_information'].shape[0] >= 1
 
 
-def test_a_contact_block_under_filer_is_read_when_one_is_present():
+def test_a_contact_block_under_filer_info_is_read_when_one_is_present():
     """The truthiness guard, at the one place in this module where it decides a
     whole object. `<contact>` with children is truthy on both backends, but an
     empty one is falsy only on lxml — so the guard reads `is not None`.
 
-    Note what this does NOT assert: that a real Form 144 ever produces a contact.
-    SEC puts `<contact>` under `<filerInfo>`, not under `<filer>`, and names its
-    children `contactName`/`contactPhoneNumber`/`contactEmailAddress` — so
-    `Form144.parse_xml` returns `contact=None` for every real filing, including
-    SEC's own sample. That is a pre-existing bug (edgartools-wsdm), deliberately
-    left alone here so this migration stays value-for-value identical.
+    SEC puts `<contact>` under `<filerInfo>` as a sibling of `<filer>`, not
+    inside `<filer>`, and names its children `contactName` / `contactPhoneNumber`
+    / `contactEmailAddress`. `Form144.parse_xml` used to search under `<filer>`
+    for `name`/`phone`/`email` and so returned `contact=None` for every real
+    filing, including SEC's own sample. Fixed under edgartools-wsdm;
+    `test_the_contact_block_is_read_from_the_real_sample` below asserts against
+    that real sample.
     """
     parsed = Form144.parse_xml("""<?xml version="1.0" encoding="UTF-8"?>
 <edgarSubmission xmlns="http://www.sec.gov/edgar/ownership"
                  xmlns:com="http://www.sec.gov/edgar/common">
   <headerData><filerInfo><filer>
       <filerCredentials><cik>0000000001</cik></filerCredentials>
-      <contact><name>Dana Reid</name><phone>555-0100</phone><email>dana@example.com</email></contact>
-  </filer></filerInfo></headerData>
+  </filer>
+  <contact><contactName>Dana Reid</contactName><contactPhoneNumber>555-0100</contactPhoneNumber><contactEmailAddress>dana@example.com</contactEmailAddress></contact>
+  </filerInfo></headerData>
   <formData>
     <issuerInfo><issuerCik>0000000002</issuerCik>
       <relationshipsToIssuer><relationshipToIssuer>Officer</relationshipToIssuer></relationshipsToIssuer>
@@ -129,6 +131,24 @@ def test_a_contact_block_under_filer_is_read_when_one_is_present():
     assert parsed['contact'].name == "Dana Reid"
     assert parsed['contact'].phone_number == "555-0100"
     assert parsed['contact'].email == "dana@example.com"
+
+
+def test_the_contact_block_is_read_from_the_real_sample(sample):
+    """Ground truth from SEC's own sample notice (edgartools-wsdm)."""
+    contact = sample['contact']
+    assert contact is not None
+    assert contact.name == "Raj C"
+    assert contact.phone_number == "2025516129"
+    assert contact.email == "joe@gmail.com"
+
+
+def test_contact_is_none_when_the_filing_has_no_contact_block():
+    """A real filing with no `<contact>` element at all must yield `None`,
+    not raise. `data/xml/apple.144.xml` is a genuine SEC Form 144 notice
+    (Apple/Luca Maestri) whose `<filerInfo>` has no `<contact>` child."""
+    xml = Path('data/xml/apple.144.xml').read_text()
+    parsed = Form144.parse_xml(xml)
+    assert parsed['contact'] is None
 
 
 def test_parse_rejects_a_document_that_is_not_an_edgar_submission():

--- a/tests/test_formd_offerings.py
+++ b/tests/test_formd_offerings.py
@@ -82,6 +82,12 @@ def test_parse_offering_with_multiple_signatures():
     print(offering)
     assert len(offering.signature_block.signatures) == 2
 
+    # <issuerPreviousNameList><previousName>None</previousName></issuerPreviousNameList>:
+    # the "no previous names" placeholder written with the <previousName> spelling,
+    # not <value> (edgartools-gi0a). Must be filtered the same way as the <value> spelling.
+    assert offering.primary_issuer.issuer_previous_names == []
+    assert offering.primary_issuer.edgar_previous_names == []
+
 
 def test_parse_offering_with_all_states_sales_compensation():
     offering: FormD = FormD.from_xml(formD_xml3)
@@ -91,6 +97,12 @@ def test_parse_offering_with_all_states_sales_compensation():
     assert offering.offering_data.sales_compensation_recipients[0].name == ""
     assert offering.offering_data.sales_compensation_recipients[0].crd == ""
     assert offering.offering_data.sales_compensation_recipients[0].states_of_solicitation == ["All States"]
+
+    # Regression for edgartools-gi0a: Shepherd's Finance, LLC (CIK 0001544190) was
+    # renamed from 84 RE Partners, LLC. SEC wrote the previous name with the
+    # <previousName> spelling, not <value>, and it was silently dropped.
+    assert offering.primary_issuer.issuer_previous_names == ["84 RE Partners, LLC"]
+    assert offering.primary_issuer.edgar_previous_names == []
 
 
 def test_formd_industry_group_none():

--- a/tests/test_formd_offerings.py
+++ b/tests/test_formd_offerings.py
@@ -110,6 +110,18 @@ def test_formd_industry_group_none():
     formd:FormD = filing.obj()
     assert formd.offering_data.industry_group.investment_fund_info is None
 
+def test_formd_sales_compensation_recipient_associated_bd_name():
+    # Regression for edgartools-aq2r: associated_bd_name was a bare annotation
+    # (`self.associated_bd_name: associated_bd_name`), not an assignment, so it
+    # was never set and raised AttributeError on access.
+    offering: FormD = FormD.from_xml(formD_xml1)
+    recipients = offering.offering_data.sales_compensation_recipients
+    assert len(recipients) == 4
+    assert recipients[0].name == "Charles Harrison"
+    assert recipients[0].associated_bd_name == "H & L Equities, LLC"
+    assert recipients[0].associated_bd_crd == "113794"
+
+
 def test_formd_business_combination():
     filing = Filing(form='D/A', filing_date='2024-04-03', company='REMY CAPITAL PARTNERS II L P', cik=920660,
            accession_no='0000935836-24-000336')

--- a/tests/test_ma_i_form_contract.py
+++ b/tests/test_ma_i_form_contract.py
@@ -225,40 +225,88 @@ def test_the_investigation_answer_is_read(goldman, minimal):
     assert minimal['disclosures'].investigation_disclosure.is_investigated is True
 
 
-def test_disclosure_answers_read_with_child_value_are_currently_always_false():
-    """Pins existing behavior, which is WRONG — see edgartools-9fy0.
+def test_disclosure_answers_are_read_from_the_elements_own_text(goldman):
+    """edgartools-9fy0: 40 of the 45 disclosure booleans were parsed with
+    `xmltools.child_value`, which reads the text of a `<value>` CHILD. MA-I
+    disclosure elements have no `<value>` child — they hold the answer as their
+    own text, e.g. `<com:isConvictedOfFelony>Y</com:isConvictedOfFelony>` — so
+    `child_value` returned `''` and the `== "Y"` comparison was always False.
+    Fixed by switching these reads to `child_text`, the pattern already used by
+    `investigation_disclosure.is_investigated`.
 
-    40 of the 45 disclosure booleans are parsed with `xmltools.child_value`, which
-    reads the text of a `<value>` CHILD. MA-I disclosure elements have no `<value>`
-    child, so `child_value` returns `''` and the `== "Y"` comparison is always
-    False. Three of the 40 real MA-I filings sampled for the lxml port answer Y to
-    a disclosure question and every one of them reads as clean.
-
-    This was NOT introduced by the port: both backends produce False identically.
-    The test exists so fixing 9fy0 is a deliberate change to these assertions
-    rather than a surprise failure.
+    The checked-in Goldman fixture answers N to every disclosure question, so
+    this asserts on a copy with one answer flipped to Y.
     """
     xml = GOLDMAN.read_text().replace('<com:isConvictedOfFelony>N<',
                                       '<com:isConvictedOfFelony>Y<')
     assert '<com:isConvictedOfFelony>Y<' in xml
     disclosures = MunicipalAdvisorForm.from_xml(xml)['disclosures']
-    assert disclosures.criminal_disclosure.is_convicted_of_felony is False  # should be True
-    assert disclosures.any() is False  # should be True
+    assert disclosures.criminal_disclosure.is_convicted_of_felony is True
+    assert disclosures.any() is True
+
+    # And the clean fixture still reads as clean.
+    assert goldman['disclosures'].criminal_disclosure.is_convicted_of_felony is False
+    assert goldman['disclosures'].any() is False
 
 
-def test_is_independent_relationship_is_currently_always_false():
-    """Pins existing behavior, which is WRONG — see edgartools-x2ko.
-
-    The parser searches for `isIndependentRelationship`; the SEC schema spells it
-    `isIndependentRelatioship`, and does so in all 40 filings sampled for the lxml
-    port. The search finds nothing, so the field is False for every MA-I ever
-    filed. Two of the 40 answer Y. Pre-existing on both backends.
+def test_is_independent_relationship_is_read_from_the_real_sec_element_name():
+    """edgartools-x2ko: the parser searched for `isIndependentRelationship`; the
+    SEC schema spells it `isIndependentRelatioship` (its own typo, present in
+    40/40 sampled MA-I filings). The search found nothing, so the field was
+    False for every MA-I ever filed. Fixed by searching for the real name.
     """
     xml = GOLDMAN.read_text().replace('<isIndependentRelatioship>N<',
                                       '<isIndependentRelatioship>Y<')
     assert '<isIndependentRelatioship>Y<' in xml
     offices = MunicipalAdvisorForm.from_xml(xml)['municipal_advisor_offices']
-    assert offices[0].is_independent_relationship is False  # should be True
+    assert offices[0].is_independent_relationship is True
+
+
+def test_civil_disclosure_is_read_from_the_real_sec_element_name():
+    """edgartools-x2ko: the parser searched for `isFoundViolationOfRegulation`;
+    the SEC schema spells it `isFoundInViolationOfRegulation` (40/40 sampled).
+    Also depends on the 9fy0 child_text fix, since this field is nested inside
+    `<civilDisclosure>` with no `<value>` child."""
+    xml = GOLDMAN.read_text().replace('<com:isFoundInViolationOfRegulation>N</com:isFoundInViolationOfRegulation>\n        <com:isDismissed>',
+                                      '<com:isFoundInViolationOfRegulation>Y</com:isFoundInViolationOfRegulation>\n        <com:isDismissed>')
+    assert '<com:isFoundInViolationOfRegulation>Y</com:isFoundInViolationOfRegulation>\n        <com:isDismissed>' in xml
+    disclosures = MunicipalAdvisorForm.from_xml(xml)['disclosures']
+    assert disclosures.civil_disclosure.is_found_violation_of_regulation is True
+    assert disclosures.civil_disclosure.any() is True
+
+
+def test_complaint_disclosure_is_read_from_the_real_sec_element_name():
+    """edgartools-x2ko: the parser searched for `isFraudCaseResultingAward`; the
+    SEC schema spells it `isFraudCaseResultedAward` (its own typo, 40/40 sampled)."""
+    xml = GOLDMAN.read_text().replace('<isFraudCaseResultedAward>N<',
+                                      '<isFraudCaseResultedAward>Y<')
+    assert '<isFraudCaseResultedAward>Y<' in xml
+    disclosures = MunicipalAdvisorForm.from_xml(xml)['disclosures']
+    assert disclosures.complaint_disclosure.is_fraud_case_resulting_award is True
+    assert disclosures.complaint_disclosure.any() is True
+
+
+def test_termination_disclosure_is_read_from_the_real_sec_element_name():
+    """edgartools-x2ko: the parser searched for `isViolatedIndustryStandards`;
+    the SEC schema spells it `isViloatedIndustryStandard` (its own typo, 40/40
+    sampled)."""
+    xml = GOLDMAN.read_text().replace('<isViloatedIndustryStandard>N<',
+                                      '<isViloatedIndustryStandard>Y<')
+    assert '<isViloatedIndustryStandard>Y<' in xml
+    disclosures = MunicipalAdvisorForm.from_xml(xml)['disclosures']
+    assert disclosures.termination_disclosure.is_violated_industry_standards is True
+    assert disclosures.termination_disclosure.any() is True
+
+
+def test_financial_disclosure_is_read_from_the_real_sec_element_name():
+    """edgartools-x2ko: the parser searched for `isTrusteeAppointed`; the SEC
+    schema spells it `isTrusteeApointed` (its own typo, 40/40 sampled)."""
+    xml = GOLDMAN.read_text().replace('<isTrusteeApointed>N<',
+                                      '<isTrusteeApointed>Y<')
+    assert '<isTrusteeApointed>Y<' in xml
+    disclosures = MunicipalAdvisorForm.from_xml(xml)['disclosures']
+    assert disclosures.financial_disclosure.is_trustee_appointed is True
+    assert disclosures.financial_disclosure.any() is True
 
 
 def test_from_xml_rejects_a_document_that_is_not_an_edgar_submission():

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -110,6 +110,50 @@ def test_issuer_previous_name_lists_keep_real_names_in_order():
     assert issuer.issuer_previous_names == ["Old Name One", "Old Name Two"]
 
 
+def test_issuer_previous_name_lists_read_the_previousName_spelling():
+    """SEC also writes previous names with a `<previousName>` child instead of
+    `<value>`. Ground truth: Shepherd's Finance, LLC (CIK 0001544190, formerly
+    84 RE Partners, LLC), data/D.Shepards.xml. Regression for edgartools-gi0a:
+    this spelling was silently dropped, returning [] instead of the real name.
+    """
+    xml = ISSUER_XML.replace(
+        "<issuerPreviousNameList>\n        <value>None</value>\n    </issuerPreviousNameList>",
+        "<issuerPreviousNameList>"
+        "<previousName>84 RE Partners, LLC</previousName>"
+        "</issuerPreviousNameList>",
+    )
+    issuer = Issuer.from_xml(_issuer_element(xml))
+    assert issuer.issuer_previous_names == ["84 RE Partners, LLC"]
+    assert issuer.edgar_previous_names == []
+
+
+def test_issuer_previous_name_lists_drop_the_literal_none_placeholder_in_either_spelling():
+    """SEC writes the literal 'None' placeholder under both spellings, e.g.
+    data/D.APFund.xml: `<issuerPreviousNameList><previousName>None</previousName>`.
+    """
+    xml = ISSUER_XML.replace(
+        "<issuerPreviousNameList>\n        <value>None</value>\n    </issuerPreviousNameList>",
+        "<issuerPreviousNameList>"
+        "<previousName>None</previousName>"
+        "</issuerPreviousNameList>",
+    )
+    issuer = Issuer.from_xml(_issuer_element(xml))
+    assert issuer.issuer_previous_names == []
+
+
+def test_issuer_previous_name_lists_merge_both_spellings_without_duplicates():
+    xml = ISSUER_XML.replace(
+        "<issuerPreviousNameList>\n        <value>None</value>\n    </issuerPreviousNameList>",
+        "<issuerPreviousNameList>"
+        "<value>Old Name One</value>"
+        "<previousName>Old Name One</previousName>"
+        "<previousName>Old Name Two</previousName>"
+        "</issuerPreviousNameList>",
+    )
+    issuer = Issuer.from_xml(_issuer_element(xml))
+    assert issuer.issuer_previous_names == ["Old Name One", "Old Name Two"]
+
+
 def test_issuer_tolerates_missing_previous_name_lists():
     xml = ISSUER_XML.replace("<issuerPreviousNameList>", "<absentList>").replace(
         "</issuerPreviousNameList>", "</absentList>"

--- a/tests/test_regd_notice_contract.py
+++ b/tests/test_regd_notice_contract.py
@@ -142,21 +142,15 @@ def test_a_previous_name_list_of_literal_none_reads_as_no_previous_names(ap_fund
     assert FormD.from_xml(REIT_1685.read_text()).primary_issuer.issuer_previous_names == []
 
 
-def test_previous_names_in_the_other_spelling_are_currently_dropped():
-    """Pins existing behavior, which is WRONG — see edgartools-gi0a.
-
-    `Issuer.from_xml` reads only `<value>` children of the previous-name lists, but
-    SEC also writes `<previousName>`, and 7 of 42 Form D filings sampled across
-    2022-2025 use that spelling with real values. Shepherd's Finance was renamed
-    from "84 RE Partners, LLC" and the parser returns an empty list.
-
-    This test exists so the loss is visible and so fixing gi0a is a deliberate,
-    single-line change to an assertion rather than a surprise. It was NOT
-    introduced by the lxml port: both backends drop it identically.
+def test_previous_names_in_the_other_spelling_are_read():
+    """SEC writes previous names as `<value>` in most filings but `<previousName>`
+    in others — 7 of 42 Form D filings sampled across 2022-2025 use that spelling
+    with real values. Both are read (edgartools-gi0a): Shepherd's Finance was
+    renamed from "84 RE Partners, LLC" and the parser returns it.
     """
     shepherds = FormD.from_xml(SHEPHERDS.read_text())
     assert "84 RE Partners, LLC" in SHEPHERDS.read_text()
-    assert shepherds.primary_issuer.issuer_previous_names == []  # should be ["84 RE Partners, LLC"]
+    assert shepherds.primary_issuer.issuer_previous_names == ["84 RE Partners, LLC"]
 
 
 def test_from_xml_rejects_a_document_that_is_not_an_edgar_submission():


### PR DESCRIPTION
## Summary

Fixes the five pre-existing parser bugs surfaced by the 40-filing corpus comparisons run during the bs4→lxml migration (edgartools-07lk.11.3). None were introduced by the migration — each reproduced identically on the pre-migration revision. All five share the same failure mode: **silent wrong output**, never an error.

One commit per bug (the two MA-I bugs share a commit because their fixes interleave in one file):

- **`fix(muniadvisors)`** — MA-I disclosure answers were read with `child_value()`, which looks for a `<value>` child; MA-I elements hold the answer as their own text, so 40 of 45 disclosure booleans were hardwired `False` — a filing disclosing a felony reported clean. Also fixes five element names the parser searched for that SEC never writes (three are the SEC schema's own misspellings, now commented so nobody corrects them back).
- **`fix(form144)`** — `Form144.contact` was `None` on all 31 corpus filings: `<contact>` was searched under `<filer>` when SEC writes it as a sibling under `<filerInfo>`, and its children were read as `name`/`phone`/`email` where the XSD names them `contactName`/`contactPhoneNumber`/`contactEmailAddress`.
- **`fix(formd)` previous names** — the previous-name lists only read `<value>` children; 7 of 42 sampled Form D filings write `<previousName>` instead, so renamed issuers parsed as never renamed. The `'None'` placeholder is now filtered under either spelling too.
- **`fix(formd)` associated_bd_name** — `self.associated_bd_name: associated_bd_name` (a colon, not an equals) was a no-op annotation, so every `SalesCompensationRecipient` raised `AttributeError` on access.

## Verification

Per the constitution, every fix asserts specific values from real SEC data:

- MA-I: contract tests that previously **pinned the wrong behavior** now assert the correct `True` values; the clean Goldman fixture still parses entirely clean (no false positives).
- Form 144: SEC's own checked-in `Sample 144.xml` (`contactName` "Raj C") plus a real Apple 144 without a contact block pinning the `None` path.
- Form D: `D.Shepards.xml` → `["84 RE Partners, LLC"]`; `D.1685REIT.xml` → 4 recipients with "H & L Equities, LLC" / CRD 113794; `D.APFund.xml` pins the `<previousName>None</previousName>` placeholder case.

Combined run: `tests/test_party.py tests/test_formd_offerings.py tests/test_144_notice_contract.py tests/test_form144.py tests/test_ma_i_form_contract.py tests/test_muni_advisors.py` → **95 passed**.

Beads: edgartools-9fy0, -x2ko, -wsdm, -gi0a, -aq2r (all closed with commit refs). Follow-up filed as edgartools-07lk.11.8 for two MA-I schema elements the parser never reads at all (new-field work, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)