### PR TITLE
refactor(settings): extract edgar/settings.py from core.py (07lk.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`edgar.settings` — a real home for connection settings and SEC identity.** The access modes (`NORMAL`, `CAUTION`, `CRAWL`), `EdgarSettings`, `set_identity`, `get_identity` and `get_edgar_data_directory` now live in `edgar.settings`. They used to sit in `edgar.core` next to quarter math, HTML sniffing, a pager, thread helpers and the logger — only about a third of that 697-line module was settings, and everything users are told to configure was in that third. Nothing breaks: `edgar.core` re-exports every one of those names, and they are the *same objects*, so `isinstance` checks and identity comparisons behave identically. Code importing from the top-level namespace (`from edgar import set_identity, CAUTION`) is unaffected now and in 6.0. The `edgar.core` re-exports are removed in 6.0; see `docs/upgrade/6.0.md`.
+
 ### Changed
 
 - **`TenK.items`, `TenQ.items` and `TwentyF.items` no longer fall back to the deprecated legacy parser.** They now report exactly what the modern parser detects. This is not expected to change any result: across a 115-filing corpus spanning 1996 to 2026, removing the fallback changed the item list on zero filings, for every one of 10-K, 10-Q, 20-F and 8-K. The fix that made it redundant was Strategy 5c above, which recovered the last two filings that still needed it. Item *lookup* — `report["Item 7"]` and `get_item_with_part()` — still consults the legacy parser, and still needs to: it is reached whenever one particular item is missing rather than only when the whole document parsed to nothing, so a partial detection miss reaches it. On the same corpus, 15 item lookups return text only because of it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -571,7 +571,7 @@ from edgar import set_identity
 set_identity("Research Team research@university.edu")
 
 # Verify identity is set
-from edgar.core import get_identity
+from edgar.settings import get_identity
 print(f"Current identity: {get_identity()}")
 ```
 
@@ -594,7 +594,7 @@ print(f"Using local storage: {using_local_storage()}")
 ### HTTP Client Configuration
 
 ```python
-from edgar.core import EdgarSettings
+from edgar.settings import EdgarSettings
 
 # Custom access mode
 custom_settings = EdgarSettings(
@@ -722,7 +722,7 @@ Typical storage usage:
 
 ```python
 import os
-from edgar.core import get_identity
+from edgar.settings import get_identity
 
 # Check identity
 print(f"Identity: {get_identity()}")
@@ -806,7 +806,7 @@ def validate_config():
     
     # Check identity
     try:
-        from edgar.core import get_identity
+        from edgar.settings import get_identity
         identity = get_identity()
         if not identity:
             issues.append("EDGAR_IDENTITY not set")

--- a/docs/guides/local-storage.md
+++ b/docs/guides/local-storage.md
@@ -359,7 +359,7 @@ use_local_storage("/shared/team/edgar_data")
 ### 3. Monitor Storage Usage
 
 ```python
-from edgar.core import get_edgar_data_directory
+from edgar.settings import get_edgar_data_directory
 import shutil
 
 storage_path = get_edgar_data_directory()

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -456,6 +456,42 @@ Where the raising form is the only form, 5.x ships a non-raising one beside it:
 
 ---
 
+## Settings and identity moved to `edgar.settings`
+
+**What changed.** Connection settings and SEC identity now live in
+`edgar.settings`: the access modes (`NORMAL`, `CAUTION`, `CRAWL`), `EdgarSettings`,
+`set_identity`, `get_identity`, and `get_edgar_data_directory`.
+
+They used to live in `edgar.core`, alongside quarter math, HTML sniffing, a pager,
+thread helpers and the logger — only about a third of that 697-line module was
+settings, and everything you are told to configure was in that third.
+
+**Nothing breaks today.** `edgar.core` re-exports every one of those names, and
+they are the *same objects*, so `is` comparisons and `isinstance` checks behave
+identically:
+
+```python
+from edgar.core import get_identity      # works today, removed in 6.0
+from edgar.settings import get_identity  # preferred
+```
+
+**Most code needs no change at all.** `set_identity` and the access modes are
+re-exported on the top-level namespace, which is how the documentation has always
+shown them:
+
+```python
+from edgar import set_identity, CAUTION   # unaffected, now and in 6.0
+```
+
+**What 6.0 changes.** The `edgar.core` re-exports go. If you import any of these
+from `edgar.core` directly, repoint at `edgar.settings` — or at `edgar`, for the
+names it exposes.
+
+The rest of `edgar.core` (the logger, `listify`, the extension tables, quarter
+helpers) stays where it is.
+
+---
+
 ## Still to come
 
 Planned for the 6.0 breaking window and **not yet shipped**. Do not write code

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -21,7 +21,8 @@ from edgar._filings import (
     get_filings,
 )
 from edgar.context import HasContext, compose_context
-from edgar.core import CAUTION, CRAWL, NORMAL, edgar_mode, get_identity, listify, set_identity
+from edgar.core import listify
+from edgar.settings import CAUTION, CRAWL, NORMAL, edgar_mode, get_identity, set_identity
 from edgar.exceptions import (
     AttachmentNotFoundError,
     CompanyFactsNotFoundError,

--- a/edgar/core.py
+++ b/edgar/core.py
@@ -5,22 +5,17 @@ import os
 import random
 import re
 import sys
-import threading
-from _thread import interrupt_main
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import date
-from functools import cached_property, lru_cache, partial, wraps
-from pathlib import Path
+from functools import lru_cache, partial, wraps
 from typing import Callable, Iterable, List, Optional, Tuple, TypeVar, Union
 
-import httpx
 import pandas as pd
 import pyarrow as pa
 from zoneinfo import ZoneInfo
 from pandas.tseries.offsets import BDay
 from rich.logging import RichHandler
-from rich.prompt import Prompt
 
 from edgar.datatools import PagingState
 
@@ -90,12 +85,38 @@ YYYY_MM_DD = "\\d{4}-\\d{2}-\\d{2}"
 DATE_PATTERN = re.compile(YYYY_MM_DD)
 DATE_RANGE_PATTERN = re.compile(f"^({YYYY_MM_DD}(:({YYYY_MM_DD})?)?|:({YYYY_MM_DD}))$")
 
-default_http_timeout: int = 12
-default_page_size = 50
-default_max_connections = 10
-default_retries = 3
-
-limits = httpx.Limits(max_connections=default_max_connections)
+# ---------------------------------------------------------------------------
+# Settings and identity now live in edgar/settings.py (edgartools-07lk.12.1).
+#
+# These are RE-EXPORTS, not aliases: the implementation moved to the canonical
+# name and this module imports it back, rather than the reverse. Aliasing onto
+# the deprecated name is the trap 07lk.23 names — it leaves the real code at the
+# path you intend to delete, so 6.0 cannot simply drop the shim.
+#
+# The whole block below goes away in 6.0. Every one of the 71 call sites is a
+# `from edgar.core import <name>` (measured: zero `import edgar.core`, zero
+# attribute access), so a re-export covers 100% of them.
+# ---------------------------------------------------------------------------
+from edgar.settings import (  # noqa: E402,F401  -- re-exports, intentionally unused here
+    CAUTION,
+    CRAWL,
+    NORMAL,
+    EdgarSettings,
+    ask_for_identity,
+    default_http_timeout,
+    default_max_connections,
+    default_page_size,
+    default_retries,
+    edgar_access_mode,
+    edgar_data_dir,
+    edgar_identity,
+    edgar_mode,
+    get_edgar_data_directory,
+    get_identity,
+    identity_prompt,
+    limits,
+    set_identity,
+)
 
 
 def strtobool (val:str):
@@ -116,132 +137,6 @@ def strtobool (val:str):
         return False
         #raise ValueError("invalid truth value %r" % (val,))
 
-
-@dataclass
-class EdgarSettings:
-    http_timeout: int
-    max_connections: int
-    retries: int = 3
-
-    @cached_property
-    def limits(self):
-        return httpx.Limits(max_connections=default_max_connections)
-
-    def __eq__(self, othr):
-        return (isinstance(othr, type(self))
-                and (self.http_timeout, self.max_connections, self.retries) ==
-                (othr.http_timeout, othr.max_connections, othr.retries))
-
-    def __hash__(self):
-        return hash((self.http_timeout, self.max_connections, self.retries))
-
-
-# Modes of accessing edgar
-
-# The normal mode of accessing edgar
-NORMAL = EdgarSettings(http_timeout=15, max_connections=10)
-
-# A bit more cautious mode of accessing edgar
-CAUTION = EdgarSettings(http_timeout=20, max_connections=5)
-
-# Use this setting when you have long-running jobs and want to avoid breaching Edgar limits
-CRAWL = EdgarSettings(http_timeout=25, max_connections=2, retries=2)
-
-edgar_access_mode = os.getenv('EDGAR_ACCESS_MODE', 'NORMAL')
-if edgar_access_mode == 'CAUTION':
-    # A bit more cautious mode of accessing edgar
-    edgar_mode = CAUTION
-elif edgar_access_mode == 'CRAWL':
-    # Use this setting when you have long-running jobs and want to avoid breaching Edgar limits
-    edgar_mode = CRAWL
-else:
-    # The normal mode of accessing edgar
-    edgar_mode = NORMAL
-
-edgar_identity = 'EDGAR_IDENTITY'
-
-# Local storage directory - use centralized path configuration
-from edgar.paths import get_data_directory as _get_data_directory
-
-edgar_data_dir = str(_get_data_directory(create=False))
-
-
-def set_identity(user_identity: str):
-    """
-    This function sets the environment variable EDGAR_IDENTITY to the identity you will use to call Edgar
-
-    This user identity looks like
-
-        "Sample Company Name AdminContact@<sample company domain>.com"
-
-    See https://www.sec.gov/os/accessing-edgar-data
-
-    :param user_identity:
-    """
-    os.environ[edgar_identity] = user_identity
-    log.info("Identity of the Edgar REST client set to [%s]", user_identity)
-
-    from edgar.httpclient import close_clients
-    close_clients() # close any httpx clients, to reset the identity.
-
-
-identity_prompt = """
-[bold turquoise4]Identify your client to SEC Edgar[/bold turquoise4]
-------------------------------------------------------------------------------
-
-Before running [bold]edgartools[/bold] it needs to know the UserAgent string to send to Edgar.
-See https://www.sec.gov/os/accessing-edgar-data
-
-This can be set in the environment variable [bold green]EDGAR_IDENTITY[/bold green].
-
-1. Set an OS environment variable
-    [bold]EDGAR_IDENTITY=[green]Name email@domain.com[/green][/bold]
-2. Or a Python environment variable
-    import os
-    [bold]os.environ['EDGAR_IDENTITY']=[green]"Name email@domain.com"[/green][/bold]
-3. Or use [bold magenta]edgartools.set_identity[/bold magenta]
-    from edgar import set_identity
-    [bold]set_identity([green]'Name email@domain.com'[/green])[/bold]
-
-But since you are already using [bold]edgartools[/bold] you can set it here
-
-Enter your [bold green]EDGAR_IDENTITY[/bold green] e.g. [bold italic green]Name email@domain.com[/bold italic green]
-"""
-
-
-def ask_for_identity(user_prompt: str = identity_prompt,
-                     timeout: int = 60):
-    timer = threading.Timer(timeout, interrupt_main)
-    timer.start()
-
-    try:
-        # Prompt the user for input
-        input_str = Prompt.ask(user_prompt)
-
-        # Strip the newline character from the end of the input string
-        input_str = input_str.strip()
-    except KeyboardInterrupt:
-        # If the timeout is reached, raise a TimeoutError exception
-        message = "You did not enter your Edgar user identity. Try again .. or set environment variable EDGAR_IDENTITY"
-        log.warning(message)
-        raise TimeoutError(message) from None
-    finally:
-        # Cancel the timer to prevent it from interrupting the main thread
-        timer.cancel()
-
-    return input_str
-
-
-def get_identity() -> str:
-    """
-    Get the sec identity used to set the UserAgent string
-    :return:
-    """
-    identity = os.environ.get(edgar_identity)
-    if not identity:
-        identity = ask_for_identity()
-        os.environ[edgar_identity] = identity
-    return identity
 
 def decode_content(content: bytes):
     try:
@@ -317,19 +212,6 @@ def get_resource(file: str):
 
     import edgar
     return importlib.resources.as_file(importlib.resources.files(edgar).joinpath(file))
-
-
-def get_edgar_data_directory() -> Path:
-    """Get the edgar data directory.
-
-    The directory can be customized via the EDGAR_LOCAL_DATA_DIR environment
-    variable or by using edgar.paths.set_data_directory().
-
-    Returns:
-        Path to the Edgar data directory. Creates it if it doesn't exist.
-    """
-    from edgar.paths import get_data_directory
-    return get_data_directory(create=True)
 
 
 # TooManyRequestsException was a dead duplicate of

--- a/edgar/diagnose_ssl/checks.py
+++ b/edgar/diagnose_ssl/checks.py
@@ -348,7 +348,7 @@ def test_http_request_raw() -> Tuple[bool, Optional[int], Optional[str]]:
     try:
         import httpx
 
-        from edgar.core import get_identity
+        from edgar.settings import get_identity
 
         # Quick request to SEC.gov robots.txt (small file)
         # Uses default httpx settings (SSL verification enabled)
@@ -374,7 +374,7 @@ def test_http_request_configured() -> Tuple[bool, Optional[int], Optional[str]]:
     try:
         import httpx
 
-        from edgar.core import get_identity
+        from edgar.settings import get_identity
         from edgar.httpclient import HTTP_MGR
 
         # Get user's configured settings

--- a/edgar/filesystem.py
+++ b/edgar/filesystem.py
@@ -328,7 +328,7 @@ def get_storage_root() -> str:
     """
     if _cloud_uri:
         return _cloud_uri
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
     return str(get_edgar_data_directory())
 
 
@@ -455,7 +455,7 @@ class EdgarPath:
 
     def _local_path(self) -> Path:
         """Get the local Path for this EdgarPath (internal use)."""
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
         return get_edgar_data_directory() / self._path
 
     def exists(self) -> bool:
@@ -625,7 +625,7 @@ class EdgarPath:
 
         if fs is None:
             # Local filesystem
-            from edgar.core import get_edgar_data_directory
+            from edgar.settings import get_edgar_data_directory
             local_base = self._local_path()
             data_dir = get_edgar_data_directory()
             for match in local_base.glob(pattern):
@@ -667,7 +667,7 @@ class EdgarPath:
 
         if fs is None:
             # Local filesystem
-            from edgar.core import get_edgar_data_directory
+            from edgar.settings import get_edgar_data_directory
             local_path = self._local_path()
             data_dir = get_edgar_data_directory()
             for item in local_path.iterdir():
@@ -750,7 +750,7 @@ class EdgarPath:
                 "Cannot get local path when cloud storage is enabled. "
                 "Use read_text(), read_bytes(), or open() instead."
             )
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
         return get_edgar_data_directory() / self._path
 
 
@@ -816,7 +816,7 @@ def sync_to_cloud(
             "  edgar.sync_to_cloud()"
         )
 
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     # Determine source directory
     local_base = get_edgar_data_directory()

--- a/edgar/httpclient.py
+++ b/edgar/httpclient.py
@@ -26,9 +26,8 @@ except (locale.Error, ValueError):
 # test_verify_reaches_the_transport_params pins the behaviour the patch protected.
 from httpxthrottlecache import HttpxThrottleCache
 
-from edgar.core import get_identity, log, strtobool
-
-from .core import get_edgar_data_directory
+from edgar.core import log, strtobool
+from edgar.settings import get_edgar_data_directory, get_identity
 
 MAX_SUBMISSIONS_AGE_SECONDS = 30  # Check for submissions every 30 seconds (reduced from 10 min for Issue #471)
 MAX_INDEX_AGE_SECONDS = 30 * 60  # Check for updates to index (ie: daily-index) every 30 minutes

--- a/edgar/reference/company_dataset.py
+++ b/edgar/reference/company_dataset.py
@@ -28,7 +28,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from tqdm import tqdm
 
-from edgar.core import get_edgar_data_directory, log
+from edgar.core import log
+from edgar.settings import get_edgar_data_directory
 
 # Try to import orjson for performance, fall back to stdlib json
 try:

--- a/edgar/reference/tickers.py
+++ b/edgar/reference/tickers.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import pandas as pd
 import pyarrow as pa
 
-from edgar.core import get_edgar_data_directory, listify, log
+from edgar.core import listify, log
+from edgar.settings import get_edgar_data_directory
 from edgar.exceptions import http_status
 from edgar.httprequests import download_file, download_json
 from edgar.reference.data.common import read_csv_from_package, read_parquet_from_package

--- a/edgar/settings.py
+++ b/edgar/settings.py
@@ -1,0 +1,197 @@
+"""Connection settings and SEC identity for edgartools.
+
+This is the canonical home for everything a user is *told* to configure: the
+access modes (:data:`NORMAL`, :data:`CAUTION`, :data:`CRAWL`), the identity
+functions the SEC requires you to set, and the local data directory.
+
+Historically all of this lived in ``edgar.core`` alongside quarter math, HTML
+sniffing, a pager, thread helpers and the logger — only about a third of that
+697-line module was settings. ``edgar.core`` still re-exports every name here so
+existing imports keep working; that shim is removed in 6.0 (edgartools-07lk.12.1).
+
+    from edgar.settings import get_identity, set_identity   # preferred
+    from edgar.core import get_identity, set_identity       # works, removed in 6.0
+
+Most users never import this module at all — :func:`set_identity` and the access
+modes are re-exported on the top-level ``edgar`` namespace.
+"""
+import logging
+import os
+import threading
+from _thread import interrupt_main
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+
+import httpx
+from rich.prompt import Prompt
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    'CAUTION',
+    'CRAWL',
+    'NORMAL',
+    'EdgarSettings',
+    'ask_for_identity',
+    'default_http_timeout',
+    'default_max_connections',
+    'default_page_size',
+    'default_retries',
+    'edgar_access_mode',
+    'edgar_data_dir',
+    'edgar_identity',
+    'edgar_mode',
+    'get_edgar_data_directory',
+    'get_identity',
+    'identity_prompt',
+    'limits',
+    'set_identity',
+]
+
+default_http_timeout: int = 12
+default_page_size = 50
+default_max_connections = 10
+default_retries = 3
+
+limits = httpx.Limits(max_connections=default_max_connections)
+
+
+@dataclass
+class EdgarSettings:
+    http_timeout: int
+    max_connections: int
+    retries: int = 3
+
+    @cached_property
+    def limits(self):
+        return httpx.Limits(max_connections=default_max_connections)
+
+    def __eq__(self, othr):
+        return (isinstance(othr, type(self))
+                and (self.http_timeout, self.max_connections, self.retries) ==
+                (othr.http_timeout, othr.max_connections, othr.retries))
+
+    def __hash__(self):
+        return hash((self.http_timeout, self.max_connections, self.retries))
+
+
+# Modes of accessing edgar
+
+# The normal mode of accessing edgar
+NORMAL = EdgarSettings(http_timeout=15, max_connections=10)
+
+# A bit more cautious mode of accessing edgar
+CAUTION = EdgarSettings(http_timeout=20, max_connections=5)
+
+# Use this setting when you have long-running jobs and want to avoid breaching Edgar limits
+CRAWL = EdgarSettings(http_timeout=25, max_connections=2, retries=2)
+
+edgar_access_mode = os.getenv('EDGAR_ACCESS_MODE', 'NORMAL')
+if edgar_access_mode == 'CAUTION':
+    # A bit more cautious mode of accessing edgar
+    edgar_mode = CAUTION
+elif edgar_access_mode == 'CRAWL':
+    # Use this setting when you have long-running jobs and want to avoid breaching Edgar limits
+    edgar_mode = CRAWL
+else:
+    # The normal mode of accessing edgar
+    edgar_mode = NORMAL
+
+edgar_identity = 'EDGAR_IDENTITY'
+
+# Local storage directory - use centralized path configuration
+from edgar.paths import get_data_directory as _get_data_directory  # noqa: E402
+
+edgar_data_dir = str(_get_data_directory(create=False))
+
+
+def set_identity(user_identity: str):
+    """
+    This function sets the environment variable EDGAR_IDENTITY to the identity you will use to call Edgar
+
+    This user identity looks like
+
+        "Sample Company Name AdminContact@<sample company domain>.com"
+
+    See https://www.sec.gov/os/accessing-edgar-data
+
+    :param user_identity:
+    """
+    os.environ[edgar_identity] = user_identity
+    log.info("Identity of the Edgar REST client set to [%s]", user_identity)
+
+    from edgar.httpclient import close_clients
+    close_clients() # close any httpx clients, to reset the identity.
+
+
+identity_prompt = """
+[bold turquoise4]Identify your client to SEC Edgar[/bold turquoise4]
+------------------------------------------------------------------------------
+
+Before running [bold]edgartools[/bold] it needs to know the UserAgent string to send to Edgar.
+See https://www.sec.gov/os/accessing-edgar-data
+
+This can be set in the environment variable [bold green]EDGAR_IDENTITY[/bold green].
+
+1. Set an OS environment variable
+    [bold]EDGAR_IDENTITY=[green]Name email@domain.com[/green][/bold]
+2. Or a Python environment variable
+    import os
+    [bold]os.environ['EDGAR_IDENTITY']=[green]"Name email@domain.com"[/green][/bold]
+3. Or use [bold magenta]edgartools.set_identity[/bold magenta]
+    from edgar import set_identity
+    [bold]set_identity([green]'Name email@domain.com'[/green])[/bold]
+
+But since you are already using [bold]edgartools[/bold] you can set it here
+
+Enter your [bold green]EDGAR_IDENTITY[/bold green] e.g. [bold italic green]Name email@domain.com[/bold italic green]
+"""
+
+
+def ask_for_identity(user_prompt: str = identity_prompt,
+                     timeout: int = 60):
+    timer = threading.Timer(timeout, interrupt_main)
+    timer.start()
+
+    try:
+        # Prompt the user for input
+        input_str = Prompt.ask(user_prompt)
+
+        # Strip the newline character from the end of the input string
+        input_str = input_str.strip()
+    except KeyboardInterrupt:
+        # If the timeout is reached, raise a TimeoutError exception
+        message = "You did not enter your Edgar user identity. Try again .. or set environment variable EDGAR_IDENTITY"
+        log.warning(message)
+        raise TimeoutError(message) from None
+    finally:
+        # Cancel the timer to prevent it from interrupting the main thread
+        timer.cancel()
+
+    return input_str
+
+
+def get_identity() -> str:
+    """
+    Get the sec identity used to set the UserAgent string
+    :return:
+    """
+    identity = os.environ.get(edgar_identity)
+    if not identity:
+        identity = ask_for_identity()
+        os.environ[edgar_identity] = identity
+    return identity
+
+
+def get_edgar_data_directory() -> Path:
+    """Get the edgar data directory.
+
+    The directory can be customized via the EDGAR_LOCAL_DATA_DIR environment
+    variable or by using edgar.paths.set_data_directory().
+
+    Returns:
+        Path to the Edgar data directory. Creates it if it doesn't exist.
+    """
+    from edgar.paths import get_data_directory
+    return get_data_directory(create=True)

--- a/edgar/sgml/sgml_common.py
+++ b/edgar/sgml/sgml_common.py
@@ -28,7 +28,7 @@ def _fetch_url_directly(url: str) -> str:
     bypass_cache parameter has no effect after the client is first created.
     """
     import httpx
-    from edgar.core import get_identity
+    from edgar.settings import get_identity
 
     headers = {"User-Agent": get_identity()}
     with httpx.Client(headers=headers) as client:

--- a/edgar/storage/_local.py
+++ b/edgar/storage/_local.py
@@ -16,7 +16,8 @@ from edgar.exceptions import EdgarError, TransportError, http_status
 from httpx import AsyncClient, HTTPStatusError
 from tqdm.auto import tqdm
 
-from edgar.core import filing_date_to_year_quarters, get_edgar_data_directory, log, strtobool
+from edgar.core import filing_date_to_year_quarters, log, strtobool
+from edgar.settings import get_edgar_data_directory
 from edgar.dates import extract_dates
 from edgar.httprequests import download_bulk_data, download_datafile, download_text
 from edgar.urls import build_company_tickers_exchange_url, build_company_tickers_url, build_mutual_fund_tickers_url, build_ticker_url

--- a/edgar/storage/_management.py
+++ b/edgar/storage/_management.py
@@ -171,7 +171,7 @@ def _scan_storage(force_refresh: bool = False) -> StorageInfo:
         if time.time() - timestamp < _CACHE_TTL:
             return info
 
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
     storage_path = get_edgar_data_directory()
 
     # Initialize counters
@@ -366,7 +366,7 @@ def analyze_storage(force_refresh: bool = False) -> StorageAnalysis:
         >>> if analysis.potential_savings_bytes > 1e9:
         ...     print(f"Can save {analysis.potential_savings_bytes / 1e9:.1f} GB")
     """
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     info = storage_info(force_refresh=force_refresh)
     storage_path = get_edgar_data_directory()
@@ -497,7 +497,7 @@ def optimize_storage(dry_run: bool = True) -> Dict[str, int]:
     import gzip
     import shutil
 
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     storage_path = get_edgar_data_directory()
     files_compressed = 0
@@ -575,7 +575,7 @@ def cleanup_storage(days: int = 365, dry_run: bool = True) -> Dict[str, int]:
     """
     from datetime import datetime, timedelta
 
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     storage_path = get_edgar_data_directory()
     cutoff_date = datetime.now() - timedelta(days=days)
@@ -660,7 +660,7 @@ def clear_cache(dry_run: bool = True, obsolete_only: bool = False) -> Dict[str, 
         >>> result = clear_cache(dry_run=False)
         >>> print(f"Cleared {result['files_deleted']} cache files")
     """
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     storage_path = get_edgar_data_directory()
     files_deleted = 0

--- a/tests/fixtures/conftest_company_subsets.py
+++ b/tests/fixtures/conftest_company_subsets.py
@@ -57,7 +57,7 @@ def check_full_dataset_available():
     This is for integration tests marked with @pytest.mark.slow that need
     the real 562K company dataset.
     """
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
 
     submissions_dir = get_edgar_data_directory() / 'submissions'
 

--- a/tests/issues/regression/test_07lk121_settings_extraction.py
+++ b/tests/issues/regression/test_07lk121_settings_extraction.py
@@ -1,0 +1,150 @@
+"""Settings and identity live in `edgar.settings`; `edgar.core` re-exports them.
+
+edgartools-07lk.12.1, staged under 07lk.23's "new paths behind import shims" row.
+
+The bead proposed renaming `edgar/core.py` to `edgar/settings.py`. Measurement
+said no: core.py was 697 lines across 56 top-level definitions and only about a
+third was settings — the rest is quarter math, HTML sniffing, a pager, thread
+helpers, `Result` and the logger. Renaming the file would have filed
+`parallel_thread_map` and `has_html_content` under "settings", relabelling the
+grab-bag instead of resolving it. So the settings third was *extracted* and the
+rest left alone.
+
+WHAT THIS FILE GUARDS, and why each half matters:
+
+1. **The implementation MOVED; core.py is the wrapper.** This is the 07lk.23
+   rename trap, and it is the whole reason the direction matters: if the code had
+   stayed in core.py with settings.py aliasing *onto* it, the real implementation
+   would still sit at the path 6.0 intends to delete, and dropping the shim would
+   take the implementation with it. Asserted by module identity, not by value.
+
+2. **The re-exports are the SAME objects, not copies.** 71 call sites import from
+   `edgar.core`, every one of them a `from edgar.core import <name>` (measured by
+   AST — zero `import edgar.core`, zero attribute access). A re-export therefore
+   covers 100% of them, but only if identity holds: `NORMAL is CAUTION`-style
+   comparisons and `isinstance(x, EdgarSettings)` must not care which path the
+   name arrived by.
+"""
+import edgar
+import edgar.core
+import edgar.settings
+
+SETTINGS_NAMES = [
+    "CAUTION",
+    "CRAWL",
+    "NORMAL",
+    "EdgarSettings",
+    "ask_for_identity",
+    "default_http_timeout",
+    "default_max_connections",
+    "default_page_size",
+    "default_retries",
+    "edgar_access_mode",
+    "edgar_data_dir",
+    "edgar_identity",
+    "edgar_mode",
+    "get_edgar_data_directory",
+    "get_identity",
+    "identity_prompt",
+    "limits",
+    "set_identity",
+]
+
+
+class TestTheImplementationMoved:
+    """Not aliased onto the deprecated name — moved to the canonical one."""
+
+    def test_functions_are_defined_in_edgar_settings(self):
+        for name in ("set_identity", "get_identity", "ask_for_identity",
+                     "get_edgar_data_directory"):
+            fn = getattr(edgar.settings, name)
+            assert fn.__module__ == "edgar.settings", (
+                f"{name} reports __module__={fn.__module__!r}; the implementation "
+                f"must live at the canonical name so 6.0 can drop the edgar.core "
+                f"shim without taking the implementation with it"
+            )
+
+    def test_edgarsettings_class_is_defined_in_edgar_settings(self):
+        assert edgar.settings.EdgarSettings.__module__ == "edgar.settings"
+
+
+class TestCoreStillReExportsEverything:
+    """The shim, removed in 6.0. Until then all 71 call sites keep working."""
+
+    def test_every_settings_name_is_reachable_from_core(self):
+        missing = [n for n in SETTINGS_NAMES if not hasattr(edgar.core, n)]
+        assert not missing, f"edgar.core stopped re-exporting: {missing}"
+
+    def test_re_exports_are_the_same_objects(self):
+        """Identity, not equality.
+
+        A copy would pass an equality check and still break
+        `isinstance(x, EdgarSettings)` and `mode is NORMAL`.
+        """
+        for name in SETTINGS_NAMES:
+            assert getattr(edgar.core, name) is getattr(edgar.settings, name), (
+                f"edgar.core.{name} is a different object from edgar.settings.{name}"
+            )
+
+    def test_the_top_level_namespace_is_unaffected(self):
+        """What the docs actually tell people to import."""
+        for name in ("set_identity", "get_identity", "NORMAL", "CAUTION", "CRAWL"):
+            assert getattr(edgar, name) is getattr(edgar.settings, name)
+
+    def test_isinstance_still_works_across_both_paths(self):
+        from edgar.core import NORMAL as core_normal
+        from edgar.settings import EdgarSettings as settings_cls
+
+        assert isinstance(core_normal, settings_cls)
+
+
+class TestWhatDeliberatelyStayedInCore:
+    """The other two thirds. Moving 34 files for one name (`log`) is churn with
+    no user-visible benefit, and `edgar/logging.py` would sit confusingly beside
+    stdlib logging."""
+
+    def test_non_settings_names_did_not_move(self):
+        for name in ("listify", "text_extensions", "binary_extensions",
+                     "has_html_content", "is_probably_html", "strtobool",
+                     "get_bool", "parallel_thread_map", "DataPager"):
+            assert hasattr(edgar.core, name)
+            assert not hasattr(edgar.settings, name), (
+                f"{name} is not settings and should not have moved"
+            )
+
+    def test_settings_has_its_own_logger_rather_than_importing_cores(self):
+        """`log` is the one name both modules define, and that is deliberate.
+
+        34 files import `log` from `edgar.core`; it stays there. But
+        `edgar.settings` cannot import it back, because core.py imports settings
+        — the dependency runs one way only, and reversing it here would make the
+        shim a cycle. So settings carries its own module logger. Two distinct
+        loggers, correctly named after their own modules.
+        """
+        assert edgar.settings.log is not edgar.core.log
+        assert edgar.settings.log.name == "edgar.settings"
+        assert edgar.core.log.name == "edgar.core"
+
+    def test_core_imports_settings_and_not_the_reverse(self):
+        """The direction that lets 6.0 delete core.py's shim block cleanly.
+
+        Checked by parsing, not by searching the text: `edgar/settings.py`
+        mentions `from edgar.core import ...` twice in prose — once in its module
+        docstring showing the old path, once inside the identity prompt string —
+        and a substring search reports those as imports.
+        """
+        import ast
+
+        def imported_modules(module) -> set:
+            tree = ast.parse(open(module.__file__).read())
+            return {
+                n.module
+                for n in ast.walk(tree)
+                if isinstance(n, ast.ImportFrom) and n.module
+            }
+
+        assert "edgar.settings" in imported_modules(edgar.core)
+        assert "edgar.core" not in imported_modules(edgar.settings), (
+            "edgar.settings must not depend on edgar.core — that would make the "
+            "deprecation shim a circular import"
+        )

--- a/tests/issues/regression/test_issue_381_pr_493.py
+++ b/tests/issues/regression/test_issue_381_pr_493.py
@@ -25,7 +25,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, AsyncMock
 
-from edgar.core import get_edgar_data_directory
+from edgar.settings import get_edgar_data_directory
 from edgar.storage import use_local_storage
 
 

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -7,7 +7,7 @@ import pyarrow.compute as pc
 from rich import print
 
 from edgar._filings import Filing, Filings, get_filings
-from edgar.core import default_page_size
+from edgar.settings import default_page_size
 from edgar.entity import public_companies
 from edgar.entity import *
 from edgar.entity.data import preprocess_company

--- a/tests/test_company_groups.py
+++ b/tests/test_company_groups.py
@@ -23,7 +23,7 @@ import pandas as pd
 from dataclasses import dataclass
 
 from edgar import Company
-from edgar.core import set_identity
+from edgar.settings import set_identity
 from edgar.reference.company_subsets import (
     CompanySubset,
     get_popular_companies,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,17 +12,8 @@ from rich.table import Table
 import edgar
 from edgar.dates import extract_dates, InvalidDateError
 from edgar.display.formatting import display_size, reverse_name, split_camel_case
-from edgar.core import (decode_content,
-                        get_identity,
-                        set_identity,
-                        ask_for_identity,
-                        Result,
-                        CRAWL, CAUTION,
-                        get_bool,
-                        is_start_of_quarter,
-                        has_html_content,
-
-                        parallel_thread_map)
+from edgar.core import decode_content, Result, get_bool, is_start_of_quarter, has_html_content, parallel_thread_map
+from edgar.settings import get_identity, set_identity, ask_for_identity, CRAWL, CAUTION
 from edgar.filtering import (
     filter_by_form,
     filter_by_cik,

--- a/tests/test_filing.py
+++ b/tests/test_filing.py
@@ -17,7 +17,7 @@ from edgar import get_filings, Filings, Filing, get_entity, get_by_accession_num
 from edgar._filings import FilingHomepage, read_fixed_width_index, form_specs, company_specs, Attachment, \
     filing_date_to_year_quarters, get_filing_by_accession
 from edgar.company_reports import TenK
-from edgar.core import default_page_size
+from edgar.settings import default_page_size
 from edgar.entity import Company
 from edgar._filings import read_index_file
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -247,7 +247,7 @@ class TestIntegrationWithEdgarCore:
 
     def test_core_uses_paths_module(self, monkeypatch, tmp_path):
         """edgar.core.get_edgar_data_directory should use paths module."""
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
 
         custom_path = tmp_path / 'edgar_data'
         custom_path.mkdir()

--- a/tests/test_reference_company_dataset.py
+++ b/tests/test_reference_company_dataset.py
@@ -279,7 +279,7 @@ class TestBuildDatasetReal:
     @pytest.mark.manual
     def test_build_real_dataset(self, tmp_path):
         """Build dataset from real submissions (if available)"""
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
 
         submissions_dir = get_edgar_data_directory() / 'submissions'
 
@@ -311,7 +311,7 @@ class TestGetDataset:
     @pytest.fixture(autouse=True)
     def check_submissions_available(self):
         """Skip all tests in this class if submissions not available"""
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
 
         submissions_dir = get_edgar_data_directory() / 'submissions'
 
@@ -471,7 +471,7 @@ class TestDuckDBIntegration:
         """Build DuckDB from real submissions"""
         pytest.importorskip("duckdb")
 
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
 
         submissions_dir = get_edgar_data_directory() / 'submissions'
 
@@ -511,7 +511,7 @@ class TestPerformance:
     @pytest.fixture(autouse=True)
     def check_submissions_available(self):
         """Skip all tests in this class if submissions not available"""
-        from edgar.core import get_edgar_data_directory
+        from edgar.settings import get_edgar_data_directory
 
         submissions_dir = get_edgar_data_directory() / 'submissions'
 

--- a/tests/test_storage_management.py
+++ b/tests/test_storage_management.py
@@ -5,7 +5,7 @@ Tests for storage management functionality
 import pytest
 from pathlib import Path
 from edgar.storage._management import storage_info, StorageInfo, _scan_storage
-from edgar.core import get_edgar_data_directory
+from edgar.settings import get_edgar_data_directory
 import time
 
 @pytest.mark.slow
@@ -232,7 +232,7 @@ def test_clear_cache_obsolete_only():
 def test_analyze_storage_detects_obsolete_cache(tmp_path):
     """Test that analyze_storage detects obsolete _pcache directory"""
     from edgar.storage._management import analyze_storage
-    from edgar.core import get_edgar_data_directory
+    from edgar.settings import get_edgar_data_directory
     import os
 
     # Create a temporary _pcache directory with a test file

--- a/tests/test_unit_compatibility_modes.py
+++ b/tests/test_unit_compatibility_modes.py
@@ -7,7 +7,7 @@ users get predictable results when requesting specific units.
 
 import pytest
 from edgar import Company
-from edgar.core import set_identity
+from edgar.settings import set_identity
 from edgar.entity.unit_handling import UnitNormalizer, UnitResult
 
 

--- a/tests/test_unit_handling.py
+++ b/tests/test_unit_handling.py
@@ -16,7 +16,7 @@ from edgar.entity.unit_handling import (
 )
 from edgar.entity.models import FinancialFact
 from edgar import Company
-from edgar.core import set_identity
+from edgar.settings import set_identity
 
 
 class TestUnitNormalizer:


### PR DESCRIPTION
Settles `07lk.12.1` item (6). The bead proposed renaming `edgar/core.py` → `edgar/settings.py`; this does the **bounded extraction** instead, per the recommendation measured onto the bead.

## Why not the rename

`core.py` was 697 lines across 56 top-level definitions, and only about a third was settings. The rest is quarter math, HTML sniffing, a pager, thread helpers, `Result` and the logger. Renaming the file would have filed `parallel_thread_map` and `has_html_content` under "settings" — relabelling the grab-bag rather than resolving it.

So the settings third moved and the rest stayed put. `edgar/settings.py` owns the access modes (`NORMAL`/`CAUTION`/`CRAWL`), `EdgarSettings`, `set_identity`, `get_identity`, `ask_for_identity` and `get_edgar_data_directory` — which is 100% of what the documentation tells users to import from `edgar.core`. `core.py` drops 697 → 584 lines.

## Direction matters

The implementation **moved** to the canonical name and `core.py` imports it back. `settings.py` does not alias onto `core`.

That is the `07lk.23` rename trap: aliasing the other way leaves the real code at the path 6.0 intends to delete, so dropping the shim would take the implementation with it. Pinned by module identity in the new regression test, not by value.

## Blast radius, re-measured

The bead says its own lists go stale and to re-measure before executing. Its headline numbers held exactly — 71 files / 149 names, and **zero** `import edgar.core` module-path statements or attribute access. Every call site is a `from edgar.core import <name>`, so a re-export covers all of them.

| | before | after |
|---|---|---|
| `edgar.core` importers | 71 files / 149 names | 58 / 106 |
| `edgar.settings` importers | — | 22 / 63 |

The 20 rewritten importers were edited via AST line ranges rather than regex, so parenthesised and multi-line import forms were handled correctly.

## Nothing breaks

`edgar.core` re-exports every moved name, and they are the **same objects** — `isinstance` checks and identity comparisons behave identically. Top-level imports (`from edgar import set_identity, CAUTION`) are unaffected now and in 6.0.

## One file deliberately skipped

`edgar/httprequests.py` carries another session's uncommitted work; editing it would entangle their change with this one at staging time. The shim keeps its `from edgar.core import get_edgar_data_directory` working, so this costs nothing functionally — it needs a one-line follow-up once that WIP lands.

## Two things the new tests caught

Both would have been silent:

- **`edgar.settings` needs its own module logger.** It cannot import `log` from `core`, because `core` imports `settings` — reversing that makes the shim a circular import. Now asserted, along with the import direction itself.
- **The "settings doesn't import core" check was initially a text search**, which matched the phrase inside `settings.py`'s own docstring and inside the identity prompt string. It parses the AST now.

## Docs

5 documented import lines repointed (`docs/configuration.md`, `docs/guides/local-storage.md`), plus a `docs/upgrade/6.0.md` section — required by `07lk.18` for every deprecation staged under `07lk.23`'s "new paths behind import shims" row.

## Verification

- `hatch run test-fast` — 5384 passed
- `hatch run test-regression` — 2577 passed, 4 xfailed, 0 reruns
- ruff on the touched files: 23 → 22 pre-existing findings, none new

🤖 Generated with [Claude Code](https://claude.com/claude-code)