### PR TITLE
refactor(company_reports): move sixk off the legacy parser (3dp Group A)

### DIFF
--- a/edgar/company_reports/sixk.py
+++ b/edgar/company_reports/sixk.py
@@ -206,7 +206,7 @@ class SixK:
 
     def _get_exhibit_content(self, exhibit) -> Optional[str]:
         """Get the rendered text content of an exhibit."""
-        from edgar.files.html import Document
+        from edgar.documents import parse_html
 
         if exhibit.empty:
             sgml_document = self._filing.sgml().get_document_by_sequence(exhibit.sequence_number)
@@ -215,8 +215,10 @@ class SixK:
         else:
             html_content = exhibit.download()
             if html_content:
-                document = Document.parse(html_content)
-                return repr_rich(document, width=200, force_terminal=False)
+                # text(table_max_col_width=200) is what the modern Document's own
+                # __repr__ returns; it is spelled out rather than reached through
+                # repr_rich because this Document has no __rich__ to render.
+                return parse_html(html_content).text(table_max_col_width=200)
 
     def _content_renderables(self):
         """Get exhibit content as rich renderables."""


### PR DESCRIPTION
The last Group A leaf of `edgartools-3dp`. Completes the group: `press_release` went in #1093, and this is `sixk`.

## ⚠️ Merge after #1095

Without the column-cap fix in #1095, this trades one defect for another: the 6-K exhibits' financial tables lose columns, and on one voting table a value. #1094 (the other blocker) is already on `main`.

## The change

`_get_exhibit_content` used `edgar.files.html.Document` + `repr_rich`; it now uses `parse_html(html).text(table_max_col_width=200)` — which is exactly what the modern `Document.__repr__` returns (`edgar/documents/document.py:1359`).

Spelled out rather than routed through `repr_rich`, because the modern `Document` has **no** `__rich__` — keeping `repr_rich` would have worked only by accident, via `__repr__`.

## Why this leaf took two prerequisites

`sixk` was the one Group A leaf where the legacy implementation was **better**, so migrating it early would have moved correct → broken:

1. **`edgartools-hxtd`** (#1094, merged) — a `<br>` between two inline elements was pruned as an empty node. `edgar.files.html.Document` was the *only* implementation that rendered a 6-K cover page's line breaks correctly.
2. **`edgartools-kq2q`** (#1095) — the renderer kept only the 8 highest-scoring columns of a table, dropping real columns from the exhibits' financial statements.

Both were found *by* this migration's comparison rather than being known in advance.

## Verification

`SixK.text()` compared before and after over **15 6-K filings from 2025Q2**, at the level of **words** rather than lengths — every bug in this group was invisible to a length check.

Prose is equal or better. The residue is dominated by the *legacy* parser's own defects, which the modern parser does not have:

- hyphenated words split at a line wrap — `forward-` / `looking`, `clinical-` / `stage`, `principles-` / `based`
- glued neighbours — `visitwww.aunainvestors.com`, `www.sedarplus.caand`, `SHEETS(Expressed`, `InquiriesInfo`
- superscript artifacts — `thday` for "6<sup>th</sup> day"

Content is not truncated even on the largest exhibit (3.2MB of HTML): its text tail is byte-identical and prose `option` appears 22 times in both.

## Known remaining gap

What the modern parser still renders less well is confined to tables: a single-character suffix column — a `%`, or the `)` closing a negative number — is scored as spacing and dropped, and some multi-row header cells are lost. That is `edgartools-3cis` and `edgartools-y0ri`, both pre-existing and tracked, and it is the last fidelity gap between the two parsers on 6-K exhibits. Worth closing before 6.0 removes `edgar.files` (`edgartools-07lk.3`), since at that point any such gap becomes permanent rather than tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)