### PR TITLE
fix(funds): warn when reference data fails for any reason but being offline

### DIFF
--- a/edgar/funds/data.py
+++ b/edgar/funds/data.py
@@ -20,7 +20,7 @@ from edgar._filings import Filings
 from edgar.datatools import drop_duplicates_pyarrow
 from edgar.entity.data import EntityData
 from edgar.funds.core import FundClass, FundCompany, FundSeries
-from edgar.httprequests import TRANSPORT_ERRORS, download_text
+from edgar.httprequests import TRANSPORT_ERRORS, download_text, is_unreachable
 
 log = logging.getLogger(__name__)
 
@@ -594,8 +594,28 @@ def _build_hierarchy_from_mf_tickers(cik: str, identifier_type: str, identifier:
     try:
         from edgar.funds.reference import get_fund_reference_data
         ref_data = get_fund_reference_data()
-    except Exception:
-        pass
+    except Exception as e:
+        # Falling through leaves every series_name/class_name below as its bare
+        # identifier — output that is well-formed, plausible, and wrong. Being
+        # offline is the one cause where that degradation is the right answer;
+        # everything else (SEC restructured the dataset page, the CSV changed
+        # shape, a bug in FundReferenceData) is a defect that must not be
+        # indistinguishable from "this class has no name".
+        #
+        # That distinction is not hypothetical. SEC turned the dataset page into
+        # a 301 with a relative Location, edgartools followed the header
+        # verbatim, and httpx raised UnsupportedProtocol — an error, not an
+        # outage. This except swallowed it, and find_fund("KINCX").name returned
+        # "C000013712" instead of "Advisor Class C" until two literal-value
+        # assertions in tests/test_funds.py happened to catch it.
+        #
+        # The sibling path at the top of this module draws the same line for the
+        # same reason; see the TRANSPORT_ERRORS comment in _get_fund_object.
+        if not is_unreachable(e):
+            log.warning(
+                "Fund reference data unavailable (%s: %s); series and class names "
+                "will fall back to their identifiers.", type(e).__name__, e,
+            )
 
     # Build hierarchy
     all_series = []

--- a/tests/issues/regression/test_mchu_fund_reference_warning.py
+++ b/tests/issues/regression/test_mchu_fund_reference_warning.py
@@ -1,0 +1,117 @@
+"""edgartools-mchu — a failed fund reference-data load must not degrade silently.
+
+`_build_hierarchy_from_mf_tickers` enriches series and class names from
+`get_fund_reference_data()`, and falls back to the bare identifier when that is
+unavailable. The fallback itself is fine; swallowing every cause of it was not.
+
+SEC turned the investment-company dataset page into a 301 with a relative
+`Location`, edgartools followed the header verbatim, and httpx raised
+`UnsupportedProtocol` — an error, not an outage. A bare `except Exception: pass`
+made that indistinguishable from "this class has no name", so
+`find_fund("KINCX").name` returned `"C000013712"` instead of `"Advisor Class C"`
+with no warning at all. It surfaced only because two literal-value assertions in
+tests/test_funds.py happened to cover those tickers.
+
+The contract these tests pin: being offline degrades quietly, every other cause
+degrades loudly. The fallback value is unchanged in both cases — this is about
+whether anyone is told.
+"""
+import logging
+
+import pandas as pd
+import pytest
+from httpx import ConnectError, TimeoutException
+
+import edgar.funds.data as fund_data
+
+LOGGER = "edgar.funds.data"
+
+# Minimal shape of the cached mutual-fund tickers frame: one class of one series
+# of one company. Real values, so a failure message points somewhere real.
+MF_TICKERS = pd.DataFrame([
+    {"cik": 1083387, "seriesId": "S000008303", "classId": "C000013712", "ticker": "KINCX"},
+])
+
+
+def _build_with_reference_failure(monkeypatch, failure):
+    """Build the hierarchy with get_fund_reference_data() raising `failure`."""
+    monkeypatch.setattr(
+        "edgar.reference.tickers.get_mutual_fund_tickers", lambda: MF_TICKERS
+    )
+
+    def boom():
+        raise failure
+
+    monkeypatch.setattr("edgar.funds.reference.get_fund_reference_data", boom)
+    return fund_data._build_hierarchy_from_mf_tickers(
+        cik="1083387", identifier_type="Class", identifier="KINCX"
+    )
+
+
+def test_defect_in_reference_data_warns(monkeypatch, caplog):
+    """A non-transport failure is a defect and must say so.
+
+    ValueError stands in for the whole family the old bare except hid: SEC
+    restructuring the dataset page, the CSV changing shape, a bug inside
+    FundReferenceData. None of them mean "no name exists".
+    """
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        fund_class = _build_with_reference_failure(
+            monkeypatch, ValueError("No fund data CSV file found on the SEC website.")
+        )
+
+    assert fund_class is not None
+    assert fund_class.name == "C000013712"  # the fallback still applies
+
+    warnings = [r for r in caplog.records if r.name == LOGGER and r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "expected exactly one warning naming the cause"
+    message = warnings[0].getMessage()
+    assert "ValueError" in message
+    assert "No fund data CSV file found" in message
+    assert "fall back to their identifiers" in message
+
+
+def test_offline_degrades_quietly(monkeypatch, caplog):
+    """Being unreachable is not a defect — no warning, same fallback.
+
+    Without this half, the fix would just trade a silent wrong answer for a
+    warning on every offline call, which is how a useful warning gets tuned out.
+    """
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        fund_class = _build_with_reference_failure(
+            monkeypatch, ConnectError("[Errno 8] nodename nor servname provided")
+        )
+
+    assert fund_class is not None
+    assert fund_class.name == "C000013712"
+
+    warnings = [r for r in caplog.records if r.name == LOGGER and r.levelno == logging.WARNING]
+    assert warnings == [], f"offline must not warn, got: {[r.getMessage() for r in warnings]}"
+
+
+@pytest.mark.parametrize(
+    "failure,expect_warning",
+    [
+        (ValueError("bad CSV"), True),
+        (AttributeError("FundReferenceData has no attribute"), True),
+        (KeyError("Class ID"), True),
+        (ConnectError("offline"), False),
+        (TimeoutException("timed out"), False),
+        # The builtin TimeoutError is deliberately NOT unreachable: UNREACHABLE_ERRORS
+        # lists the httpx and httpcore types, and every fetch on this path goes
+        # through httpx, so a bare builtin here means something other than a stalled
+        # socket and should be reported.
+        (TimeoutError("not an httpx timeout"), True),
+    ],
+)
+def test_warning_split_follows_is_unreachable(monkeypatch, caplog, failure, expect_warning):
+    """The split is `is_unreachable`, not an exception allowlist.
+
+    Pinned as a table so that widening UNREACHABLE_ERRORS in httprequests
+    changes this behaviour deliberately rather than by accident.
+    """
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _build_with_reference_failure(monkeypatch, failure)
+
+    warned = any(r.name == LOGGER and r.levelno == logging.WARNING for r in caplog.records)
+    assert warned is expect_warning


### PR DESCRIPTION
## The bug

`_build_hierarchy_from_mf_tickers` enriches fund series and class names from `get_fund_reference_data()`, falling back to the bare identifier when that is unavailable. The fallback is reasonable. Swallowing every cause of it was not:

```python
try:
    ref_data = get_fund_reference_data()
except Exception:
    pass
```

A network error, an SEC page restructure, a changed CSV shape and a bug inside `FundReferenceData` were all indistinguishable from "this class has no name" — and each produced a well-formed, plausible, wrong answer.

That is not hypothetical. It is what made #1077's transport bug invisible: SEC turned the investment-company dataset page into a 301 with a relative `Location`, httpx raised `UnsupportedProtocol`, this `except` ate it, and

```python
find_fund("KINCX").name   # "C000013712"  — should be "Advisor Class C"
```

went wrong silently. Every series and class name resolved through the fast path degraded to its ID. It surfaced only because two literal-value assertions in `tests/test_funds.py` happened to cover those tickers.

## The fix

Split on `is_unreachable()`: being genuinely offline degrades quietly, every other cause degrades loudly with the exception type and message.

Both halves matter. Warning on every offline call is how a useful warning gets tuned out, which is why the quiet half is pinned by its own test rather than left implicit.

The returned value is unchanged in both cases — nothing downstream shifts. This only decides whether anyone is told.

It is also the distinction this module already draws on its sibling path with `TRANSPORT_ERRORS`, and the exact failure mode `is_unreachable`'s own docstring warns about: *"an SEC 404, an expired certificate or a missing identity are all answers of a kind, and swallowing them would hide a bug behind a plausible empty result."*

## Verification

`tests/issues/regression/test_mchu_fund_reference_warning.py` — 8 tests, fully offline, so they gate every PR rather than landing in the post-merge-only tree:

- a defect (`ValueError`) warns, names the cause, and still returns the identifier fallback
- an offline failure (`ConnectError`) returns the same fallback and stays silent
- a parametrized table pinning that the split follows `is_unreachable` rather than an exception allowlist, so widening `UNREACHABLE_ERRORS` changes this deliberately rather than by accident

Confirmed offline under `tests/_offline_harness.py` (8 passed with sockets blocked) and end to end against live SEC data — healthy path returns `'Advisor Class C'`; forced defect returns `'C000013712'` **and** logs `Fund reference data unavailable (ValueError: boom); series and class names will fall back to their identifiers.`

82 passed across `test_funds`, `test_fund_reference`, `test_funds_data_unit`, `test_fund_wrapper` and the new file.

## Scope

Closes `edgartools-mchu`. Two sibling swallows with the same shape are **not** in this PR and are tracked under `edgartools-07lk.25`: `edgar/bdc/reference.py` (every year-probe fails, returns a hardcoded `2024` as "latest available year") and `edgar/bdc/datasets.py` (returns `[]`, reading as "SEC published nothing"). Those are probe loops where swallowing a 404 is correct and swallowing a transport failure is not, so they need the same split with slightly different handling.
