### PR TITLE
fix(documents): a div styled display:inline no longer shatters its words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A word came back split across lines when the filer bolded one of its letters.** Filers routinely put an acronym's initials in their own `<font>` runs; where those sit inside a `<div>` styled `display:inline`, `Document.text()` emitted each run as its own block. Aardvark Therapeutics' 8-K of 2025-04-01 rendered "(Hunger Elimination or Reduction Objective)" one letter to a line. Such a div now reads as a paragraph — unless it wraps a table or another block, which is how iXBRL containers hold whole statements.
+
 ## [5.52.0] - 2026-08-22
 
 ### Added

--- a/edgar/documents/strategies/document_builder.py
+++ b/edgar/documents/strategies/document_builder.py
@@ -337,7 +337,17 @@ class DocumentBuilder:
                     text_node.set_metadata('original_tag', tag)
                     text_node.set_metadata('inline_via_css', True)
                     return text_node
-                # If no text but inline, still process children inline
+                # If no text but inline, still process children inline.
+                # _get_element_text() only descends into children for elements that
+                # are inline BY TAG, so a div whose content sits entirely in child
+                # <font>/<span> runs yields nothing here. Falling through to a bare
+                # ContainerNode then emits each run as its own block and shatters
+                # words across lines -- `<div style="display:inline"><font>H</font>
+                # <font>unger</font></div>` became "H\n\nunger". A ParagraphNode
+                # concatenates inline children, which is what the normal-block path
+                # below already does for this exact shape.
+                if self._is_inline_run_container(element):
+                    return ParagraphNode(style=style)
                 return ContainerNode(tag_name=tag, style=style)
 
             # Normal block behavior
@@ -613,6 +623,28 @@ class DocumentBuilder:
         if inline and len(text_parts) == 1:
             return text_parts[0]
         return ' '.join(text_parts)
+
+    def _is_inline_run_container(self, element: HtmlElement) -> bool:
+        """Check that every child is a genuine inline run and no block sits below.
+
+        Deliberately stricter than :meth:`_is_text_only_container`, which looks
+        only at DIRECT children and treats any unrecognised tag as inline. IXBRL
+        wrappers are the reason: ``ix:continuation`` and ``ix:nonNumeric`` are not
+        in BLOCK_ELEMENTS, so they pass that test while wrapping whole tables and
+        headings -- on the GS 10-Q fixture exactly two such divs did, and
+        flattening them collapsed rendered tables into run-on lines.
+        """
+        for child in element:
+            if not isinstance(child.tag, str):
+                continue  # comments and processing instructions
+            if child.tag.lower() not in self.INLINE_ELEMENTS:
+                return False
+        for descendant in element.iter():
+            if descendant is element or not isinstance(descendant.tag, str):
+                continue
+            if descendant.tag.lower() in self.BLOCK_ELEMENTS:
+                return False
+        return True
 
     def _is_text_only_container(self, element: HtmlElement) -> bool:
         """Check if element contains only text and inline elements."""

--- a/tests/issues/regression/test_2h2s_inline_div_word_shattering.py
+++ b/tests/issues/regression/test_2h2s_inline_div_word_shattering.py
@@ -1,0 +1,104 @@
+"""A div styled ``display:inline`` no longer shatters its inline runs
+(edgartools-2h2s).
+
+Filers routinely bold one letter of a word by putting it in its own ``<font>``
+or ``<span>`` — the initials of an acronym, a drop cap. When those runs sit
+inside a ``<div>`` whose style carries ``display:inline``, ``Document.text()``
+used to emit each run as its own block::
+
+    <div style="display:inline;"><font>H</font><font>unger </font>
+    <font>E</font><font>limination</font></div>
+
+    legacy edgar.files : 'Hunger Elimination'
+    edgar.documents    : 'H\\n\\nunger\\n\\nE\\n\\nlimination'
+
+Every character survived, which is why no length check caught it — the damage
+only shows in a word-level comparison, or to a reader.
+
+CAUSE. In ``DocumentBuilder``'s div/block branch, ``style.display in
+('inline','inline-block')`` called ``_get_element_text()`` and, on a falsy
+result, returned a bare ``ContainerNode`` — which emits each child run as its
+own block. But ``_get_element_text()`` only descends into children for elements
+that are inline BY TAG, and a ``div`` is not one, so it sees only the div's
+direct text. That is empty for exactly the shape this branch exists to serve,
+so the fallback fired every time. The normal-block path directly below already
+handled the same shape correctly via ``_is_text_only_container()`` ->
+``ParagraphNode``, which concatenates inline children. The ``display:inline``
+branch was strictly worse than the block branch it was meant to refine.
+
+WHY THE BARE-DIV TEST IS HERE. The bare ``<div>`` case was always correct. It is
+pinned below so that a future change cannot "fix" the inline case by regressing
+the block case — the two paths sit four lines apart and share a fallback.
+
+Found while comparing legacy and modern text output for the ``press_release``
+migration (edgartools-3dp), on 8-K 0000950170-25-047769, where the filer writes
+the acronym HERO with each initial bolded: '(Hunger Elimination or Reduction
+Objective)' came out as '(\\nH\\nunger\\nE\\nlimination or\\nR\\neduction\\nO\\nbjective)'.
+"""
+import pytest
+
+from edgar.documents import parse_html
+
+pytestmark = pytest.mark.fast
+
+
+RUNS = ('<font style="font-weight:bold;">H</font><font>unger </font>'
+        '<font style="font-weight:bold;">E</font><font>limination</font>')
+
+# The shape as the real filing writes it, attributes and all.
+REAL_SHAPE = (
+    '<div style="width:100%;display:inline;">'
+    '<font style="color:#212121;white-space:pre-wrap;font-weight:bold;font-size:12pt;'
+    'font-family:\'Aptos\',sans-serif;font-kerning:none;min-width:fit-content;">H</font>'
+    '<font style="color:#212121;white-space:pre-wrap;font-size:12pt;'
+    'font-family:\'Aptos\',sans-serif;font-kerning:none;min-width:fit-content;">unger </font>'
+    '<font style="color:#212121;white-space:pre-wrap;font-weight:bold;font-size:12pt;'
+    'font-family:\'Aptos\',sans-serif;font-kerning:none;min-width:fit-content;">E</font>'
+    '<font style="color:#212121;white-space:pre-wrap;font-size:12pt;'
+    'font-family:\'Aptos\',sans-serif;font-kerning:none;min-width:fit-content;">limination</font>'
+    '</div>'
+)
+
+
+@pytest.mark.parametrize("display", ["inline", "inline-block"])
+def test_an_inline_styled_div_keeps_its_runs_on_one_line(display):
+    """Both values route through the same branch, so both must hold."""
+    text = parse_html(f'<div style="display:{display};">{RUNS}</div>').text().strip()
+    assert text == "Hunger Elimination"
+
+
+def test_the_real_filing_shape_survives():
+    """The 8-K 0000950170-25-047769 shape, attributes included.
+
+    The synthetic case above is the diagnosis; this is the thing that broke.
+    """
+    assert parse_html(REAL_SHAPE).text().strip() == "Hunger Elimination"
+
+
+def test_a_word_is_never_split_across_lines():
+    """The symptom stated directly, rather than via an equality that could be
+    satisfied by some other rendering."""
+    text = parse_html(f'<div style="display:inline;">{RUNS}</div>').text().strip()
+    assert "\n" not in text
+    assert "H\nunger" not in text
+
+
+@pytest.mark.parametrize("container", [
+    f'<div>{RUNS}</div>',
+    f'<p>{RUNS}</p>',
+    f'<div style="width:100%;">{RUNS}</div>',
+])
+def test_containers_that_were_already_correct_stay_correct(container):
+    """Guards the block path, four lines from the one that was fixed."""
+    assert parse_html(container).text().strip() == "Hunger Elimination"
+
+
+def test_an_inline_div_holding_a_real_block_is_not_flattened():
+    """The fix routes through ``_is_text_only_container``, so a div carrying an
+    actual block child must still keep those blocks apart — otherwise the fix
+    would have traded one wrong rendering for another."""
+    html = '<div style="display:inline;"><p>First para</p><p>Second para</p></div>'
+    text = parse_html(html).text()
+    assert "First para" in text
+    assert "Second para" in text
+    assert "First paraSecond para" not in text


### PR DESCRIPTION
## The bug

Filers routinely bold one letter of a word by giving it its own `<font>` run — the initials of an acronym, a drop cap. Where those runs sat inside a `<div>` carrying `display:inline`, `Document.text()` emitted each run as its own block:

```html
<div style="display:inline;"><font>H</font><font>unger </font><font>E</font><font>limination</font></div>
```
```
legacy edgar.files : 'Hunger Elimination'
edgar.documents    : 'H\n\nunger\n\nE\n\nlimination'
```

Every character survives, which is why no length check caught it — the damage shows only in a word-level comparison, or to a reader. A **bare** `<div>` with the identical children was always correct; it is `display:inline`, which should make content *more* inline, that broke it.

Real filing: 8-K `0000950170-25-047769` (Aardvark Therapeutics, 2025-04-01), which writes the acronym HERO with each initial bolded. `(Hunger Elimination or Reduction Objective)` came out as `(\nH\nunger\nE\nlimination or\nR\neduction\nO\nbjective)`.

Found while comparing legacy and modern text output for the `press_release` migration, not by looking for it.

## Cause

In `DocumentBuilder`'s div/block branch, `style.display in ('inline','inline-block')` called `_get_element_text()` and, on a falsy result, returned a bare `ContainerNode` — which emits each child run as its own block.

`_get_element_text()` only descends into children for elements that are inline **by tag**. A `div` is not one, so it sees only the div's direct text — empty for exactly the shape this branch exists to serve, so the fallback fired every time. The normal-block path immediately below already handled the same shape correctly (`ParagraphNode`, which concatenates inline children). The `display:inline` branch was strictly worse than the branch it was meant to refine.

## The obvious fix is wrong

Worth reading before reviewing the diff, because it passed more than it should have.

Reusing the existing `_is_text_only_container()` — mirroring the block path four lines below — went green on the minimal repro **and** on both parity ratchets, and still broke the GS 10-Q: `part_i_item_1` fell 620,442 → 619,037 characters, failing two `test_dt1f1_10q_part_boundary` tests.

That helper inspects only **direct** children and treats any unrecognised tag as inline. `ix:continuation` and `ix:nonNumeric` are in neither element set — `INLINE_ELEMENTS` deliberately admits only `ix:nonfraction`, `ix:footnote`, `ix:fraction` — so an iXBRL wrapper holding an entire table passes it. Instrumenting showed **exactly two** divs in that fixture took the new path, both wrapping whole tables and headings, and flattening them collapsed rendered tables into run-on lines:

```
before: Two-notch downgrade      $  1,532      $  1,200
after:  Two-notch downgrade $ 1,532 $ 1,200 Hedge Accounting
```

— the following heading pulled onto the table's last row.

So the shipped predicate, `_is_inline_run_container()`, requires every direct child to be in `INLINE_ELEMENTS` **and** no descendant at any depth to be a block.

Two things this cost that are worth keeping: those two divs were invisible in aggregate — length deltas and green ratchets both looked fine, and only a fixture test with a pinned character count caught it. And the GS fixture has **519** `display:inline` divs, so the shape is common; it was the iXBRL-wrapped ones that were dangerous, not the count.

## Verification

- **5,500 fast tests** pass (the two GS failures are gone), **both parity ratchets** pass (13), ruff clean.
- Regression test: 8 tests, covering the synthetic repro, the real filing's shape with its attributes, `inline-block` as well as `inline`, the containers that were always correct, and an inline div holding real blocks — so the fix can't be traded for the opposite wrong rendering.
- Verified by planted regression: reverting the fix fails 4 of the 8 and leaves the 4 controls green.
- The test carries an explicit `pytest.mark.fast` rather than trusting the filename patterns in `tests/conftest.py`, since a name matching none of them runs in no CI job.

## Scope

Parser fix only. It surfaced as a prerequisite for the `edgar.files` → `edgar.documents` migration of `company_reports/`, but none of that migration is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
