### PR TITLE
fix(documents): keep the line break a <br> writes between inline elements (hxtd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A line break the filer wrote was dropped, gluing the words either side.** A `<br>` between two inline elements — the shape of every 6-K and 8-K cover page — was pruned as an empty node, so `UNITED STATES<br/>SECURITIES AND EXCHANGE COMMISSION` came back as `UNITED STATESSECURITIES AND EXCHANGE COMMISSION`. `<br>` between bare text was never affected. Exelon's 8-K of 2005-04-27 regains two line breaks; its text is otherwise unchanged, at the same 2,629 characters.
+
+### Fixed
+
 - **A word came back split across lines when the filer bolded one of its letters.** Filers routinely put an acronym's initials in their own `<font>` runs; where those sit inside a `<div>` styled `display:inline`, `Document.text()` emitted each run as its own block. Aardvark Therapeutics' 8-K of 2025-04-01 rendered "(Hunger Elimination or Reduction Objective)" one letter to a line. Such a div now reads as a paragraph — unless it wraps a table or another block, which is how iXBRL containers hold whole statements.
 
 ## [5.52.0] - 2026-08-22

--- a/edgar/documents/processors/postprocessor.py
+++ b/edgar/documents/processors/postprocessor.py
@@ -87,6 +87,14 @@ class DocumentPostprocessor:
         if node.type == NodeType.IMAGE:
             return False
 
+        # Never remove an explicit line break. Its content is a newline, so every
+        # text check below reads it as empty, but a <br> is content the filer
+        # wrote -- dropping it glues the words either side together. The generic
+        # metadata rule below would also spare it; this is stated separately so
+        # the reason survives any future tightening of that rule.
+        if node.metadata.get('is_line_break'):
+            return False
+
         # Never remove nodes with metadata
         if node.metadata:
             return False

--- a/edgar/documents/strategies/document_builder.py
+++ b/edgar/documents/strategies/document_builder.py
@@ -321,8 +321,14 @@ class DocumentBuilder:
             )
 
         elif tag == 'br':
-            # Line break - add as text node
-            return TextNode(content='\n')
+            # Line break - add as text node. Mark it, because its content is
+            # whitespace and the postprocessor prunes whitespace-only text nodes:
+            # unmarked, a <br> between two inline elements was dropped and the
+            # words either side glued together ("UNITED STATESSECURITIES AND
+            # EXCHANGE COMMISSION" on a 6-K cover page).
+            line_break = TextNode(content='\n')
+            line_break.set_metadata('is_line_break', True)
+            return line_break
 
         elif tag in ['section', 'article']:
             return SectionNode(style=style)

--- a/tests/issues/regression/test_filing_text_baseline.py
+++ b/tests/issues/regression/test_filing_text_baseline.py
@@ -191,7 +191,15 @@ BASELINE = {
     "0000950137-05-004969": (
         dict(form="8-K", filing_date="2005-04-27", company="EXELON CORP",
              cik=1109357, accession_no="0000950137-05-004969"),
-        "a57148944a33bf13bce04b692856c8ad5a61e50132bc648d480b089a5d7ecdda",
+        # Re-captured for edgartools-hxtd: a <br> between two inline elements was
+        # being pruned as an empty node, so the filer's line breaks arrived as
+        # spaces. This cover page gains two of them back --
+        # "CURRENT REPORT Pursuant to Section 13" -> "CURRENT REPORT\nPursuant to
+        # Section 13", and the same at "April 26, 2005 Date of Report". Length is
+        # unchanged at 2,629 characters and
+        # "".join(before.split()) == "".join(after.split()) holds, so nothing but
+        # whitespace moved. This is the only filing of the five that changed.
+        "37211411d05d2120eece22347d8c7cbfde46680d516751fbcce17f060dcb7b5e",
     ),
     # 424B2 structured note
     "0001481057-23-010389": (

--- a/tests/issues/regression/test_hxtd_br_between_inline_elements.py
+++ b/tests/issues/regression/test_hxtd_br_between_inline_elements.py
@@ -1,0 +1,93 @@
+"""A ``<br>`` between two inline elements keeps its line break (edgartools-hxtd).
+
+The 6-K/8-K cover page is written as one paragraph of bold lines separated by
+``<br>``::
+
+    <p><strong>UNITED STATES</strong><br/>
+       <strong>SECURITIES AND EXCHANGE COMMISSION</strong><br/>
+       <strong>Washington, D.C. 20549</strong></p>
+
+``Document.text()`` used to return ``UNITED STATESSECURITIES AND EXCHANGE
+COMMISSIONWashington, D.C. 20549`` -- the break dropped and the words either
+side glued. ``<br>`` between *bare text* always worked; it was specifically
+``<br>`` between inline ELEMENTS that was lost.
+
+CAUSE, and why it took a walk of the tree to find. ``DocumentBuilder`` does
+create the node (``elif tag == 'br': TextNode(content='\\n')``) and does attach
+it -- tracing ``add_child`` shows it arriving on the ParagraphNode. It is
+``DocumentPostprocessor._remove_empty_nodes`` that takes it away afterwards:
+``_is_empty_node`` asks ``not node.text().strip()``, and a newline strips to
+nothing, so the one node whose entire meaning IS whitespace was read as empty.
+The node is now marked ``is_line_break`` at construction and exempted by name,
+in the same style as the TABLE and IMAGE exemptions beside it -- the latter
+added after empty-node pruning silently dropped images (GH #886), which is the
+same bug in a different costume.
+
+WHY IT MATTERED BEYOND ITS SIZE. ``edgar.files.html.Document`` was the only
+implementation that got this right -- ``edgar.files.html_documents.HtmlDocument``
+and ``edgar.documents`` both glued -- so until this was fixed, deleting
+``edgar/files`` would have removed the correct behaviour and left the broken one
+on the cover page of a great many filings. It blocked edgartools-07lk.3.
+
+Found in the edgartools-3dp Group A comparison, on 6-K 0001171843-25-004208.
+"""
+import pytest
+
+from edgar.documents import parse_html
+
+pytestmark = pytest.mark.fast
+
+
+COVER_PAGE = (
+    '<p><strong>UNITED STATES</strong><br/>'
+    '<strong>SECURITIES AND EXCHANGE COMMISSION</strong><br/>'
+    '<strong>Washington, D.C. 20549</strong></p>'
+)
+
+
+@pytest.mark.parametrize("inline_tag", ["strong", "span", "b", "em", "font"])
+def test_a_break_between_inline_elements_survives(inline_tag):
+    html = (f'<p><{inline_tag}>UNITED STATES</{inline_tag}><br/>'
+            f'<{inline_tag}>SECURITIES AND EXCHANGE COMMISSION</{inline_tag}></p>')
+    assert parse_html(html).text().strip() == "UNITED STATES\nSECURITIES AND EXCHANGE COMMISSION"
+
+
+def test_the_cover_page_shape_reads_as_three_lines():
+    """The thing that actually broke, rather than its reduction."""
+    lines = [ln for ln in parse_html(COVER_PAGE).text().strip().split("\n") if ln.strip()]
+    assert lines == ["UNITED STATES",
+                     "SECURITIES AND EXCHANGE COMMISSION",
+                     "Washington, D.C. 20549"]
+
+
+def test_words_either_side_are_never_glued():
+    """States the symptom directly — the failure was a missing separator, and an
+    equality test alone could be satisfied by some other rendering."""
+    text = parse_html(COVER_PAGE).text()
+    assert "STATESSECURITIES" not in text
+    assert "COMMISSIONWashington" not in text
+
+
+def test_a_break_between_bare_text_still_works():
+    """This path was always correct; it shares the node type that was fixed."""
+    html = '<p>UNITED STATES<br/>SECURITIES AND EXCHANGE COMMISSION</p>'
+    assert parse_html(html).text().strip() == "UNITED STATES\nSECURITIES AND EXCHANGE COMMISSION"
+
+
+def test_a_break_inside_a_div_survives_too():
+    html = '<div><strong>A</strong><br/><strong>B</strong></div>'
+    assert parse_html(html).text().strip() == "A\nB"
+
+
+def test_consecutive_breaks_are_both_kept():
+    """Two <br> is how filers write a blank line; collapsing them to one would be
+    a quieter version of the same bug."""
+    assert parse_html('<p><strong>A</strong><br/><br/><strong>B</strong></p>').text().strip() == "A\n\nB"
+
+
+def test_incidental_whitespace_is_still_pruned():
+    """The exemption is for <br> only. Whitespace between tags carries no meaning
+    and must not start surviving as blank lines, or every document grows them."""
+    text = parse_html('<div>  <p>A</p>   <p>B</p>  </div>').text()
+    assert "\n\n\n" not in text
+    assert [ln for ln in text.split("\n") if ln.strip()] == ["A", "B"]


### PR DESCRIPTION
Fixes the bug that was blocking removal of the legacy HTML parser.

## The bug

The 6-K/8-K cover page is one paragraph of bold lines separated by `<br>`:

```html
<p><strong>UNITED STATES</strong><br/><strong>SECURITIES AND EXCHANGE COMMISSION</strong></p>
```

| parser | before this PR |
|---|---|
| `edgar.files.html.Document` | `UNITED STATES\nSECURITIES AND EXCHANGE COMMISSION` ✅ |
| `edgar.files.html_documents.HtmlDocument` | `UNITED STATESSECURITIES…` ❌ |
| `edgar.documents` | `UNITED STATESSECURITIES…` ❌ |

`<br>` between **bare text** was always correct. It was specifically `<br>` between inline **elements** that was lost — which is why it survived so long, and why the minimal repro only reproduces with tags either side.

## Cause

Two plausible suspects were innocent, so this is worth stating precisely.

`DocumentBuilder` **does** create the node — `elif tag == 'br': TextNode(content='\n')` — and **does** attach it; tracing `add_child` shows it arriving on the ParagraphNode. `TextNode('\n').text()` correctly returns `'\n'`.

`DocumentPostprocessor._remove_empty_nodes` takes it away afterwards. `_is_empty_node` asks `not node.text().strip()`, and a newline strips to nothing — so the one node whose entire meaning *is* whitespace was read as empty and pruned.

The node is now marked `is_line_break` at construction and exempted by name, beside the existing TABLE and IMAGE exemptions. That IMAGE exemption is worth noting: it was added after this same pruning silently dropped images from text and markdown output (GH #886). This is the same bug in another costume, and the fix follows the same shape deliberately.

## Why it mattered beyond its size

**It blocked #930.** `edgar.files.html.Document` was the only implementation that got this right. Deleting `edgar/files` would have removed the correct behaviour and left the glued one on the cover page of a great many filings.

It also blocked the `sixk.py` half of the `company_reports/` migration (#1093), whose `_get_exhibit_content` reads through `files.html.Document` — migrating it would have moved correct → glued. On a 15-exhibit 6-K corpus the worst filing's missing-token rate falls from **2.6% → 0.9%**, and `STATES` / `SECURITIES` / `COMMISSION` / `Washington` leave the missing list entirely.

## A deliberate baseline re-capture

`test_filing_text_baseline` pins `Filing.text()` by SHA-256 and its docstring says a failure there "is not automatically a regression — but it IS a change in what users get, so it must be a deliberate, explained one."

Exelon's 8-K of 2005-04-27 changed. It gains two line breaks where spaces had stood in:

```
- CURRENT REPORT Pursuant to Section 13 or 15(d) of the Securities Exchange Act of 1934
+ CURRENT REPORT
+ Pursuant to Section 13 or 15(d) of the Securities Exchange Act of 1934
```

Length is unchanged at 2,629 characters and `"".join(before.split()) == "".join(after.split())` holds, so nothing but whitespace moved. It is the only one of the five pinned filings that changed. The new hash carries that explanation inline, in the style the file already uses.

## What this does *not* fix

Two diffs remain on that 6-K corpus, both filed separately:

- A rendered table omits its **index column**, losing `Date: June 30, 2025` from a signature block. The content is still in the model — `to_dataframe()` has it in the index — so this is a rendering loss, invisible to any check that inspects the table. Filed P2.
- Tokens like `COMMISSIONWashington` and `ofJune` that the **legacy** parser glued and the new one separates correctly. Not a regression.

## Verification

- 5,511 fast tests, both parity ratchets (13), ruff clean.
- Regression test: 11 tests across `strong`/`span`/`b`/`em`/`font`, a `div` container, consecutive `<br>`, and the full three-line cover page.
- Verified by planted regression: reverting the fix fails 9 of the 11. The 2 that stay green are the controls — bare-text `<br>`, which always worked, and a check that incidental whitespace between tags is *still* pruned, so the exemption cannot start growing blank lines in every document.
- Explicit `pytest.mark.fast`, since a filename matching none of the patterns in `tests/conftest.py` runs in no CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
