### PR TITLE
fix(documents): read bare TextNodes as section headers on pre-2002 filings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Filings from before about 2002 returned no items at all from the modern parser.** Those filings are preformatted text wrapped in minimal HTML, so they parse to a container-and-text tree with no headings and no paragraphs — and every header strategy in the section extractor drew its candidates from headings, section nodes, bold paragraphs or table cells. There was no candidate source at all on such a document, so detection returned nothing however well the patterns matched, and `TenK.items` or `TwentyF.items` came back empty unless the deprecated legacy parser rescued them. Bare text nodes are now read as headers, using each node's first line, since one node carries both the heading and the body that follows it. A 2001 10-K and a 2001 20-F recover their Item 7; across a 121-filing corpus this was the last remaining difference between the modern parser and the legacy one on these forms.
+
 ## [5.51.0] - 2026-08-19
 
 ### Performance

--- a/edgar/documents/extractors/pattern_section_extractor.py
+++ b/edgar/documents/extractors/pattern_section_extractor.py
@@ -755,6 +755,45 @@ class SectionExtractor:
                         headers.append((node, text.strip(), position))
                         existing_positions.add(position)
 
+        # Strategy 5c: bare TextNode headers, for filings with no block structure
+        # at all.
+        #
+        # Pre-2002 filings are preformatted text wrapped in minimal HTML, and they
+        # parse to ContainerNode > TextNode with *zero* HeadingNodes and *zero*
+        # ParagraphNodes. Every strategy above draws its candidates from headings,
+        # sections, bold paragraphs or table cells, so on those documents the
+        # header list is not merely short — there is no candidate source at all,
+        # and section detection returns nothing however good the patterns are.
+        # That is why these filings fell through to the legacy ChunkedDocument
+        # fallback in the report classes (edgartools-3dp).
+        #
+        # The header is the node's FIRST LINE, not its whole text: in
+        # preformatted filings a single TextNode carries the heading and the body
+        # that follows it, so the untrimmed text is a thousand characters of prose
+        # that `_looks_like_section_header` rejects on length alone. A title
+        # wrapped across two lines is truncated by this ("...AND RESULTS" without
+        # "OF OPERATIONS"), which costs nothing — the pattern match is anchored at
+        # the start, and the section's title comes from the pattern table rather
+        # than from the matched text.
+        if not self._item_structure_found(headers):
+            from edgar.documents.nodes import TextNode as _BareTextNode
+
+            existing_positions = {pos for _, _, pos in headers}
+            for node in document.root.find(lambda n: isinstance(n, _BareTextNode)):
+                text = node.text()
+                if not text:
+                    continue
+                first_line = text.strip().split("\n", 1)[0].strip()
+                if not re.match(r'^Item\s+\d', first_line, re.IGNORECASE):
+                    continue
+                if not self._looks_like_section_header(first_line):
+                    continue
+                position = _node_position(node)
+                if position in existing_positions:
+                    continue
+                headers.append((node, first_line, position))
+                existing_positions.add(position)
+
         # Strategy 5b: SIGNATURES terminal header for 8-K (and 8-K/A).
         #
         # 8-Ks end with a SIGNATURES block that bounds the last item.  The preceding

--- a/edgar/documents/extractors/pattern_section_extractor.py
+++ b/edgar/documents/extractors/pattern_section_extractor.py
@@ -775,7 +775,19 @@ class SectionExtractor:
         # "OF OPERATIONS"), which costs nothing — the pattern match is anchored at
         # the start, and the section's title comes from the pattern table rather
         # than from the matched text.
-        if not self._item_structure_found(headers):
+        # NOT for 8-K/6-K, and the reason generalises: this strategy can only
+        # find the items that happen to START a TextNode, so it may hand back a
+        # PARTIAL header set. For the annual forms a partial set is still an
+        # improvement on nothing. For current reports it is actively worse —
+        # CurrentReport.__getitem__ tries the new parser first and only falls
+        # through to its text-based extraction when the parser yields nothing, so
+        # one detected header makes it stop at a section that runs past the item
+        # it should have ended at. That is a real filing: GMAC 0001047469-05-006981
+        # carries Item 4.02 at the head of one node and Item 8.01 elsewhere, and
+        # asking for 4.02 returned 8.01's text as well (test_issue_l6cl_8k_items_missing).
+        # Current reports already have era-appropriate text extraction; the annual
+        # forms are what had nothing.
+        if not self._item_structure_found(headers) and not self.form.startswith(("8-K", "6-K")):
             from edgar.documents.nodes import TextNode as _BareTextNode
 
             existing_positions = {pos for _, _, pos in headers}

--- a/tests/issues/regression/test_3dp_bare_textnode_headers.py
+++ b/tests/issues/regression/test_3dp_bare_textnode_headers.py
@@ -1,0 +1,111 @@
+"""Pre-2002 filings with no block structure still yield their items (edgartools-3dp).
+
+Filings from before roughly 2002 are preformatted text wrapped in minimal HTML.
+They parse to ``ContainerNode > TextNode`` with **zero** ``HeadingNode`` and
+**zero** ``ParagraphNode``, and every header strategy in the pattern extractor
+drew its candidates from headings, section nodes, bold paragraphs or table cells.
+On those documents the header list was not merely short — there was no candidate
+source at all, so section detection returned nothing no matter how good the
+patterns were, and the report classes fell through to the legacy
+``ChunkedDocument``.
+
+Strategy 5c reads bare ``TextNode``s, using each node's first line as the header:
+in a preformatted filing one TextNode carries both the heading and the body that
+follows it, so the untrimmed text is a thousand characters of prose that
+``_looks_like_section_header`` rejects on length alone.
+
+This was the last thing keeping the legacy fallback load-bearing. Measured across
+121 corpus fixtures, it was the only remaining behavioural difference between
+``.items`` with the legacy path and without it.
+
+CORPUS NOTE. The 20-F asserted here lives in ``tests/fixtures/parity_gate``, which
+is tracked, so this test runs in CI. Its 10-K twin (``0000927356-01-000369``) is
+in ``tests/fixtures/text_boundary_corpus``, which is gitignored — asserting on
+that one alone would make this test skip in CI while passing locally, which is how
+parity evidence was lost before. It is checked opportunistically below.
+"""
+import pathlib
+
+import pytest
+
+from edgar.company_reports.ten_k import TenK
+from edgar.company_reports.twenty_f import TwentyF
+
+FIXTURES = pathlib.Path(__file__).parent.parent.parent / "fixtures"
+TRACKED_20F = FIXTURES / "parity_gate" / "20-F" / "0000928385-01-500187.html"
+IGNORED_10K = (FIXTURES / "text_boundary_corpus" / "e1_1996_2001" / "10-K"
+               / "0000927356-01-000369.html")
+
+
+class FixtureFiling:
+    """The minimum surface the report classes touch, backed by a local file."""
+
+    filing_date = None
+
+    def __init__(self, path: pathlib.Path, form: str):
+        self._path = path
+        self.form = form
+        self.company = "fixture"
+        self.accession_number = path.stem
+        self.base_dir = str(path.parent)
+
+    def html(self):
+        return self._path.read_text(encoding="utf-8", errors="replace")
+
+
+def _without_legacy(cls):
+    """A subclass whose legacy fallback is unavailable.
+
+    Deliberately a throwaway subclass rather than patching and deleting the
+    attribute on ``cls``: TenK, TenQ and CurrentReport each define
+    ``_chunked_document`` on themselves, so ``del cls._chunked_document`` would
+    destroy the real override instead of restoring it, and every later assertion
+    in the session would silently measure a different object.
+    """
+    return type(
+        f"NoLegacy{cls.__name__}",
+        (cls,),
+        {"_chunked_document": property(lambda self: None)},
+    )
+
+
+def test_the_tracked_fixture_is_present():
+    """Absent is not passing — guard the fixture this test rests on."""
+    assert TRACKED_20F.exists(), (
+        f"{TRACKED_20F} is tracked and must be present; without it the "
+        f"assertions below would vacuously skip"
+    )
+
+
+def test_2001_20f_finds_item_7_without_the_legacy_parser():
+    filing = FixtureFiling(TRACKED_20F, "20-F")
+
+    assert TwentyF(filing).items == ["Item 7"]
+    # The point of the fix: the same answer with the legacy path gone.
+    assert TwentyF.__mro__ and _without_legacy(TwentyF)(filing).items == ["Item 7"]
+
+
+def test_the_20f_document_really_has_no_block_structure():
+    """Pins the precondition, so a parser change that starts emitting headings
+    here does not leave this test passing for a different reason."""
+    from edgar.documents.config import ParserConfig
+    from edgar.documents.nodes import HeadingNode, ParagraphNode
+    from edgar.documents.parser import HTMLParser
+
+    doc = HTMLParser(ParserConfig(form="20-F", detect_sections=True)).parse(
+        TRACKED_20F.read_text(encoding="utf-8", errors="replace")
+    )
+    nodes = list(doc.root.walk())
+    assert not [n for n in nodes if isinstance(n, HeadingNode)]
+    assert not [n for n in nodes if isinstance(n, ParagraphNode)]
+
+
+@pytest.mark.skipif(
+    not IGNORED_10K.exists(),
+    reason="text_boundary_corpus is gitignored; present on developer machines only",
+)
+def test_2001_10k_finds_item_7_without_the_legacy_parser():
+    filing = FixtureFiling(IGNORED_10K, "10-K")
+
+    assert TenK(filing).items == ["Item 7"]
+    assert _without_legacy(TenK)(filing).items == ["Item 7"]

--- a/tests/test_section_parity_ratchet.py
+++ b/tests/test_section_parity_ratchet.py
@@ -107,7 +107,15 @@ pytestmark = pytest.mark.slow
 # when triaging the remaining dt1f gaps — some may be extraction, not detection.
 BASELINE_GAPS = {
     ("8-K", "0001104659-03-004925"): ["9"],
-    ("10-K", "0000927356-01-000369"): ["7"],
+    # CLOSED 2026-08-20, together with ("20-F", "0000928385-01-500187") below:
+    # both were pre-2002 filings that parse to ContainerNode > TextNode with zero
+    # HeadingNodes and zero ParagraphNodes, and every header strategy in the
+    # pattern extractor drew its candidates from headings, sections, bold
+    # paragraphs or table cells. There was no candidate source at all on those
+    # documents, so detection returned nothing however good the patterns were.
+    # Strategy 5c reads bare TextNodes, taking the node's first line as the
+    # header. Regression test:
+    # tests/issues/regression/test_3dp_bare_textnode_headers.py.
     # Banked 2026-08-14: 14 -> 3, closing the item-separator defect below. What
     # remains is era semantics plus one regex detail, not separators: in 1999
     # Item 4 was "Submission of Matters to a Vote of Security Holders" and Item
@@ -129,7 +137,8 @@ BASELINE_GAPS = {
     # away. Regression test:
     # tests/issues/regression/test_dt1f_toc_augmentation_gate.py.
     ("10-Q", "gs/10q"): ["5", "6"],
-    ("20-F", "0000928385-01-500187"): ["7"],
+    # ("20-F", "0000928385-01-500187") CLOSED 2026-08-20 — see the note on the
+    # 10-K entry above; one fix closed both.
     ("20-F", "0001062993-16-008650"): ["11", "16", "6"],
     # Banked 2026-08-13: 22 -> 8, closing edgartools-dt1f Defect 1. The fallback
     # strategies in the pattern extractor were gated on whether *any* header


### PR DESCRIPTION
Closes the last two parity gaps that kept the legacy `ChunkedDocument` fallback load-bearing in `company_reports/`.

## The bug

Filings from before roughly 2002 are preformatted text wrapped in minimal HTML. They parse to `ContainerNode > TextNode` with **zero** `HeadingNode`s and **zero** `ParagraphNode`s — and every header strategy in `_find_section_headers` draws its candidates from headings (S1), section nodes (S2), bold paragraphs (S3/3b), table cells (S4) or plain paragraphs (S5).

So on these documents there was no candidate source at all. Section detection returned nothing however well the patterns matched, and `TenK.items` / `TwentyF.items` came back empty unless the deprecated legacy parser rescued them.

## The fix

Strategy 5c reads bare `TextNode`s, gated on `_item_structure_found` being False so it cannot affect filings that already detect structure.

It takes each node's **first line** as the header. In a preformatted filing one node carries the heading *and* the body that follows it, so the untrimmed text is ~1000 characters of prose that `_looks_like_section_header` rejects on its 300-char cap. A title wrapped across two lines is truncated (`"...AND RESULTS"` without `"OF OPERATIONS"`), which costs nothing — the pattern match is anchored at the start and the section's title comes from the pattern table, not the matched text.

## Measured over all 121 corpus fixtures (tracked + parity_gate + era)

- **`.items` is identical with and without the `ChunkedDocument` fallback on 121/121, up from 118/121.** The `company_reports` legacy dependency is now behaviourally dead everywhere in the corpus, which is what `edgartools-3dp` needed.
- Two filings recover `Item 7` without the legacy parser: `0000927356-01-000369` (2001 10-K) and `0000928385-01-500187` (2001 20-F). Both `BASELINE_GAPS` entries are removed in this commit, as `test_closed_gaps_are_recorded` requires.
- One filing gains a genuine item: `0001012118-01-000019`, a 2001 10-Q, now yields `Part I, Item 2`. Legacy finds *nothing* on that filing, so the new parser beats it there. Verified against the filing text — the body carries `Item 2. Management's Discussion and Analysis` after a table close, and the earlier hit is the TOC entry.
- No item gained or lost anywhere else; no fixture starts erroring.

## Verification

- `tests/test_section_parity_ratchet.py` — 6 passed (the `test_closed_gaps_are_recorded` half was red before this change, by design)
- 109 section-detection tests pass across 8 files
- `hatch run test-fast` — 5367 passed, 4 skipped, 0 failures (up 4 = the new regression tests)
- Control run: with the fix reverted, both new item assertions fail; restored, they pass

**A check the existing tooling could not make.** `parity_benchmark` reports only `legacy_only` — what legacy finds and the new parser misses — so a change that *invents* items is invisible to it. "No new gaps" is not "no regressions". I captured `.items` across all 121 fixtures before and after and diffed both directions; that is how the gained item was found and then verified rather than assumed.

The new regression test anchors on the **tracked** `parity_gate` fixture so it runs in CI — its 10-K twin lives in the gitignored `text_boundary_corpus` and would skip silently there — and pins the zero-headings/zero-paragraphs precondition so a future parser change cannot leave it passing for a different reason.

## Not in scope

`("8-K", "0001104659-03-004925"): ["9"]` stays in `BASELINE_GAPS`. It blocks nothing: with `CurrentReport`'s Strategy 2 suppressed, all 18 8-K fixtures return identical `.items`, so that chunked union is dead weight rather than a fallback.

Separately noted and left alone: `find_toc_boundaries` searches for a literal lowercase `'</table>'`, and these filings carry 0 lowercase against 33 uppercase closes, so it falls through to a 50KB *estimate* of the TOC region. Real latent bug, unrelated to this fix, and a naive case-insensitive fix would regress the 10-K by stretching the region over the real heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)