### PR TITLE
feat(reference): detect SEC-side changes instead of absorbing them silently

### DIFF
--- a/edgar/bdc/README.md
+++ b/edgar/bdc/README.md
@@ -316,7 +316,7 @@ if is_bdc_cik(company.cik):
 
 The SEC maintains an authoritative list of all entities with 814- file numbers.
 
-**URL:** https://www.sec.gov/about/opendatasetsshtmlbdc
+**URL:** https://www.sec.gov/data-research/sec-markets-data/opendatasetsshtmlbdc
 
 **Files:** `business-development-company-{year}.csv` (2016-2025)
 

--- a/edgar/bdc/datasets.py
+++ b/edgar/bdc/datasets.py
@@ -37,6 +37,7 @@ Example usage:
 import io
 import zipfile
 from dataclasses import dataclass
+import logging
 from datetime import date
 from functools import lru_cache
 from typing import Optional, Union, TYPE_CHECKING
@@ -49,8 +50,10 @@ from rich import box
 from rich.panel import Panel
 from rich.table import Table
 
-from edgar.httprequests import get_with_retry
+from edgar.httprequests import get_with_retry, is_unreachable
 from edgar.richtools import repr_rich
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     'BDCDataset',
@@ -805,16 +808,43 @@ def get_available_quarters(max_years_back: int = 5) -> list[tuple[int, int]]:
     """
     available = []
     current_year = date.today().year
+    unreachable = 0
+    probed = 0
 
     for year in range(current_year, current_year - max_years_back, -1):
         for quarter in range(4, 0, -1):
             url = _build_quarterly_url(year, quarter)
+            probed += 1
             try:
                 response = get_with_retry(url, timeout=5.0)
                 if response.status_code == 200:
                     available.append((year, quarter))
-            except Exception:
+            except Exception as e:
+                # A quarter SEC never published answers 404, which returns a
+                # response rather than raising. Reaching here means the probe got
+                # no answer, which is not evidence of absence.
+                if is_unreachable(e):
+                    unreachable += 1
+                else:
+                    log.warning(
+                        "Unexpected error probing the %sQ%s BDC dataset (%s: %s); skipping it.",
+                        year, quarter, type(e).__name__, e,
+                    )
                 continue
+
+    # An empty list reads as "SEC has published no datasets". Only say that when
+    # the probes actually answered.
+    if not available and probed:
+        if unreachable == probed:
+            log.warning(
+                "Could not reach SEC for any BDC dataset quarter (%s probes failed); "
+                "returning an empty list, which does not mean none exist.", probed,
+            )
+        else:
+            log.warning(
+                "No BDC datasets found in the last %s years — check whether they moved from %s.",
+                max_years_back, BDC_DATASET_BASE_URL,
+            )
 
     return available
 

--- a/edgar/bdc/reference.py
+++ b/edgar/bdc/reference.py
@@ -4,8 +4,9 @@ SEC BDC (Business Development Company) reference data.
 This module provides access to the SEC's authoritative list of Business Development Companies
 from the SEC BDC Report, published annually.
 
-Data source: https://www.sec.gov/about/opendatasetsshtmlbdc
+Data source: https://www.sec.gov/data-research/sec-markets-data/opendatasetsshtmlbdc
 """
+import logging
 import io
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -21,7 +22,9 @@ import httpx
 import pandas as pd
 
 from edgar.display.formatting import cik_text
-from edgar.httprequests import get_with_retry
+from edgar.httprequests import get_with_retry, is_unreachable
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     'BDCEntity',
@@ -35,6 +38,10 @@ __all__ = [
 
 # Base URL for SEC BDC Report files
 BDC_REPORT_BASE_URL = "https://www.sec.gov/files/investment/data/other/business-development-company-report"
+
+# Used only when no year answers a probe. Every use is logged: an unconfirmed
+# year presented as confirmed is how a moved dataset reads as current data.
+_BDC_REPORT_FALLBACK_YEAR = 2024
 
 
 @dataclass
@@ -506,17 +513,48 @@ def get_latest_bdc_report_year() -> int:
         The latest year with an available BDC report.
     """
     current_year = datetime.now().year
+    unreachable = 0
+    probed = 0
 
     for year in range(current_year, 2015, -1):
         url = f"{BDC_REPORT_BASE_URL}/business-development-company-{year}.csv"
+        probed += 1
         try:
             response = get_with_retry(url, timeout=5)
             if response.status_code == 200:
                 return year
-        except Exception:
+        except Exception as e:
+            # A missing year is a 404, which returns a response rather than
+            # raising, so it never reaches here — reaching here means the probe
+            # did not get an answer at all. Counting those separates "SEC has no
+            # report for this year" from "we could not ask", which is the whole
+            # difference between the fallback below being a reasonable default
+            # and being a fabricated claim about what the latest year is.
+            if is_unreachable(e):
+                unreachable += 1
+            else:
+                log.warning(
+                    "Unexpected error probing the %s BDC report (%s: %s); skipping that year.",
+                    year, type(e).__name__, e,
+                )
             continue
 
-    return 2024  # Fallback to known good year
+    # Reaching here means no year answered 200. Say so rather than presenting a
+    # hardcoded year as though it had been confirmed: if SEC moves
+    # BDC_REPORT_BASE_URL the way it moved the fund dataset page, every probe
+    # misses and this silently reports 2024 as current forever.
+    if unreachable == probed:
+        log.warning(
+            "Could not reach SEC for any BDC report year (%s probes failed); "
+            "falling back to %s, which may be stale.", probed, _BDC_REPORT_FALLBACK_YEAR,
+        )
+    else:
+        log.warning(
+            "No BDC report found for any year from %s back to 2016; falling back to %s. "
+            "This usually means the report moved — check %s.",
+            current_year, _BDC_REPORT_FALLBACK_YEAR, BDC_REPORT_BASE_URL,
+        )
+    return _BDC_REPORT_FALLBACK_YEAR
 
 
 @lru_cache(maxsize=4)

--- a/edgar/funds/reference.py
+++ b/edgar/funds/reference.py
@@ -475,7 +475,11 @@ def _find_latest_fund_data_url():
 
 
     """
-    list_url = "https://www.sec.gov/about/opendatasetsshtmlinvestment_company"
+    # SEC migrated this page from /about/opendatasets* to /data-research/sec-markets-data/*
+    # in 2026 and left a 301 with a RELATIVE Location behind. redirect_url() in
+    # httprequests follows that correctly now, so the old address still works — this
+    # names the destination directly to save the extra hop, not because the hop breaks.
+    list_url = "https://www.sec.gov/data-research/sec-markets-data/investment-company-series-class-information"
     html_content = download_text(list_url)
     soup = BeautifulSoup(html_content, 'html.parser')
 

--- a/tests/issues/regression/test_07lk25_bdc_probe_warnings.py
+++ b/tests/issues/regression/test_07lk25_bdc_probe_warnings.py
@@ -1,0 +1,131 @@
+"""edgartools-07lk.25 — BDC probe loops must not report a guess as a finding.
+
+Both loops ask SEC "does this year/quarter exist?" by probing URLs. A year SEC
+never published answers 404, which `get_with_retry` returns as a response rather
+than raising — so reaching the `except` means the probe got no answer at all.
+Swallowing that was the bug: it made "we could not ask" indistinguishable from
+"SEC has nothing", and each loop then stated a conclusion it had not earned.
+
+  get_latest_bdc_report_year()  returned a hardcoded 2024 as "the latest year"
+  get_available_quarters()      returned [], which reads as "SEC published none"
+
+If SEC moves BDC_REPORT_BASE_URL the way it moved the fund dataset page, the
+first one reports 2024 as current indefinitely, with nothing in the logs.
+
+The value returned is deliberately unchanged — callers keep their fallback. What
+changes is that using the fallback is now stated out loud, and the message
+distinguishes the two causes.
+"""
+import logging
+
+import pytest
+from httpx import ConnectError
+
+REFERENCE_LOGGER = "edgar.bdc.reference"
+DATASETS_LOGGER = "edgar.bdc.datasets"
+
+
+class _Response:
+    """Minimal stand-in — the loops only read status_code."""
+
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def _warnings(caplog, logger):
+    return [r.getMessage() for r in caplog.records
+            if r.name == logger and r.levelno == logging.WARNING]
+
+
+class TestLatestReportYear:
+
+    def test_unreachable_says_so_and_does_not_claim_a_year(self, monkeypatch, caplog):
+        from edgar.bdc import reference
+
+        monkeypatch.setattr(
+            reference, "get_with_retry",
+            lambda *a, **k: (_ for _ in ()).throw(ConnectError("offline")),
+        )
+        with caplog.at_level(logging.WARNING, logger=REFERENCE_LOGGER):
+            year = reference.get_latest_bdc_report_year()
+
+        assert year == reference._BDC_REPORT_FALLBACK_YEAR  # value unchanged
+        messages = _warnings(caplog, REFERENCE_LOGGER)
+        assert len(messages) == 1
+        assert "Could not reach SEC" in messages[0]
+        assert "may be stale" in messages[0]
+
+    def test_all_404s_reports_a_moved_dataset_not_an_outage(self, monkeypatch, caplog):
+        """404 everywhere is an answer — and the answer is 'it moved'."""
+        from edgar.bdc import reference
+
+        monkeypatch.setattr(reference, "get_with_retry", lambda *a, **k: _Response(404))
+        with caplog.at_level(logging.WARNING, logger=REFERENCE_LOGGER):
+            year = reference.get_latest_bdc_report_year()
+
+        assert year == reference._BDC_REPORT_FALLBACK_YEAR
+        messages = _warnings(caplog, REFERENCE_LOGGER)
+        assert len(messages) == 1
+        assert "No BDC report found" in messages[0]
+        assert reference.BDC_REPORT_BASE_URL in messages[0]
+
+    def test_a_real_hit_is_silent(self, monkeypatch, caplog):
+        """The healthy path must stay quiet, or the warning gets tuned out."""
+        from edgar.bdc import reference
+
+        monkeypatch.setattr(reference, "get_with_retry", lambda *a, **k: _Response(200))
+        with caplog.at_level(logging.WARNING, logger=REFERENCE_LOGGER):
+            year = reference.get_latest_bdc_report_year()
+
+        assert year > reference._BDC_REPORT_FALLBACK_YEAR
+        assert _warnings(caplog, REFERENCE_LOGGER) == []
+
+
+class TestAvailableQuarters:
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """get_available_quarters is lru_cached; without this the result depends
+        on whichever test ran first."""
+        from edgar.bdc.datasets import get_available_quarters
+        get_available_quarters.cache_clear()
+        yield
+        get_available_quarters.cache_clear()
+
+    def test_empty_from_unreachable_is_flagged(self, monkeypatch, caplog):
+        from edgar.bdc import datasets
+
+        monkeypatch.setattr(
+            datasets, "get_with_retry",
+            lambda *a, **k: (_ for _ in ()).throw(ConnectError("offline")),
+        )
+        with caplog.at_level(logging.WARNING, logger=DATASETS_LOGGER):
+            quarters = datasets.get_available_quarters()
+
+        assert quarters == []  # value unchanged
+        messages = _warnings(caplog, DATASETS_LOGGER)
+        assert len(messages) == 1
+        assert "Could not reach SEC" in messages[0]
+        assert "does not mean none exist" in messages[0]
+
+    def test_empty_from_404s_points_at_the_dataset_url(self, monkeypatch, caplog):
+        from edgar.bdc import datasets
+
+        monkeypatch.setattr(datasets, "get_with_retry", lambda *a, **k: _Response(404))
+        with caplog.at_level(logging.WARNING, logger=DATASETS_LOGGER):
+            quarters = datasets.get_available_quarters()
+
+        assert quarters == []
+        messages = _warnings(caplog, DATASETS_LOGGER)
+        assert len(messages) == 1
+        assert "No BDC datasets found" in messages[0]
+
+    def test_found_quarters_are_silent(self, monkeypatch, caplog):
+        from edgar.bdc import datasets
+
+        monkeypatch.setattr(datasets, "get_with_retry", lambda *a, **k: _Response(200))
+        with caplog.at_level(logging.WARNING, logger=DATASETS_LOGGER):
+            quarters = datasets.get_available_quarters()
+
+        assert len(quarters) > 0
+        assert _warnings(caplog, DATASETS_LOGGER) == []

--- a/tests/test_sec_reference_contract.py
+++ b/tests/test_sec_reference_contract.py
@@ -1,0 +1,194 @@
+"""Contract tests for the SEC reference datasets edgartools depends on.
+
+WHAT THIS IS FOR. SEC changes its own site and datasets on its own schedule.
+The repo already has six ``test_*_contract.py`` files, but every one of them
+pins a FILING parser; nothing watched the reference datasets. So when SEC turned
+the investment-company dataset page into a 301 with a relative ``Location``,
+nothing noticed: the fetch failed, the caller swallowed it, and every fund series
+and class name silently degraded to its bare identifier. It surfaced days later
+because two literal-value assertions in tests/test_funds.py happened to cover the
+affected tickers.
+
+This file is the detector that should have caught it on day one. Each test names
+one external source, asserts a SPECIFIC value from it, and fails with a message
+saying which source moved — so a red run points at SEC rather than at us.
+
+WRITING TESTS HERE. Assert values, not existence: ``is not None`` passes on
+exactly the degraded output this file exists to catch. Prefer a fact stable
+across quarters (a class name, a floor on a row count) over one that drifts (an
+exact row count, the current year's filing volume).
+
+Marked ``network`` so it runs in the post-merge and nightly lanes, never on the
+pull-request gate.
+"""
+import re
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.network
+
+
+def _fail(source: str, detail: str) -> str:
+    return (
+        f"SEC reference source appears to have changed: {source}\n"
+        f"  {detail}\n"
+        "  This is a contract test — the likely cause is upstream, not a code change here."
+    )
+
+
+class TestFundReferenceData:
+    """https://www.sec.gov/data-research/sec-markets-data/investment-company-series-class-information"""
+
+    def test_landing_page_still_yields_a_csv_url(self):
+        from edgar.funds.reference import _find_latest_fund_data_url
+
+        url = _find_latest_fund_data_url()
+        assert url.startswith("https://www.sec.gov/"), _fail(
+            "investment-company series/class landing page",
+            f"scrape returned a non-SEC url: {url!r}",
+        )
+        assert url.endswith(".csv"), _fail(
+            "investment-company series/class landing page",
+            f"scrape no longer resolves to a CSV: {url!r}",
+        )
+
+    def test_class_names_resolve_to_real_names_not_identifiers(self):
+        """The exact degradation that went unnoticed: name falls back to class id."""
+        from edgar.funds.reference import get_fund_reference_data
+
+        ref = get_fund_reference_data()
+        klass = ref.get_class("C000013712")
+        assert klass is not None, _fail(
+            "investment-company series/class CSV", "class C000013712 is missing from the dataset"
+        )
+        assert klass.name == "Advisor Class C", _fail(
+            "investment-company series/class CSV",
+            f"C000013712 resolved to {klass.name!r}, expected 'Advisor Class C' "
+            "(a bare identifier here means the enrichment silently degraded)",
+        )
+
+    def test_find_fund_surfaces_the_name(self):
+        """End to end through the public API, which is where users saw the bug."""
+        from edgar.funds import find_fund
+
+        fund_class = find_fund("KINCX")
+        assert fund_class.name == "Advisor Class C", _fail(
+            "fund lookup by ticker",
+            f"find_fund('KINCX').name is {fund_class.name!r}, expected 'Advisor Class C'",
+        )
+        assert fund_class.class_id == "C000013712"
+
+
+class TestBDCReference:
+    """https://www.sec.gov/data-research/sec-markets-data/opendatasetsshtmlbdc"""
+
+    def test_latest_report_year_is_not_the_stale_fallback(self):
+        """Assert it moved PAST the fallback, not merely that it is >= it.
+
+        get_latest_bdc_report_year() returns a hardcoded 2024 when every probe
+        misses. A test asserting `>= 2024` would pass on exactly that failure,
+        so the floor has to sit above the fallback to mean anything.
+        """
+        from edgar.bdc.reference import _BDC_REPORT_FALLBACK_YEAR, get_latest_bdc_report_year
+
+        year = get_latest_bdc_report_year()
+        assert year > _BDC_REPORT_FALLBACK_YEAR, _fail(
+            "SEC BDC report",
+            f"latest year is {year}, which is the hardcoded fallback "
+            f"({_BDC_REPORT_FALLBACK_YEAR}) or older — every probe likely missed",
+        )
+
+    def test_report_lists_known_bdcs(self):
+        """MAIN is a long-lived BDC; the yearly list churns, so pin on it."""
+        from edgar.bdc.reference import get_bdc_list
+
+        bdcs = get_bdc_list()
+        assert len(bdcs) > 50, _fail("SEC BDC report", f"only {len(bdcs)} BDCs returned")
+        ciks = {int(b.cik) for b in bdcs}
+        assert 1396440 in ciks, _fail(
+            "SEC BDC report", "Main Street Capital (CIK 1396440) is missing from the BDC list"
+        )
+
+
+class TestBDCDatasets:
+    """https://www.sec.gov/data-research/sec-markets-data/bdc-data-sets"""
+
+    def test_quarters_are_discoverable(self):
+        from edgar.bdc.datasets import get_available_quarters
+
+        quarters = get_available_quarters()
+        assert quarters, _fail(
+            "BDC quarterly datasets",
+            "no quarters discovered — an empty list here does not distinguish "
+            "'SEC published none' from 'we could not reach SEC'",
+        )
+        assert len(quarters) >= 4, _fail(
+            "BDC quarterly datasets", f"only {len(quarters)} quarters discovered"
+        )
+        assert all(1 <= q <= 4 for _, q in quarters)
+
+
+class TestTickerReferenceData:
+    """The ticker and CIK datasets under https://www.sec.gov/files/."""
+
+    def test_company_tickers_has_plausible_volume_and_known_members(self):
+        from edgar.reference.tickers import get_company_tickers
+
+        tickers = get_company_tickers()
+        assert len(tickers) > 9000, _fail(
+            "company_tickers.json", f"only {len(tickers)} rows (expected roughly 10k+)"
+        )
+        by_ticker = set(tickers["ticker"])
+        for expected in ("AAPL", "MSFT", "JPM"):
+            assert expected in by_ticker, _fail(
+                "company_tickers.json", f"{expected} is missing from the ticker dataset"
+            )
+
+    def test_mutual_fund_tickers_keeps_its_column_contract(self):
+        from edgar.reference.tickers import get_mutual_fund_tickers
+
+        mf = get_mutual_fund_tickers()
+        assert list(mf.columns) == ["cik", "seriesId", "classId", "ticker"], _fail(
+            "mutual fund tickers", f"columns changed to {list(mf.columns)}"
+        )
+        assert len(mf) > 10000, _fail("mutual fund tickers", f"only {len(mf)} rows")
+        assert "KINCX" in set(mf["ticker"]), _fail(
+            "mutual fund tickers", "KINCX is missing from the mutual fund ticker dataset"
+        )
+
+    def test_cik_lookup_data_parses(self):
+        from edgar.httprequests import download_text
+
+        text = download_text("https://www.sec.gov/Archives/edgar/cik-lookup-data.txt")
+        assert text, _fail("cik-lookup-data.txt", "downloaded empty")
+        lines = [ln for ln in text.split("\n") if ln.strip()]
+        assert len(lines) > 500000, _fail(
+            "cik-lookup-data.txt", f"only {len(lines)} lines (expected 500k+)"
+        )
+        # Every line is NAME:CIK:, and that holds for all 1,056,064 of them as of
+        # 2026-08-22 — so assert all, not a sample. NAME is allowed to be empty:
+        # four real rows begin with ':' and sort to the top of the file, which is
+        # why this is `.*` rather than `.+`.
+        malformed = [ln for ln in lines if not re.match(r"^.*:\d{10}:$", ln)]
+        assert not malformed, _fail(
+            "cik-lookup-data.txt",
+            f"{len(malformed)} lines no longer match NAME:CIK:, e.g. {malformed[:3]}",
+        )
+
+
+class TestSubmissionsApi:
+    """https://data.sec.gov — the other host, with its own cache rules."""
+
+    def test_company_submissions_still_shapes_as_expected(self):
+        from edgar import Company
+
+        apple = Company("AAPL")
+        assert apple.cik == 320193, _fail(
+            "data.sec.gov submissions", f"AAPL resolved to CIK {apple.cik}, expected 320193"
+        )
+        filings = apple.get_filings(form="10-K")
+        assert len(filings) > 10, _fail(
+            "data.sec.gov submissions", f"only {len(filings)} 10-K filings for AAPL"
+        )
+        assert isinstance(filings.to_pandas(), pd.DataFrame)


### PR DESCRIPTION
SEC changes its own site and datasets on its own schedule, and edgartools had no way to find out. The redirect bug fixed in #1077 was invisible for exactly that reason: the fetch failed, the caller swallowed it, and every fund series and class name degraded to its bare identifier until two literal-value assertions happened to cover the affected tickers.

Three parts, each measured rather than assumed.

## 1. Stale URLs

SEC is mid-migration from `/about/opendatasets*` to `/data-research/sec-markets-data/*`. `edgar/bdc/datasets.py` already sat on a migrated URL while `edgar/funds/reference.py` and `edgar/bdc/reference.py` did not — which is itself the evidence the migration is ongoing. Both now name the destination directly.

The old addresses still work, since `redirect_url()` from #1077 follows the relative `Location` correctly. This just saves the extra hop.

## 2. The two BDC probe loops

Both loops ask SEC *"does this year/quarter exist?"* by probing a URL. A year SEC never published answers **404, which `get_with_retry` returns as a response rather than raising** — so reaching the `except` means the probe got no answer at all. Swallowing it made "we could not ask" indistinguishable from "SEC has nothing", and each loop stated a conclusion it had not earned:

| | was |
|---|---|
| `get_latest_bdc_report_year()` | returned a hardcoded `2024` as "the latest year" |
| `get_available_quarters()` | returned `[]`, which reads as "SEC published none" |

If SEC moves `BDC_REPORT_BASE_URL` the way it just moved the fund dataset page, the first reports 2024 as current indefinitely with nothing in the logs.

Both now split on `is_unreachable()` and say which case they are in. **Return values are unchanged**, so no caller shifts — what changes is that falling back is stated out loud, with the two causes distinguished.

The magic `2024` becomes `_BDC_REPORT_FALLBACK_YEAR` so tests can assert *against* it instead of restating it. That matters more than it looks: a floor of `>= 2024` would pass on exactly the failure being guarded. Live, the year resolves to **2026**, two years past the fallback.

Neither `bdc` module had a logger. Both do now — worth noting because the first draft of this change called `log.warning` in modules that would have raised `NameError` precisely when the branch fired.

## 3. Reference-data contract tests

`tests/test_sec_reference_contract.py`, marked `network`, so it runs post-merge and nightly and never on the PR gate.

The repo already had six `test_*_contract.py` files — and every one of them pins a **filing parser**. Nothing watched the reference **datasets**. Ten tests now assert specific values per source, per the constitution's "assert values, not existence":

- `C000013712` resolves to `"Advisor Class C"`, not to its own identifier
- the fund landing-page scrape still yields a resolvable `.csv`
- the BDC report year is strictly past the fallback
- `cik-lookup-data.txt` still matches `NAME:CIK:` across **all 1,056,064 lines** (4 rows legitimately have an empty name, which is why the pattern allows it)
- `company_tickers.json` carries AAPL/MSFT/JPM above a row floor
- mutual-fund tickers keep their four-column contract and still contain KINCX
- AAPL is still CIK 320193 on `data.sec.gov`

Each failure message names the source that moved, so a red run points at SEC rather than at us. **This is the test that would have caught #1077 on day one.**

## Verification

- 10 contract tests pass live; marker routing confirmed — 10 collected under the network lane selector, 0 under `fast`
- 6 offline regression tests pin both probe-loop branches, including that the healthy path stays **silent**, since warning on every call is how a useful warning gets tuned out
- 242 passed across `tests/test_bdc.py` plus the new regression file
- All live paths re-verified end to end: new fund URL resolves the CSV, `C000013712` → `"Advisor Class C"`, BDC year `2026`, 13 dataset quarters discovered

## Scope

Part of `edgartools-07lk.25`. The third swallow of this family — `edgar/funds/data.py` — is `edgartools-mchu`, in #1079, which this does not depend on.
