### PR TITLE
refactor(company_reports): drop the dead legacy fallback from .items (07lk.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`TenK.items`, `TenQ.items` and `TwentyF.items` no longer fall back to the deprecated legacy parser.** They now report exactly what the modern parser detects. This is not expected to change any result: across a 115-filing corpus spanning 1996 to 2026, removing the fallback changed the item list on zero filings, for every one of 10-K, 10-Q, 20-F and 8-K. The fix that made it redundant was Strategy 5c above, which recovered the last two filings that still needed it. Item *lookup* — `report["Item 7"]` and `get_item_with_part()` — still consults the legacy parser, and still needs to: it is reached whenever one particular item is missing rather than only when the whole document parsed to nothing, so a partial detection miss reaches it. On the same corpus, 15 item lookups return text only because of it.
+
 ### Fixed
 
 - **Filings from before about 2002 returned no items at all from the modern parser.** Those filings are preformatted text wrapped in minimal HTML, so they parse to a container-and-text tree with no headings and no paragraphs — and every header strategy in the section extractor drew its candidates from headings, section nodes, bold paragraphs or table cells. There was no candidate source at all on such a document, so detection returned nothing however well the patterns matched, and `TenK.items` or `TwentyF.items` came back empty unless the deprecated legacy parser rescued them. Bare text nodes are now read as headers, using each node's first line, since one node carries both the heading and the body that follows it. A 2001 10-K and a 2001 20-F recover their Item 7; across a 121-filing corpus this was the last remaining difference between the modern parser and the legacy one on these forms.

--- a/edgar/company_reports/ten_k.py
+++ b/edgar/company_reports/ten_k.py
@@ -322,12 +322,20 @@ class TenK(CompanyReport):
                     items.append(key)
             if items:
                 return _canonical(items)
-            return _canonical(self._chunked_document.list_items()) if self._chunked_document else []
 
-        # Fallback to old parser for backward compatibility
-        if self._chunked_document:
-            return _canonical(self._chunked_document.list_items())
-
+        # No legacy fallback here any more (edgartools-07lk.23). Measured across
+        # the 115-fixture era-stratified corpus: removing it changes `.items` on
+        # ZERO filings, for every one of 10-K, 10-Q, 20-F and 8-K. Strategy 5c in
+        # the pattern extractor closed the last case that needed it — a 2001 10-K
+        # losing Item 7 (edgartools-3dp).
+        #
+        # This says nothing about `__getitem__` below, which still falls back and
+        # still has to: `.items` consulted legacy only when the new parser found
+        # NOTHING, while `__getitem__` consults it whenever THIS item is missing,
+        # so a partial detection miss reaches the second and never the first. That
+        # is not hypothetical — on the same corpus, 15 item lookups return real
+        # text only because of the fallback (e.g. 0000950153-99-001234 Item 14,
+        # 19KB). Deleting that one is a separate, unfinished piece of work.
         return []
 
     # These four go through .get() rather than self[...] on purpose, and keep

--- a/edgar/company_reports/ten_q.py
+++ b/edgar/company_reports/ten_q.py
@@ -250,7 +250,10 @@ class TenQ(CompanyReport):
         Returns items in the format "Part I, Item X" or "Part II, Item X"
         to distinguish between same-numbered items in different parts.
 
-        Falls back to old chunked_document if new parser returns no sections.
+        Returns an empty list when the new parser finds no items. The legacy
+        chunked_document fallback that used to sit here was removed after being
+        measured to change no result on any corpus filing (edgartools-07lk.23);
+        ``__getitem__`` and ``get_item_with_part`` still use it.
 
         Returns:
             List of part-qualified item titles (e.g., ['Part I, Item 1', 'Part II, Item 1'])
@@ -281,12 +284,13 @@ class TenQ(CompanyReport):
                             items.append(f"{part}, Item {item_num}")
                         else:
                             items.append(f"Item {item_num}")
-            return items if items else (self._chunked_document.list_items() if self._chunked_document else [])
+            if items:
+                return items
 
-        # Fallback to old parser for backward compatibility
-        if self._chunked_document:
-            return self._chunked_document.list_items()
-
+        # No legacy fallback here any more — see the note in TenK.items
+        # (edgartools-07lk.23). Measured 0 differences across the 115-fixture
+        # corpus. `__getitem__` and `get_item_with_part` below still fall back and
+        # still need to.
         return []
 
     def __getitem__(self, item_or_part: str) -> Optional[str]:

--- a/edgar/company_reports/twenty_f.py
+++ b/edgar/company_reports/twenty_f.py
@@ -155,9 +155,10 @@ class TwentyF(CompanyReport):
         """
         List of detected item names in standard "Item X" format.
 
-        Uses the new parser's section detection, falling back to the legacy
-        ChunkedDocument only when the new parser finds nothing — the same shape
-        TenK, TenQ and CurrentReport already use.
+        Uses the new parser's section detection, and nothing else. The legacy
+        ChunkedDocument fallback that used to back this up was removed once it
+        was measured to change no result on any filing in the corpus
+        (edgartools-07lk.23).
 
         This class was the last one where legacy was PRIMARY. Its stated reason
         was that "the pattern-based extractor doesn't handle the Table of
@@ -187,12 +188,16 @@ class TwentyF(CompanyReport):
             if items:
                 return _canonical(items)
 
-        # Legacy fallback, for filings where the new parser found nothing at all.
-        # This is what recovers 0000928385-01-500187, a 2001 20-F whose only item
-        # legacy finds and the new parser does not.
-        if self._chunked_document:
-            return _canonical(self._chunked_document.list_items())
-
+        # The legacy fallback that used to sit here is gone (edgartools-07lk.23).
+        # It existed for exactly one filing — 0000928385-01-500187, a 2001 20-F
+        # whose only item legacy found and the new parser did not — and Strategy
+        # 5c in the pattern extractor now finds it directly (edgartools-3dp), so
+        # the fallback had stopped doing anything. Measured 0 differences across
+        # the 115-fixture corpus.
+        #
+        # `__getitem__` below is a different matter and keeps its fallback: on
+        # this corpus five 20-F item lookups return text only because of it
+        # (0001144204-10-017467 Items 5, 6, 11, 12, 15).
         return []
 
     def __getitem__(self, item_name: str):

--- a/tests/issues/regression/test_07lk23_items_fallback_deleted.py
+++ b/tests/issues/regression/test_07lk23_items_fallback_deleted.py
@@ -1,0 +1,141 @@
+"""`.items` no longer consults the legacy parser — and `__getitem__` still does.
+
+edgartools-07lk.23. Two halves, and the second matters as much as the first.
+
+**What was deleted.** `TenK.items`, `TenQ.items` and `TwentyF.items` each ended
+with a fallback to the legacy ``ChunkedDocument`` for filings where the new
+parser found nothing. Strategy 5c (edgartools-3dp) closed the last case that
+needed one, and measurement across the 115-fixture era-stratified corpus put the
+difference at zero filings for all four report forms. The fallbacks are gone.
+
+**What was NOT deleted, and why this file says so out loud.** The same measurement
+found the fallbacks in ``__getitem__`` and ``get_item_with_part`` are very much
+alive: 15 item lookups and 4 part-qualified lookups across the corpus return real
+text only because legacy is still there. The two are not the same question, and
+the reason is structural rather than incidental —
+
+    ``.items``       consults legacy only when the new parser found NOTHING
+    ``__getitem__``  consults legacy whenever THIS ONE item is missing
+
+— so a *partial* detection miss reaches the second and never the first. A filing
+whose Items 1-13 parse cleanly and whose Item 14 does not will never trigger the
+``.items`` fallback, and will always trigger the ``__getitem__`` one. Zero
+difference on the first therefore implies nothing whatever about the second.
+
+The planning note for this work described it as deleting "the now-dead
+``_chunked_document`` fallbacks" from four classes and dropping four
+``edgar.files`` importers. That was measured and is not accurate: only the
+``.items`` third of it is dead, and because ``__getitem__`` still imports
+``ChunkedDocument`` no importer is dropped at all. The live half is pinned below
+so the next person to read that note finds evidence instead of repeating it.
+"""
+import pathlib
+
+import pytest
+
+from edgar.company_reports.ten_k import TenK
+from edgar.company_reports.twenty_f import TwentyF
+
+FIXTURES = pathlib.Path(__file__).parent.parent.parent / "fixtures"
+# Both tracked, so these assertions run in CI. The corpus this was measured on is
+# mostly gitignored (text_boundary_corpus, 91 MB); anchoring on that alone would
+# make the whole file skip in CI while passing locally, which is how parity
+# evidence has been lost here before.
+GATE_10K = FIXTURES / "parity_gate" / "10-K" / "0000950153-99-001234.html"
+GATE_20F = FIXTURES / "parity_gate" / "20-F" / "0001062993-16-008650.html"
+
+
+class FixtureFiling:
+    """The minimum surface the report classes touch, backed by a local file."""
+
+    filing_date = None
+
+    def __init__(self, path: pathlib.Path, form: str):
+        self._path = path
+        self.form = form
+        self.company = "fixture"
+        self.accession_number = path.stem
+        self.base_dir = str(path.parent)
+
+    def html(self):
+        return self._path.read_text(encoding="utf-8", errors="replace")
+
+
+def _without_legacy(cls):
+    """A subclass whose legacy fallback is unavailable.
+
+    Deliberately a throwaway subclass rather than patching and deleting the
+    attribute on ``cls``: TenK, TenQ and CurrentReport each define
+    ``_chunked_document`` on themselves, so ``del cls._chunked_document`` would
+    destroy the real override instead of restoring it, and every later assertion
+    in the session would silently measure a different object.
+    """
+    return type(
+        f"NoLegacy{cls.__name__}",
+        (cls,),
+        {"_chunked_document": property(lambda self: None)},
+    )
+
+
+def test_the_tracked_fixtures_are_present():
+    """Absent is not passing — guard the fixtures the assertions rest on."""
+    for path in (GATE_10K, GATE_20F):
+        assert path.exists(), f"{path} is tracked and must be present"
+
+
+class TestItemsNoLongerNeedsLegacy:
+    """The deleted half: `.items` is identical with and without the fallback."""
+
+    def test_tenk_items_unchanged_without_legacy(self):
+        filing = FixtureFiling(GATE_10K, "10-K")
+        assert TenK(filing).items == _without_legacy(TenK)(filing).items
+
+    def test_twentyf_items_unchanged_without_legacy(self):
+        filing = FixtureFiling(GATE_20F, "20-F")
+        assert TwentyF(filing).items == _without_legacy(TwentyF)(filing).items
+
+    def test_items_is_a_list_when_nothing_is_found(self):
+        """Not None — `for item in report.items` must stay safe now that the
+        fallback that used to backstop an empty result is gone."""
+
+        class Empty(TenK):
+            @property
+            def sections(self):
+                return {}
+
+        empty = _without_legacy(Empty)(FixtureFiling(GATE_10K, "10-K"))
+        assert empty.items == []
+
+
+class TestGetitemStillNeedsLegacy:
+    """The half that was NOT deleted, pinned as live rather than asserted dead.
+
+    If a later change to the pattern extractor makes these pass without legacy,
+    that is good news and this class should be revisited — but it has to be
+    *observed*, not assumed. Failing here means the fallback stopped being
+    load-bearing, so re-measure and then delete it deliberately.
+    """
+
+    @pytest.mark.parametrize("item,least", [("Item 14", 5000), ("Item 7A", 100)])
+    def test_1999_tenk_items_come_only_from_legacy(self, item, least):
+        filing = FixtureFiling(GATE_10K, "10-K")
+
+        text = TenK(filing)[item]
+        assert text and len(text) > least, (
+            f"{item} should still be retrievable via the legacy fallback"
+        )
+
+    @pytest.mark.parametrize("item,least", [("Item 6", 5000), ("Item 11", 100)])
+    def test_2016_twentyf_items_come_only_from_legacy(self, item, least):
+        filing = FixtureFiling(GATE_20F, "20-F")
+
+        text = TwentyF(filing)[item]
+        assert text and len(text) > least
+
+        # And the fallback is why: without it the same lookup returns nothing.
+        # TwentyF.__getitem__ guards its fallback, so this is a clean None rather
+        # than the TypeError that TenK's unguarded deref would raise.
+        assert _without_legacy(TwentyF)(filing)[item] is None, (
+            f"{item} no longer needs the legacy fallback — re-measure "
+            f"edgartools-07lk.23 and delete it deliberately"
+        )

--- a/tests/issues/regression/test_07lk3_twentyf_items_new_parser_primary.py
+++ b/tests/issues/regression/test_07lk3_twentyf_items_new_parser_primary.py
@@ -5,6 +5,12 @@ PRIMARY source of items; TenK, TenQ and CurrentReport had already flipped, using
 legacy only as an empty-result fallback. Deleting ``edgar.files`` in 6.0 means
 deleting ChunkedDocument, so every remaining primary use has to go first.
 
+UPDATE (edgartools-07lk.23): the fallback this file was written around is now
+gone from ``.items`` in TenK, TenQ and TwentyF alike — measured to change no
+result on any of 115 era-stratified fixtures. See
+``TestLegacyIsNotConsultedAtAll`` below, which replaced the class that pinned the
+old fallback contract.
+
 Its in-code justification for staying legacy-first — that "the pattern-based
 extractor doesn't handle the Table of Contents format well" — did not survive
 measurement. On the one 20-F where legacy clearly beat the new parser, TOC
@@ -123,12 +129,24 @@ class TestItemsComeFromTheNewParser:
 
 
 @pytest.mark.fast
-class TestLegacyIsOnlyAFallback:
+class TestLegacyIsNotConsultedAtAll:
+    """Superseded 07lk.23: legacy is not a fallback here any more, it is gone.
+
+    This class used to assert the *fallback* contract — new parser first, legacy
+    when it finds nothing. That fallback was deleted after measurement showed it
+    changed `.items` on zero filings across the 115-fixture era-stratified corpus;
+    Strategy 5c (edgartools-3dp) had closed its last live case, a 2001 20-F. The
+    assertion that legacy answers when the new parser finds nothing is therefore
+    no longer a description of this code, and pinning it would block the deletion
+    it was written to enable.
+
+    Note this is scoped to `.items`. `TwentyF.__getitem__` still falls back to
+    legacy and still needs to: on the same corpus, five 20-F item lookups return
+    text only because of it (0001144204-10-017467 Items 5, 6, 11, 12 and 15).
+    """
 
     def test_legacy_is_not_consulted_when_the_new_parser_finds_items(self):
-        """The point of the flip: ChunkedDocument is off the primary path.
-
-        Asserted by construction rather than by output, because legacy and new
+        """Asserted by construction rather than by output, because legacy and new
         agree on this document — if `.items` still built a ChunkedDocument the
         answer would look identical and the deletion would still be blocked.
         """
@@ -138,12 +156,15 @@ class TestLegacyIsOnlyAFallback:
         assert report.items
         sentinel.list_items.assert_not_called()
 
-    def test_legacy_answers_when_the_new_parser_finds_nothing(self):
+    def test_legacy_is_not_consulted_when_the_new_parser_finds_nothing_either(self):
+        """The 07lk.23 flip: an empty new-parser result is now the final answer."""
         report = _twenty_f(NO_ITEMS_HTML)
         legacy = MagicMock()
         legacy.list_items.return_value = ['Item 7']
         report.__dict__['_chunked_document'] = legacy
-        assert report.items == ['Item 7']
+
+        assert report.items == []
+        legacy.list_items.assert_not_called()
 
     def test_no_items_anywhere_is_an_empty_list(self):
         """Not None — `for item in report.items` must stay safe."""


### PR DESCRIPTION
`TenK.items`, `TenQ.items` and `TwentyF.items` each ended with a fallback to the deprecated `ChunkedDocument` for filings where the new parser found nothing. Strategy 5c (#1073, edgartools-3dp) closed the last case that needed one. This measures the fallback as dead and removes it.

## The planning note was wrong, and the correction is the point of this PR

`07lk.23` described this work as deleting "the now-dead `_chunked_document` fallbacks" from four classes, dropping 4 of the 23 `edgar.files` importers. Measured across the 115-fixture era-stratified corpus (1996–2026), comparing each report class against a no-legacy subclass:

| call site | probes | differ | verdict |
|---|---:|---:|---|
| `.items` | 115 | **0** | dead → deleted |
| `__getitem__` | 1902 | **15** | **live** → kept |
| `get_item_with_part` | 286 | **4** | **live** → kept |

Only the `.items` third is dead, and **zero `edgar.files` importers are dropped** — `__getitem__` still imports `ChunkedDocument` in `ten_k.py` and `ten_q.py`.

### Why these are different questions

```
.items       consults legacy only when the new parser found NOTHING
__getitem__  consults it whenever THIS ONE item is missing
```

A *partial* detection miss reaches the second and never the first. A filing whose Items 1–13 parse cleanly and whose Item 14 does not will never trigger the `.items` fallback and will always trigger the `__getitem__` one. So zero difference on the first implies nothing whatever about the second — and the `3dp` result ("121/121 identical with and without the fallback") was a statement about `.items` alone. It should not be reused as a deletion gate.

That is not hypothetical. 19 lookups across the corpus return real text *only* because legacy is still there — `0000950153-99-001234` Item 14 is 19KB, `0001144204-10-017467` loses five 20-F items. The full list is on bead `edgartools-07lk.3`.

### A second problem behind `get_item_with_part`

When legacy is removed it falls through to `id_parse_document` (`edgar/files/html_documents_id_parser.py`), which 6.0 also plans to delete — and it is worse, not equivalent: 222,536 chars for `pg/10q` "Part II, Item 1" (essentially the whole document) and 0 chars for `gs/10q` "Part II, Item 6". Both fallbacks behind that method are slated for removal and neither has a working replacement yet.

## CurrentReport is deliberately untouched

Its chunked parser is a *union* member in `.items` — it backfills items the new parser misses (edgartools-83gh) — not a fallback, and `CurrentReport.doc` returns the chunked document as public API. Its `.items` measured 0-diff too, but that measurement used an approximated `filing.text()`, so it is weaker evidence than the other three.

## Test changes

`test_07lk3_twentyf_items_new_parser_primary.py` pinned `test_legacy_answers_when_the_new_parser_finds_nothing` — precisely the behaviour removed here. Inverted rather than deleted: legacy must now not be consulted at all.

New `test_07lk23_items_fallback_deleted.py` pins **both** halves, including a `TestGetitemStillNeedsLegacy` class asserting the surviving fallback is load-bearing, so the next person reading the planning note finds evidence instead of repeating it. Both anchor on tracked `parity_gate` fixtures so they run in CI rather than skipping.

## Verification

- `hatch run test-fast` — 5375 passed
- `hatch run test-regression` — 2568 passed, 4 xfailed, 0 reruns
- `hatch run test:pytest tests/test_section_parity_ratchet.py` — 6 passed
- `.items` snapshotted from the **unedited** classes and diffed against the real edited ones: **115/115 identical**. The no-legacy-subclass differential answers "what would removing it do"; this answers "does the code that ships still return what it returned", which is the question that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)