### PR TITLE
docs: derive the public-API counts instead of transcribing them

### DIFF
--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -73,14 +73,14 @@ python -W "default::DeprecationWarning" your_script.py
 
 ## `edgar` now declares `__all__`
 
-**What changed.** The top-level package declares its public API — 110 names.
-Until now there was no way to tell an API from an accident: 141 names were
-reachable from `edgar`, including `Optional` and `partial` (imported for
-annotations) and `Document`, which is the *legacy* `edgar.files` parser and a
-different class from `edgar.documents.Document`.
+**What changed.** The top-level package declares its public API in `__all__`.
+Until now there was no way to tell an API from an accident: everything reachable
+from `edgar` looked equally official, including `Optional` and `partial`
+(imported for annotations) and `Document`, which is the *legacy* `edgar.files`
+parser and a different class from `edgar.documents.Document`.
 
 **What breaks today: `from edgar import *` is narrower.** It no longer supplies
-the 31 names outside `__all__`. If you use star-import and something stops
+the names outside `__all__`. If you use star-import and something stops
 resolving, import it from where it lives:
 
 ```python

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -179,7 +179,10 @@ get_portfolio_holding_filings = partial(get_filings, form=THIRTEENF_FORMS)
 # the enforcement in 6.0). If something you depend on is missing here, that is
 # worth an issue before 6.0 rather than after.
 #
-# THREE THINGS DELIBERATELY LEFT OUT, of 141 public names on 2026-08-10:
+# THREE THINGS DELIBERATELY LEFT OUT. (No count here on purpose — this line used
+# to say "of 141 public names on 2026-08-10" and was 153 eleven days later, with
+# nothing to catch it. `tests/issues/regression/test_public_api_surface.py`
+# derives the current figures; run it with `-s` to see them.)
 #
 #   1. `List`, `Optional`, `Union`, `lru_cache`, `partial` — imported above for
 #      annotations and never API. `from edgar import Optional` works today and
@@ -198,7 +201,7 @@ get_portfolio_holding_filings = partial(get_filings, form=THIRTEENF_FORMS)
 # `__all__`; this governs the top-level namespace only.
 #
 # Keep it grouped rather than sorted — the grouping is the documentation of what
-# the library is for, and a flat alphabetical list of 110 names is not.
+# the library is for, and a flat alphabetical list is not.
 __all__ = [
     # -- Entry points --------------------------------------------------------
     "find", "obj",

--- a/tests/issues/regression/test_public_api_surface.py
+++ b/tests/issues/regression/test_public_api_surface.py
@@ -4,11 +4,19 @@ The declared public API of `edgar`, pinned.
 Bead: edgartools-07lk.5
 
 `edgar/__init__.py` had no `__all__`, so "is this part of the API?" had no
-answer except whether the import happened to work. 141 names were reachable
-from the top-level namespace, including `Optional` and `partial` — imported for
-annotations and never API — and `Document`, the *legacy* parser from
-`edgar.files`, a different class from `edgar.documents.Document` and scheduled
-for removal in 6.0.
+answer except whether the import happened to work. Everything reachable from the
+top-level namespace looked equally official, including `Optional` and `partial`
+— imported for annotations and never API — and `Document`, the *legacy* parser
+from `edgar.files`, a different class from `edgar.documents.Document` and
+scheduled for removal in 6.0.
+
+NO COUNTS IN THIS PROSE, deliberately. It used to open "141 names were
+reachable"; `edgar/__init__.py` and `docs/upgrade/6.0.md` carried the same figure
+plus "110 names" and "31 names outside `__all__`". Eleven days later the real
+numbers were 153, 123 and 30, and nothing failed — a count written into a
+sentence is prose wearing the costume of a measurement, and no test guarded it.
+`test_report_the_current_surface` below derives them instead, so the numbers come
+from the code that has them rather than from someone remembering to retype them.
 
 WHAT THESE TESTS ARE FOR. Not to freeze the API — names get added, and adding
 one here is a two-line change. They exist so that adding a name to the top-level
@@ -164,4 +172,33 @@ def test_the_exported_document_class_is_not_the_legacy_one():
     assert edgar.Document is not ModernDocument, (
         "edgar.Document now IS edgar.documents.Document — that is a change worth "
         "making deliberately, and this test and __all__ should follow it."
+    )
+
+
+def test_report_the_current_surface(capsys):
+    """Derive the surface counts instead of transcribing them into prose.
+
+    Run with `-s` to read them:
+
+        hatch run test:pytest tests/issues/regression/test_public_api_surface.py \
+            -k report_the_current_surface -s
+
+    This asserts internal consistency rather than a fixed size — pinning the
+    numbers is what rotted last time, and freezing them would fail on every
+    added name, which the tests above deliberately do not do. What it does catch
+    is the surface drifting in a way the classification missed: every public
+    name is either exported or listed INTERNAL, so the three totals must add up.
+    """
+    public = _public_names()
+    exported = set(edgar.__all__)
+    undeclared = public - exported
+
+    print(f"\npublic top-level names: {len(public)}")
+    print(f"declared in __all__:    {len(exported)}")
+    print(f"undeclared (INTERNAL):  {len(undeclared)}")
+
+    assert len(public) == len(exported & public) + len(undeclared)
+    assert undeclared == INTERNAL & public, (
+        "the undeclared set has drifted from INTERNAL — "
+        f"unclassified: {sorted(undeclared - INTERNAL)}"
     )


### PR DESCRIPTION
Follow-up to #1075. Found while reviewing `edgar/__init__.py`; unrelated to that change, which was surface-neutral (153/123/30 before and after).

## The problem

Five hardcoded counts described the top-level surface. All five were wrong:

| Claim | Where | Actual |
|---|---|---|
| "110 names" in `__all__` | `__init__.py:201`, `6.0.md:76` | **123** |
| "141 public names on 2026-08-10" | `__init__.py:182`, `6.0.md:77`, `test_public_api_surface.py:7` | **153** |
| "31 names outside `__all__`" | `6.0.md:83` | **30** |

Eleven days, twelve names, and nothing failed. `test_public_api_surface.py` guards the `INTERNAL` classification programmatically but never guarded either figure — so a count written into a sentence was prose wearing the costume of a measurement.

## The fix

Retyping the numbers fixes today and drifts again on the next added name. So the sentences drop the counts and a new test derives them.

The prose loses nothing. "The top-level package declares its public API" makes its point without a figure, and `docs/upgrade/6.0.md` is read by users who gain nothing from an exact count.

`test_report_the_current_surface` prints public / declared / undeclared and asserts the three are internally consistent — every public name is either exported or listed `INTERNAL`, so the totals must add up:

```
$ hatch run test:pytest tests/issues/regression/test_public_api_surface.py \
      -k report_the_current_surface -s

public top-level names: 153
declared in __all__:    123
undeclared (INTERNAL):  30
```

Deliberately **not** a fixed size. Pinning the number is what rotted, and freezing it would fail on every added name — which these tests exist specifically not to do; their whole design note says "not to freeze the API".

The old figures survive as quotations inside the notes explaining why they were removed. Those are historical statements about what the text used to say, so they cannot go stale.

## Verification

- `hatch run test-fast` — 5385 passed
- `test_public_api_surface.py` — 131 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)