### PR TITLE
fix(documents): a wide table keeps every column, not the best-scoring eight (kq2q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A line break the filer wrote was dropped, gluing the words either side.** A `<br>` between two inline elements — the shape of every 6-K and 8-K cover page — was pruned as an empty node, so `UNITED STATES<br/>SECURITIES AND EXCHANGE COMMISSION` came back as `UNITED STATESSECURITIES AND EXCHANGE COMMISSION`. `<br>` between bare text was never affected. Exelon's 8-K of 2005-04-27 regains two line breaks; its text is otherwise unchanged, at the same 2,629 characters.
 
-### Fixed
-
 - **Wide tables silently lost real columns.** The text renderer scored each column of a table, sorted the scores highest-first, and kept only the top eight. Because of that ordering the discarded columns were not the right-hand edge but whichever scored lowest anywhere in the table, so a 21-column segment table rendered without its `Corporate and unallocated` and `Total` headers, and a 10-column voting table dropped the `% Withheld` figure altogether — 6.45 was in `to_dataframe()` and nowhere in `text()`. Every column that clears the content threshold is now rendered; per-column width is still bounded by `table_max_col_width`.
 
 - **A word came back split across lines when the filer bolded one of its letters.** Filers routinely put an acronym's initials in their own `<font>` runs; where those sit inside a `<div>` styled `display:inline`, `Document.text()` emitted each run as its own block. Aardvark Therapeutics' 8-K of 2025-04-01 rendered "(Hunger Elimination or Reduction Objective)" one letter to a line. Such a div now reads as a paragraph — unless it wraps a table or another block, which is how iXBRL containers hold whole statements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wide tables silently lost real columns.** The text renderer scored each column of a table, sorted the scores highest-first, and kept only the top eight. Because of that ordering the discarded columns were not the right-hand edge but whichever scored lowest anywhere in the table, so a 21-column segment table rendered without its `Corporate and unallocated` and `Total` headers, and a 10-column voting table dropped the `% Withheld` figure altogether — 6.45 was in `to_dataframe()` and nowhere in `text()`. Every column that clears the content threshold is now rendered; per-column width is still bounded by `table_max_col_width`.
+
 - **A word came back split across lines when the filer bolded one of its letters.** Filers routinely put an acronym's initials in their own `<font>` runs; where those sit inside a `<div>` styled `display:inline`, `Document.text()` emitted each run as its own block. Aardvark Therapeutics' 8-K of 2025-04-01 rendered "(Hunger Elimination or Reduction Objective)" one letter to a line. Such a div now reads as a paragraph — unless it wraps a table or another block, which is how iXBRL containers hold whole statements.
 
 ## [5.52.0] - 2026-08-22

--- a/edgar/documents/renderers/fast_table.py
+++ b/edgar/documents/renderers/fast_table.py
@@ -300,15 +300,21 @@ class FastTableRenderer:
         # Sort by score descending
         column_scores.sort(key=lambda x: x[1], reverse=True)
 
-        # Take columns with meaningful content (score >= 0.5 or among top columns)
+        # Take every column with meaningful content. The score threshold below is the
+        # only filter: there used to be a further `if len(meaningful_columns) >= 8:
+        # break` here, for readability. Because the loop walks the columns in
+        # DESCENDING score order, that cap did not drop the last columns of the table --
+        # it dropped the eight-best-scoring columns' losers wherever they sat, real data
+        # among them. A 21-column segment table kept 8 and silently lost the "Logistics
+        # and other solution services", "Corporate and unallocated" and "Total" headers;
+        # a 10-column voting table lost the "% Withheld" figure entirely, so 6.45 was in
+        # to_dataframe() but nowhere in text(). Width is already bounded per column by
+        # style.max_col_width, so readability does not need a column count as well.
         meaningful_columns = []
         for col_idx, avg_score, total_score in column_scores:
             # Include if it has good average score or significant total content
             if avg_score >= 0.5 or total_score >= 5:
                 meaningful_columns.append(col_idx)
-            # Limit to reasonable number of columns for readability
-            if len(meaningful_columns) >= 8:
-                break
 
         # Sort by original column order
         meaningful_columns.sort()

--- a/tests/issues/regression/test_dt1f1_10q_part_boundary.py
+++ b/tests/issues/regression/test_dt1f1_10q_part_boundary.py
@@ -158,8 +158,14 @@ def test_gs_10q_resolves_its_part_ii_sections():
     }
 
     # Part I is untouched — the fix adds a boundary, it does not move one.
-    assert len(sections["part_i_item_1"].text()) == 620442
-    assert len(sections["part_i_item_2"].text()) == 393389
+    # Both counts grew when the fast_table 8-column cap was removed (edgartools-kq2q):
+    # these two sections carry GS's financial statements, and their wide tables were
+    # rendering without columns the cap had discarded. Verified non-lossy at the word
+    # level -- the only tokens that leave the Counter do so by gaining a "$" prefix
+    # ("1,656,611" -> "$1,656,611"), 139 "$" markers arrive, and the section's first
+    # and last 80 characters are byte-identical, so no boundary moved.
+    assert len(sections["part_i_item_1"].text()) == 632360
+    assert len(sections["part_i_item_2"].text()) == 397515
 
     assert sections["part_ii_item_1"].text().startswith("Item 1. Legal Proceedings")
     assert sections["part_ii_item_6"].text().startswith("Item 6. Exhibits")
@@ -184,7 +190,8 @@ def test_gs_10q_lookups_answer_without_any_legacy_fallback():
 
     # Part I still answers from the new parser too — get_item_with_part must not
     # have started depending on the Part II marker to resolve anything.
-    assert len(report.get_item_with_part("Part I", "Item 1")) == 620442
+    # Count re-pinned for edgartools-kq2q; see the note in the test above.
+    assert len(report.get_item_with_part("Part I", "Item 1")) == 632360
 
 
 def test_signatures_bounds_the_last_item_on_other_filings_too():

--- a/tests/issues/regression/test_dt1f1_wrapped_item_headers.py
+++ b/tests/issues/regression/test_dt1f1_wrapped_item_headers.py
@@ -201,9 +201,13 @@ def test_2010_20f_resolves_all_eight_wrapped_items_without_the_legacy_parser():
     filing = FixtureFiling(IGNORED_20F, "20-F")
     report = _without_legacy(TwentyF)(filing)
 
+    # Items 5 and 6 grew by 150 and 20 characters when the fast_table 8-column cap
+    # was removed (edgartools-kq2q) -- they are the two that carry tables. The other
+    # six are unchanged, which is the signal that the cap removal touches table
+    # rendering only and moves no item boundary.
     expected = {
-        "Item 5": 107307,
-        "Item 6": 57841,
+        "Item 5": 107457,
+        "Item 6": 57861,
         "Item 11": 7504,
         "Item 12": 152,
         "Item 15": 14078,

--- a/tests/issues/regression/test_fast_table_column_cap.py
+++ b/tests/issues/regression/test_fast_table_column_cap.py
@@ -1,0 +1,67 @@
+"""A wide table keeps every meaningful column (fast_table 8-column cap).
+
+``FastTableRenderer._identify_meaningful_columns`` scored each column, sorted the
+scores DESCENDING, then stopped after eight. Because of that ordering the cap did
+not trim the right-hand edge of a wide table -- it discarded whichever columns
+scored lowest, wherever they sat, and on real financial tables those are ordinary
+data columns.
+
+Two shapes found in the edgartools-3dp Group A comparison over 6-K exhibits:
+
+* a 21-column segment table (0001213900-25-059683 EX-99.2) rendered 8 columns, so
+  the "Logistics and other solution services", "Corporate and unallocated" and
+  "Total" headers were absent from ``text()`` while present in ``to_dataframe()``;
+* a 10-column voting table (0001641172-25-017205 EX-99.1) lost the "% Withheld"
+  VALUE -- 6.45 was in the model and nowhere in the text.
+
+Per-column width is bounded separately by ``style.max_col_width``, so dropping
+columns bought nothing that the width limit does not already provide.
+"""
+import pytest
+
+from edgar.documents import parse_html
+
+pytestmark = pytest.mark.fast
+
+
+def _wide_table_html(n_cols: int) -> str:
+    """A table with n_cols distinctly-labelled data columns plus a row label."""
+    headers = "".join(f"<td>Col{i}</td>" for i in range(n_cols))
+    cells = "".join(f"<td>{1000 + i}</td>" for i in range(n_cols))
+    return f"""
+    <html><body><table>
+      <tr><td>Segment</td>{headers}</tr>
+      <tr><td>Revenue</td>{cells}</tr>
+    </table></body></html>
+    """
+
+
+def test_wide_table_keeps_every_column():
+    """A 12-column table renders all 12 headers, not the 8 best-scoring ones."""
+    text = parse_html(_wide_table_html(12)).text(table_max_col_width=200)
+
+    for i in range(12):
+        assert f"Col{i}" in text, f"header Col{i} was dropped from text()"
+        assert str(1000 + i) in text, f"value {1000 + i} was dropped from text()"
+
+
+def test_narrow_table_is_unaffected():
+    """The threshold still removes spacing-only columns."""
+    html = """
+    <html><body><table>
+      <tr><td>Segment</td><td> </td><td>Revenue</td></tr>
+      <tr><td>Nursing</td><td> </td><td>1,654,567</td></tr>
+    </table></body></html>
+    """
+    text = parse_html(html).text(table_max_col_width=200)
+
+    assert "Segment" in text
+    assert "1,654,567" in text
+
+
+def test_column_count_beyond_the_old_cap_survives():
+    """The old cap kept exactly 8; anything past that is the regression under test."""
+    text = parse_html(_wide_table_html(15)).text(table_max_col_width=200)
+
+    present = sum(1 for i in range(15) if f"Col{i}" in text)
+    assert present == 15, f"only {present}/15 columns survived rendering"

--- a/tests/issues/regression/test_filing_text_baseline.py
+++ b/tests/issues/regression/test_filing_text_baseline.py
@@ -173,13 +173,26 @@ BASELINE = {
     "0000320193-23-000106": (
         dict(form="10-K", filing_date="2023-11-03", company="Apple Inc.",
              cik=320193, accession_no="0000320193-23-000106"),
-        "6147976a87b59b1400d374831c625d023f0202b4d36fda6b931e8407a07a4ccc",
+        # Re-captured for the fast_table column cap: the renderer kept only the 8
+        # highest-scoring columns of a table, so wide financial tables silently lost
+        # real columns. Apple's marketable-securities and stock-performance tables
+        # regain their headers ("September", "Cash", "Unrealized", "Losses",
+        # "Marketable", "Securities") and 22 "$" markers; "98 204 269" becomes
+        # "$98  $204  $269". No value is lost -- every number in the old text is still
+        # present, and the only tokens that leave the word Counter do so by gaining a
+        # "$" prefix.
+        "a878a2084898cc6bebf519a9b6b765985fc8e8b75e469405ed44e9638676e012",
     ),
     # Plain HTML 10-K
     "0001193125-20-052640": (
         dict(form="10-K", filing_date="2020-02-27", company="10x Genomics, Inc.",
              cik=1770787, accession_no="0001193125-20-052640"),
-        "feae74ba4ffd7cb9bc267297bab99ab3f2d0a707cda06ce1bbb6ee19257580df",
+        # Re-captured for the same fast_table column cap. 10x Genomics' statement of
+        # stockholders' equity regains "Accumulated", "Shares", "Amount", "Net" and
+        # "Stock" headers, 24 "$" markers, and a whole "$2" column that the cap had
+        # dropped. Counts of every existing figure (420,083 / 682,494 / 138,450 /
+        # 3,437 / 99,869 / 96,431) are unchanged before and after.
+        "0ec6d25aafba3e988faecb31b293b5b781da50cd0a5355b142dcb01d133d70b8",
     ),
     # CORRESP — the shape where the two paths already agreed before the fix
     "0000065873-05-000060": (

--- a/tests/issues/regression/test_yrrh_get_item_with_part.py
+++ b/tests/issues/regression/test_yrrh_get_item_with_part.py
@@ -132,7 +132,13 @@ def _parser_only(cls):
     "ticker,part,item,expected",
     [
         # The two rows this bead was filed for.
-        ("xom", "Part I", "Item 1", 138607),
+        # 138,607 before the fast_table 8-column cap was removed (edgartools-kq2q).
+        # XOM's Item 1 is financial statements; the segment tables were rendering
+        # without the columns the cap discarded. Verified non-lossy at the word
+        # level: ZERO tokens lost, 570 gained, all of them column headers
+        # ("Non-U.S.", "Total", "Segment", "Products"), and the section's first and
+        # last 80 characters are unchanged, so the boundaries did not move.
+        ("xom", "Part I", "Item 1", 167042),
         ("pg", "Part II", "Item 1", 975),
         # And the two that closed earlier with the 10-Q Part II boundary fix
         # (dt1f.1 Defect D), kept here so the whole method is covered by one


### PR DESCRIPTION
Closes `edgartools-kq2q`.

## The bug

`FastTableRenderer._identify_meaningful_columns` scored each column of a table, sorted the scores **descending**, then stopped after eight:

```python
if len(meaningful_columns) >= 8:
    break
```

Because the loop walked columns in *score* order rather than *positional* order, that cap did not trim the right-hand edge of a wide table. It discarded whichever columns scored lowest, wherever they sat — and on real financial tables those are ordinary data columns.

Two shapes found while comparing the legacy and modern parsers over 6-K exhibits:

| Filing | Table | Symptom |
|---|---|---|
| `0001213900-25-059683` EX-99.2 | 21-column segment table | rendered 8 columns; the `Logistics and other solution services`, `Corporate and unallocated` and `Total` headers were absent from `text()` while present in `to_dataframe()` |
| `0001641172-25-017205` EX-99.1 | 10-column voting table | lost a **value** — `% Withheld` of `6.45` was in the model and nowhere in the text |

The mechanism was confirmed by instrumenting the predicate rather than inferring from totals — it logs `cols 21 -> kept 8` along with the dropped cells' contents.

## The fix

Delete the cap. The score threshold above it is the correct filter, and per-column width is already bounded separately by `style.max_col_width`, so the column *count* bought no readability the width limit does not already provide.

## Verification

Full fast suite: **5514 passed, 0 failed.**

Six pinned assertions moved, all upward, and each was checked at the **word** level rather than by length — because a length that grows is also exactly what a section-boundary leak looks like.

**Two text baselines** (`test_filing_text_baseline.py`) — both gain content and lose none:
- Apple 10-K regains six marketable-securities headers and 22 `$` markers; `98 204 269` becomes `$98 $204 $269`.
- 10x Genomics 10-K regains five stockholders'-equity headers, 24 `$` markers, and a whole `$2` column the cap had dropped.
- Counts of every pre-existing figure (`420,083` / `682,494` / `138,450` / `3,437` / `99,869` / `96,431`) are identical before and after.

**Four section lengths** (`dt1f1` ×3, `yrrh` ×1):
- XOM Part I Item 1 (138,607 → 167,042): **zero** tokens lost, 570 gained, every one a column header — `Non-U.S.` ×26, `Total` ×12, `Segment` ×10, `Products` ×8.
- GS Part I Item 1 (620,442 → 632,360): 355 gained including 139 `$`; the only three departing tokens leave by gaining a `$` prefix (`1,656,611` → `$1,656,611`).
- Both sections' first and last 80 characters are byte-identical, so no boundary moved.
- The four Part II sections (1,222 / 1,976 / 535 / 1,188) and six of the eight 20-F items are **unchanged**. Prose static while table sections grow is the signal that this is table rendering and nothing else.

New regression test `test_fast_table_column_cap.py` fails pre-fix at `7 == 15` columns.

## Also here

One commit folds the `[Unreleased]` CHANGELOG back to a single `### Fixed` heading — #1094 added its entry under a second one.

## Related

Found in the `edgartools-3dp` Group A comparison. The remaining table-fidelity gaps are `edgartools-3cis` (single-char suffix columns `%` and `)` are still scored as spacing and dropped) and `edgartools-y0ri` (index column omitted), both pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)