### PR TITLE
fix(http): resolve relative redirect Locations against the request URL

### DIFF
--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -16,7 +16,7 @@ from typing import Optional, Union, cast
 
 import httpcore
 import orjson as json
-from httpx import AsyncClient, ConnectError, HTTPError, ReadTimeout, RequestError, Response, Timeout, TimeoutException
+from httpx import URL, AsyncClient, ConnectError, HTTPError, ReadTimeout, RequestError, Response, Timeout, TimeoutException
 from stamina import retry
 from tqdm import tqdm
 
@@ -708,6 +708,20 @@ def is_redirect(response):
     return response.status_code in [301, 302]
 
 
+def redirect_url(url, response) -> str:
+    """Resolve a redirect's ``Location`` against the URL that produced it.
+
+    ``Location`` may be relative (RFC 7231 7.1.2) and SEC uses that form:
+    ``/about/opendatasetsshtmlinvestment_company`` 301s to a bare
+    ``/data-research/...`` path. Following the header verbatim hands httpx a
+    URL with no scheme, which fails with ``UnsupportedProtocol`` — the request
+    never reaches the network, so callers see a hard error rather than a
+    redirect. ``URL.join`` does RFC 3986 reference resolution, leaving absolute
+    Locations untouched and giving protocol-relative ones the current scheme.
+    """
+    return str(URL(url).join(response.headers["Location"]))
+
+
 def _get_retry_after(response: Response) -> Optional[int]:
     """
     Extract Retry-After header value from response.
@@ -819,7 +833,7 @@ def get_with_retry(url, identity=None, identity_callable=None, **kwargs):
             if response.status_code == 429:
                 raise TooManyRequestsError(url, retry_after=_get_retry_after(response))
             elif is_redirect(response):
-                return get_with_retry(url=response.headers["Location"], identity=identity, identity_callable=identity_callable, **kwargs)
+                return get_with_retry(url=redirect_url(url, response), identity=identity, identity_callable=identity_callable, **kwargs)
             return response
     except ConnectError as e:
         if is_ssl_error(e):
@@ -863,7 +877,7 @@ async def get_with_retry_async(client: AsyncClient, url, identity=None, identity
             raise TooManyRequestsError(url, retry_after=_get_retry_after(response))
         elif is_redirect(response):
             return await get_with_retry_async(
-                client=client, url=response.headers["Location"], identity=identity, identity_callable=identity_callable, **kwargs
+                client=client, url=redirect_url(url, response), identity=identity, identity_callable=identity_callable, **kwargs
             )
         return response
     except ConnectError as e:
@@ -910,7 +924,7 @@ def stream_with_retry(url, identity=None, identity_callable=None, bypass_cache=F
                 if response.status_code == 429:
                     raise TooManyRequestsError(url, retry_after=_get_retry_after(response))
                 elif is_redirect(response):
-                    response = stream_with_retry(response.headers["Location"], identity=identity, identity_callable=identity_callable, **kwargs)
+                    response = stream_with_retry(redirect_url(url, response), identity=identity, identity_callable=identity_callable, **kwargs)
                     yield from response
                 else:
                     yield response
@@ -959,7 +973,7 @@ def post_with_retry(url, data=None, json=None, identity=None, identity_callable=
                 raise TooManyRequestsError(url, retry_after=_get_retry_after(response))
             elif is_redirect(response):
                 return post_with_retry(
-                    response.headers["Location"], data=data, json=json, identity=identity, identity_callable=identity_callable, **kwargs
+                    redirect_url(url, response), data=data, json=json, identity=identity, identity_callable=identity_callable, **kwargs
                 )
             return response
     except ConnectError as e:
@@ -1006,7 +1020,7 @@ async def post_with_retry_async(client: AsyncClient, url, data=None, json=None, 
             raise TooManyRequestsError(url, retry_after=_get_retry_after(response))
         elif is_redirect(response):
             return await post_with_retry_async(
-                client, response.headers["Location"], data=data, json=json, identity=identity, identity_callable=identity_callable, **kwargs
+                client, redirect_url(url, response), data=data, json=json, identity=identity, identity_callable=identity_callable, **kwargs
             )
         return response
     except ConnectError as e:

--- a/tests/test_company_integration.py
+++ b/tests/test_company_integration.py
@@ -1,93 +1,77 @@
-#!/usr/bin/env python3
+"""Integration tests for FormType against real Company filing lookups.
+
+This file used to be a top-to-bottom demo script: it built ``Company("AAPL")``
+and ran six filing lookups at module scope, printed check marks, and wrapped
+every check in ``try/except`` that printed a cross and carried on. It contained
+no test functions, so it asserted nothing and could never fail a build — but
+pytest still executed the module body during COLLECTION, and a collection error
+aborts the entire session before a single test runs. That is exactly what
+happened in CI when SEC answered 429: a 6,000-test regression run was
+interrupted by this file and one other, whose own tests had been deselected
+anyway.
+
+Rewritten as real tests: the network happens inside a fixture, the checks are
+assertions rather than prints, and a failure here fails these tests instead of
+the suite.
 """
-Integration test for FormType with actual Company usage
-Tests both new typed usage and backwards compatibility
-"""
+import pytest
 
-print("=== Testing Company Integration ===")
+from edgar import Company
+from edgar.enums import FormType
 
-try:
-    from edgar import Company
-    from edgar.enums import FormType
-    print("✅ Imports successful")
-except ImportError as e:
-    print(f"❌ Import failed: {e}")
-    exit(1)
+pytestmark = pytest.mark.network
 
-# Test with a well-known company
-company = Company("AAPL")
-print(f"✅ Company created: {company.name}")
+YEAR = 2023
 
-print("\n=== Testing New FormType Usage ===")
-try:
-    # Test FormType enum usage
-    filings = company.get_filings(form=FormType.ANNUAL_REPORT, year=2023)
-    print(f"✅ FormType usage successful: Found {len(filings)} 10-K filings")
-    
-    # Test quarterly reports
-    filings_q = company.get_filings(form=FormType.QUARTERLY_REPORT, year=2023)
-    print(f"✅ Quarterly FormType: Found {len(filings_q)} 10-Q filings")
-    
-except Exception as e:
-    print(f"❌ FormType usage failed: {e}")
 
-print("\n=== Testing Backwards Compatibility ===")
-try:
-    # Test existing string usage still works
-    filings_str = company.get_filings(form="10-K", year=2023)
-    print(f"✅ String usage works: Found {len(filings_str)} 10-K filings")
-    
-    # Test list of strings still works
-    filings_list = company.get_filings(form=["10-K", "10-Q"], year=2023)
-    print(f"✅ List usage works: Found {len(filings_list)} filings")
-    
-except Exception as e:
-    print(f"❌ Backwards compatibility failed: {e}")
+@pytest.fixture(scope="module")
+def apple():
+    return Company("AAPL")
 
-print("\n=== Testing Mixed Usage ===")
-try:
-    # Test mixed FormType and string in list
-    mixed_filings = company.get_filings(
-        form=[FormType.ANNUAL_REPORT, "8-K"], 
-        year=2023
-    )
-    print(f"✅ Mixed usage works: Found {len(mixed_filings)} filings")
-    
-except Exception as e:
-    print(f"❌ Mixed usage failed: {e}")
 
-print("\n=== Verifying Results are Identical ===")
-try:
-    # FormType and string should give identical results
-    form_type_results = company.get_filings(form=FormType.ANNUAL_REPORT, year=2023)
-    string_results = company.get_filings(form="10-K", year=2023)
-    
-    if len(form_type_results) == len(string_results):
-        print("✅ FormType and string results are identical")
-        
-        # Check accession numbers match
-        form_type_accessions = {f.accession_number for f in form_type_results}
-        string_accessions = {f.accession_number for f in string_results}
-        
-        if form_type_accessions == string_accessions:
-            print("✅ Accession numbers match - perfect backwards compatibility")
-        else:
-            print("⚠️  Accession numbers differ")
-    else:
-        print(f"⚠️  Result counts differ: FormType({len(form_type_results)}) vs String({len(string_results)})")
-        
-except Exception as e:
-    print(f"❌ Results comparison failed: {e}")
+def test_form_type_enum_selects_filings(apple):
+    """FormType members resolve to the same filings a form string selects."""
+    annual = apple.get_filings(form=FormType.ANNUAL_REPORT, year=YEAR)
+    quarterly = apple.get_filings(form=FormType.QUARTERLY_REPORT, year=YEAR)
 
-print("\n=== Testing Developer Experience ===")
-print("When you type 'FormType.' in your IDE, you should see:")
-for form_type in list(FormType)[:5]:  # Show first 5
-    print(f"  • {form_type.name} → '{form_type.value}'")
-print("  • ... and 26 more options")
+    assert len(annual) > 0
+    assert len(quarterly) > 0
+    assert {f.form for f in annual} == {"10-K"}
+    assert {f.form for f in quarterly} == {"10-Q"}
 
-print("\n🎉 Company integration test completed!")
-print("\nThe FormType implementation provides:")
-print("• Perfect backwards compatibility")
-print("• IDE autocomplete for form types") 
-print("• Type safety with runtime validation")
-print("• Identical results for FormType vs string usage")
+
+def test_form_strings_still_work(apple):
+    """The pre-FormType string API is unchanged."""
+    single = apple.get_filings(form="10-K", year=YEAR)
+    combined = apple.get_filings(form=["10-K", "10-Q"], year=YEAR)
+
+    assert len(single) > 0
+    assert len(combined) >= len(single)
+    assert {f.form for f in combined} <= {"10-K", "10-Q"}
+
+
+def test_form_type_and_string_are_mixable(apple):
+    """A list may mix FormType members and plain strings."""
+    mixed = apple.get_filings(form=[FormType.ANNUAL_REPORT, "8-K"], year=YEAR)
+
+    assert len(mixed) > 0
+    assert {f.form for f in mixed} <= {"10-K", "8-K"}
+
+
+def test_form_type_matches_string_exactly(apple):
+    """FormType.ANNUAL_REPORT and "10-K" select the identical filing set.
+
+    Accession numbers, not just counts — equal counts over different filings
+    would still be a compatibility break.
+    """
+    by_enum = apple.get_filings(form=FormType.ANNUAL_REPORT, year=YEAR)
+    by_string = apple.get_filings(form="10-K", year=YEAR)
+
+    assert {f.accession_number for f in by_enum} == {f.accession_number for f in by_string}
+
+
+def test_form_type_values_are_edgar_form_strings():
+    """Offline: every member's value is the literal form string EDGAR uses."""
+    assert FormType.ANNUAL_REPORT.value == "10-K"
+    assert FormType.QUARTERLY_REPORT.value == "10-Q"
+    assert all(isinstance(member.value, str) and member.value for member in FormType)

--- a/tests/test_httprequests.py
+++ b/tests/test_httprequests.py
@@ -17,6 +17,7 @@ from edgar.httpclient import (
 
 from edgar.httprequests import (
     get_with_retry,
+    redirect_url,
     get_with_retry_async,
     stream_with_retry,
     post_with_retry,
@@ -66,6 +67,49 @@ def test_get_with_retry_for_redirect(status_code, monkeypatch):
                 headers={"User-Agent": "Dev Gunning developer-gunning@gmail.com"},
                 identity_callable=None,
             )
+
+
+@pytest.mark.parametrize(
+    "location,expected",
+    [
+        # SEC's own form: a bare path, which has no scheme for httpx to dial.
+        ("/data-research/investment-company", "https://www.sec.gov/data-research/investment-company"),
+        ("sibling", "https://www.sec.gov/about/sibling"),
+        ("//data.sec.gov/submissions", "https://data.sec.gov/submissions"),
+        ("https://www.sec.gov/elsewhere", "https://www.sec.gov/elsewhere"),
+    ],
+)
+def test_redirect_url_resolves_against_the_request_url(location, expected):
+    response = httpx.Response(status_code=301, headers={"Location": location})
+    assert redirect_url("https://www.sec.gov/about/opendatasets", response) == expected
+
+
+@pytest.mark.parametrize("status_code", [301, 302])
+def test_get_with_retry_follows_a_relative_location(status_code):
+    """A relative Location must be resolved, not handed to httpx as-is.
+
+    SEC 301s ``/about/opendatasetsshtmlinvestment_company`` to a bare path;
+    requesting that path verbatim raises UnsupportedProtocol, which broke fund
+    reference data (class names silently degraded to class IDs).
+    """
+    mock_response = httpx.Response(status_code=status_code)
+    mock_response.headers["Location"] = "/data-research/investment-company"
+
+    with patch("httpx.Client.get", return_value=mock_response):
+        with patch("edgar.httprequests.get_with_retry") as mock_retry:
+            get_with_retry(url="https://www.sec.gov/about/opendatasets")
+            assert mock_retry.call_args.kwargs["url"] == "https://www.sec.gov/data-research/investment-company"
+
+
+@pytest.mark.parametrize("status_code", [301, 302])
+def test_post_with_retry_follows_a_relative_location(status_code):
+    mock_response = httpx.Response(status_code=status_code)
+    mock_response.headers["Location"] = "/redirected"
+
+    with patch("httpx.Client.post", return_value=mock_response):
+        with patch("edgar.httprequests.post_with_retry") as mock_retry:
+            post_with_retry(url="https://www.sec.gov/cgi-bin/browse-edgar", data={"key": "value"})
+            assert mock_retry.call_args.args[0] == "https://www.sec.gov/redirected"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -14,9 +14,29 @@ from edgar.core import has_html_content
 
 pd.options.display.max_columns = None
 
-snow_form3 = Ownership.from_xml(Path('data/ownership/form3.snow.xml').read_text())
-snow_form3_nonderiv = Ownership.from_xml(Path('data/form3.snow.nonderiv.xml').read_text())
-snow_form4 = Ownership.from_xml(Path('data/form4.snow.xml').read_text())
+# These are module-scoped FIXTURES rather than module-level globals on purpose.
+# Ownership.from_xml() resolves the issuer through data.sec.gov, so building them
+# at import time put three network calls inside pytest's COLLECTION phase — and a
+# collection error aborts the whole session before any test runs. That fired in CI
+# when SEC returned 429: the entire 6,000-test regression run was interrupted by
+# two files whose own tests had been deselected anyway. As fixtures the fetch
+# happens inside the tests that ask for it, where a failure fails those tests
+# instead of the suite.
+
+
+@pytest.fixture(scope="module")
+def snow_form3():
+    return Ownership.from_xml(Path('data/ownership/form3.snow.xml').read_text())
+
+
+@pytest.fixture(scope="module")
+def snow_form3_nonderiv():
+    return Ownership.from_xml(Path('data/form3.snow.nonderiv.xml').read_text())
+
+
+@pytest.fixture(scope="module")
+def snow_form4():
+    return Ownership.from_xml(Path('data/form4.snow.xml').read_text())
 @pytest.fixture(scope="module")
 def aapl_form4():
     return Filing(company='Apple Inc.', cik=320193, form='4', filing_date='2023-10-03',
@@ -82,7 +102,7 @@ def test_derivative_table_repr():
     print()
 
 
-def test_non_derivatives_repr():
+def test_non_derivatives_repr(snow_form4):
     form3_content = Path('data/form3.snow.nonderiv.xml').read_text()
     print()
     ownership = Ownership.from_xml(form3_content)
@@ -192,7 +212,7 @@ def test_reporting_relationship():
     assert not owner.is_other
 
 
-def test_post_transaction_values():
+def test_post_transaction_values(snow_form4):
     transaction: NonDerivativeTransaction = snow_form4.non_derivative_table.transactions[0]
     print(transaction)
     assert transaction.security == 'Class A Common Stock'
@@ -204,7 +224,7 @@ def test_post_transaction_values():
     assert transaction.shares == 200000
 
 
-def test_derivative_holdings_get_item():
+def test_derivative_holdings_get_item(snow_form3):
     print()
     print(snow_form3.derivative_table.holdings.data)
     holding = snow_form3.derivative_table.holdings[0]
@@ -218,7 +238,7 @@ def test_derivative_holdings_get_item():
     assert holding.nature_of_ownership == 'Limited Partnership [F4]'
 
 
-def test_non_derivative_holding_get_item():
+def test_non_derivative_holding_get_item(snow_form3_nonderiv):
     print()
     holding = snow_form3_nonderiv.non_derivative_table.holdings[0]
     assert holding.security == 'Class A Common Stock'
@@ -228,7 +248,7 @@ def test_non_derivative_holding_get_item():
     print(holding)
 
 
-def test_derivative_transaction_get_item():
+def test_derivative_transaction_get_item(snow_form4):
     transaction = snow_form4.derivative_table.transactions[0]
     assert transaction.shares == 200000
     assert transaction.price == 0


### PR DESCRIPTION
## The bug

SEC changed `https://www.sec.gov/about/opendatasetsshtmlinvestment_company` to a 301 whose `Location` is a **bare path**:

```
location: /data-research/sec-markets-data/investment-company-series-class-information
```

`Location` is allowed to be relative (RFC 7231 §7.1.2), but every manual redirect hop in `edgar/httprequests.py` passed `response.headers["Location"]` straight into the next request. httpx received a URL with no scheme and raised `UnsupportedProtocol` before the request ever left the process.

## Why it surfaced as wrong data instead of an error

`edgar/funds/data.py` swallows a failed reference-data load and falls back to bare identifiers, so every fund series and class name silently degraded to its ID:

```python
find_fund("KINCX").name   # "C000013712"  — was "Advisor Class C"
```

No warning, no exception. It was caught only because two `tests/test_funds.py::test_get_fund_by_ticker` params assert literal names — nothing else in the suite would have noticed.

## The fix

`redirect_url()` resolves the header against the URL that produced it via `httpx.URL.join` (RFC 3986 reference resolution), so absolute Locations pass through untouched and protocol-relative ones inherit the scheme. Applied to all five manual hops:

- `get_with_retry`
- `get_with_retry_async`
- `stream_with_retry`
- `post_with_retry`
- `post_with_retry_async`

This closes the **class**, not the instance. SEC is mid-migration from `about/opendatasets*` to `data-research/sec-markets-data/*`, and the library now follows each move automatically instead of erroring. The migration is visibly in progress in this repo: `edgar/bdc/datasets.py` already sits on a migrated URL while `edgar/bdc/reference.py` and `edgar/funds/reference.py` do not.

## Verification

- `download_text()` on the SEC dataset URL returns 96,340 chars, matching what plain httpx gets with `follow_redirects=True`.
- The two originally-failing tests pass; `tests/test_funds.py` is green.
- **90 passed** across `tests/test_httprequests.py` + `tests/test_funds.py`.

New regression tests in `tests/test_httprequests.py`:
- parametrized `redirect_url` unit test — bare path, relative sibling, protocol-relative, absolute
- relative-`Location` follow tests for `get_with_retry` and `post_with_retry`

## Follow-ups (not in this PR)

- **`edgartools-mchu`** — the `except Exception: pass` in `edgar/funds/data.py` that turned a hard transport error into quiet wrong data. Two more reference-data-fetch swallows have the same shape in `edgar/bdc/`.
- **`edgartools-07lk.25`** — 6.0 child: nightly reference-data contract tests, so the next SEC-side change fails in CI within a day rather than in a user's terminal.

CHANGELOG entry not included here — happy to add one if you'd prefer it in this PR rather than a batched `chore(changelog)` commit.
