### PR TITLE
chore(release): 5.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.51.0] - 2026-08-19
+
 ### Performance
 
 - **Parsing the current-filings feed is 6.1x faster**, measured on a real 100-entry page (9.6ms to 1.6ms). Most of that is invisible behind the network round trip when you fetch one page, but `get_all_current_filings()` pages through the whole feed and pays it every time. Output is byte-identical; the entries, their order, and their fields are unchanged.

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.50.1'
+__version__ = '5.51.0'


### PR DESCRIPTION
Cuts 5.51.0 from the 20 commits on main since v5.50.1.

**Performance — the XBRL-adjacent XML parsers crossed to lxml (9 of 9).** Current-filings feed 6.1x, EFFECT 9.0x, Forms 3/4/5 2.7x, FilingSummary 6.9x, 13F cover page 5.7x, Form 144 3.1x, Form D 8.8x, MA-I 2.9x, Schedule 13D/G 4.2x. Every port carries a measured before/after against a real filing corpus, with parsed fields identical on both sides.

**Fixed — nine silent-wrong-output bugs**, most surfaced by the corpus comparisons the migration required: MA-I disclosure booleans reading `False` regardless of what the filing said (45 fields, including three SEC misspellings), `Form144.contact` `None` on every filing, Form D previous names dropped under the `previousName` spelling, `associated_bd_name` lost to a `:`-for-`=` typo, malformed-XML recovery restored to match bs4's behaviour, and `SecForms.load()` returning a doubly-nested object.

Full detail in CHANGELOG.md.

Verification: `hatch run test-fast` — 5363 passed, 4 skipped, 0 failures. `hatch build` produces both artifacts; wheel METADATA reads 5.51.0 and `edgar/py.typed` is present.

Release-mechanics only — no code changes in this PR (CHANGELOG date header + version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)