### PR TITLE
refactor(httprequests): import get_edgar_data_directory from edgar.settings

### DIFF
--- a/edgar/httprequests.py
+++ b/edgar/httprequests.py
@@ -23,7 +23,8 @@ from tqdm import tqdm
 # Suppress stamina retry logging (e.g., "stamina.retry_scheduled" messages)
 logging.getLogger("stamina").setLevel(logging.ERROR)
 
-from edgar.core import get_edgar_data_directory, text_extensions
+from edgar.core import text_extensions
+from edgar.settings import get_edgar_data_directory
 from edgar.exceptions import (
     IdentityNotSetError,
     TooManyRequestsError,


### PR DESCRIPTION
Completes the `07lk.12.1` migration started in #1075.

This is the one file that PR deliberately skipped. It carried another session's uncommitted redirect-`Location` work, and `git add` stages whole files, so touching it would have swept that unfinished change into an unrelated commit. That work has since landed as #1077, so the file is free.

```diff
-from edgar.core import get_edgar_data_directory, text_extensions
+from edgar.core import text_extensions
+from edgar.settings import get_edgar_data_directory
```

With this, **no module under `edgar/` imports a settings name from `edgar.core`.** Verified by AST resolution rather than grep — four other `core.py` modules exist in the tree (`edgar/entity/`, `edgar/xbrl/stitching/`, `edgar/offerings/crowdfunding/formc/`, and `edgar/proxy`'s relative `.core`), so a plain search for `.core` overcounts.

Behaviour is unchanged either way: the `edgar.core` re-export shim covers this import, and does so until 6.0 removes it. This is about not leaving the last internal caller sitting on the deprecated path.

## Verification

- `tests/test_httprequests.py` + `tests/issues/regression/test_07lk121_settings_extraction.py` — 89 passed
- `get_edgar_data_directory` confirmed identity-equal across both import paths
- ruff clean on the file

Built in a separate git worktree off `origin/main`, because the shared working directory is currently checked out on another session's active branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)