### PR TITLE
perf(headers): parse filing headers with lxml instead of BeautifulSoup (07lk.11.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Filing header parsing is about 7x faster.** `Filing.index_headers` parsed the header page with BeautifulSoup's pure-Python `html.parser`; it now uses lxml, measured at 460µs to 66µs per header across the tracked header corpus. Output is unchanged — the full parsed model is pinned against a baseline captured from the previous implementation. Malformed input behaves as before, including the `IndexError` an empty page has always raised.
+
 - **`PressRelease.text()` now reads through the modern parser.** Output changes slightly, all of it in your favour: the old path leaked raw `<img>` markup into the text and left `&amp;` undecoded as a literal "amp", both of which are gone. Across 12 real 8-K press releases no word is lost that is not one of those artifacts. Table cells no longer repeat the `$` that filers put in their own column; the figures and the header's units are unchanged.
 
 ### Fixed

--- a/edgar/headers.py
+++ b/edgar/headers.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import lxml.html
 import orjson as json
 import pandas as pd
-from bs4 import BeautifulSoup, Comment, Tag
+from lxml.etree import ParserError
 from pydantic import BaseModel
 from rich import box
 from rich.console import Group
@@ -14,6 +15,7 @@ from rich.text import Text
 from edgar._party import Address, get_addresses_as_columns
 from edgar.config import SEC_BASE_URL
 from edgar.display.formatting import display_size
+from edgar.documents.utils.html_utils import create_lxml_parser
 from edgar.httprequests import download_file
 from edgar.reference import describe_form
 from edgar.richtools import repr_rich
@@ -256,15 +258,48 @@ class IndexHeaders(BaseModel):
         address_dict['state_or_country'] = address_dict.pop('state', '')
         return Address(**address_dict)
 
+    @staticmethod
+    def _first_comment_text(html_text: str) -> str:
+        """The SGML header, which SEC wraps in the first HTML comment of the page.
+
+        ``remove_comments=False`` is the whole point here and is NOT the house
+        default: everywhere else in the codebase comments are noise, and here the
+        comment IS the payload.
+
+        ``getroottree()`` rather than xpath off the parsed element, because a
+        comment can sit before ``<html>``. Today's files put it inside ``<head>``
+        after the title, but bs4 found it either way and this keeps that true.
+
+        ``ParserError`` is mapped to "no comments" so that empty or
+        whitespace-only input still raises ``IndexError`` below, which is what
+        BeautifulSoup did — it returned an empty soup and the caller indexed off
+        the end of it. Preserved so the parser swap is not also an exception-type
+        change for callers.
+        """
+        parser = create_lxml_parser(
+            remove_blank_text=False,
+            remove_comments=False,
+            recover=True,
+            encoding='utf-8',
+        )
+        try:
+            tree = lxml.html.fromstring(html_text, parser=parser)
+            comments = tree.getroottree().xpath('//comment()')
+        except (ParserError, ValueError):
+            comments = []
+
+        # Indexes unguarded, as it always has. A header file with no comment is
+        # not a filing this parser understands, and a bare IndexError here is
+        # ugly but load-bearing: see test_headers_characterization.py.
+        return (comments[0].text or '').strip()
+
     @classmethod
     def load(cls, header_text: str):
         """
         Load the IndexHeaders from the HTML file content.
         """
-        soup = BeautifulSoup(header_text, 'html.parser')
-
         # The SEC-HEADER tag contains the filing header information
-        header_text = soup.find_all(string=lambda text: isinstance(text, Comment))[0].strip()
+        header_text = cls._first_comment_text(header_text)
 
 
         lines = header_text.strip().split("\n")
@@ -472,26 +507,8 @@ class IndexHeaders(BaseModel):
             "issuer": issuer
         }
 
-        # The <PRE> block contains the HTML for the documents
-        #documents = IndexHeaders._extract_documents_from_pre(soup.find("pre"))
-
         # Initialize IndexHeaders with the parsed data
         return cls(**sec_header_data)
-
-    @staticmethod
-    def _extract_documents_from_pre(pre_tag:Tag):
-        soup = BeautifulSoup(pre_tag.text)
-        document_tags = soup.find_all("document")
-        for document_tag in document_tags:
-            document_tag.find("type")
-
-
-    @staticmethod
-    def _extract_comment_text(soup):
-        comments = soup.find_all(string=lambda text: isinstance(text, Comment))
-        if comments:
-            return comments[0].strip()
-        return None
 
     @staticmethod
     def _extract_accession_number(title: str):

--- a/tests/fixtures/headers/index_headers_baseline.json
+++ b/tests/fixtures/headers/index_headers_baseline.json
@@ -1,0 +1,222 @@
+{
+ "0001971857-23-000246-index-headers.html": {
+  "acceptance_datetime": "2023-06-12T15:05:50",
+  "accession_number": "0001971857-23-000246",
+  "date_of_filing_date_change": "2023-06-12",
+  "effectiveness_date": null,
+  "filer": null,
+  "filing_date": "2023-06-12",
+  "form": "144",
+  "issuer": null,
+  "items": [],
+  "period": null,
+  "public_document_count": 1,
+  "reporting_owner": {
+   "company_data": {
+    "assigned_sic": null,
+    "cik": "0001701746",
+    "conformed_name": "Hendrian Catherine A",
+    "fiscal_year_end": null,
+    "irs_number": null,
+    "organization_name": null
+   },
+   "filing_values": {
+    "act": "",
+    "file_number": "",
+    "film_number": "",
+    "form_type": "144"
+   },
+   "mail_address": {
+    "city": "JACKSON",
+    "state_or_country": "MI",
+    "state_or_country_description": null,
+    "street1": "ONE ENERGY PLAZA",
+    "street2": null,
+    "zipcode": "49201"
+   },
+   "owner_data": null
+  },
+  "subject_company": {
+   "business_address": {
+    "city": "JACKSON",
+    "state_or_country": "MI",
+    "state_or_country_description": null,
+    "street1": "ONE ENERGY PLAZA",
+    "street2": null,
+    "zipcode": "49201"
+   },
+   "company_data": {
+    "assigned_sic": "4931",
+    "cik": "0000201533",
+    "conformed_name": "CONSUMERS ENERGY CO",
+    "fiscal_year_end": "1231",
+    "irs_number": "380442310",
+    "organization_name": null
+   },
+   "filing_values": {
+    "act": "33",
+    "file_number": "001-05611",
+    "film_number": "231007818",
+    "form_type": "144"
+   },
+   "former_company": [],
+   "mail_address": {
+    "city": "JACKSON",
+    "state_or_country": "MI",
+    "state_or_country_description": null,
+    "street1": "ONE ENERGY PLAZA",
+    "street2": null,
+    "zipcode": "49201"
+   }
+  }
+ },
+ "23AndMe.index-headers.html": {
+  "acceptance_datetime": "2024-06-03T08:06:02",
+  "accession_number": "0001193125-24-152391",
+  "date_of_filing_date_change": "2024-06-03",
+  "effectiveness_date": null,
+  "filer": {
+   "business_address": {
+    "city": "SOUTH SAN FRANCISCO",
+    "state_or_country": "CA",
+    "state_or_country_description": null,
+    "street1": "349 OYSTER POINT BOULEVARD",
+    "street2": null,
+    "zipcode": "94080"
+   },
+   "company_data": {
+    "assigned_sic": "2834",
+    "cik": "0001804591",
+    "conformed_name": "23andMe Holding Co.",
+    "fiscal_year_end": "0331",
+    "irs_number": "871240344",
+    "organization_name": "03 Life Sciences"
+   },
+   "filing_values": {
+    "act": "34",
+    "file_number": "001-39587",
+    "film_number": "241012050",
+    "form_type": "8-K"
+   },
+   "former_company": [],
+   "mail_address": {
+    "city": "SOUTH SAN FRANCISCO",
+    "state_or_country": "CA",
+    "state_or_country_description": null,
+    "street1": "349 OYSTER POINT BOULEVARD",
+    "street2": null,
+    "zipcode": "94080"
+   }
+  },
+  "filing_date": "2024-06-03",
+  "form": "8-K",
+  "issuer": null,
+  "items": [
+   "7.01",
+   "9.01"
+  ],
+  "period": "20240603",
+  "public_document_count": 14,
+  "reporting_owner": null,
+  "subject_company": null
+ },
+ "form4.index-headers.html": {
+  "__error__": "IndexError: list index out of range"
+ },
+ "index-headers.html": {
+  "acceptance_datetime": "2024-06-03T16:08:21",
+  "accession_number": "0000905729-24-000095",
+  "date_of_filing_date_change": "2024-06-03",
+  "effectiveness_date": null,
+  "filer": {
+   "business_address": {
+    "city": "SPARTA",
+    "state_or_country": "MI",
+    "state_or_country_description": null,
+    "street1": "109 E DIVISION",
+    "street2": "P O BOX 186",
+    "zipcode": "49345-0186"
+   },
+   "company_data": {
+    "assigned_sic": "6022",
+    "cik": "0000803164",
+    "conformed_name": "CHOICEONE FINANCIAL SERVICES INC",
+    "fiscal_year_end": "1231",
+    "irs_number": "382659066",
+    "organization_name": "02 Finance"
+   },
+   "filing_values": {
+    "act": "34",
+    "file_number": "001-39209",
+    "film_number": "241013654",
+    "form_type": "8-K"
+   },
+   "former_company": [],
+   "mail_address": {
+    "city": "SPARTA",
+    "state_or_country": "MI",
+    "state_or_country_description": null,
+    "street1": "109 EAST DIVISION",
+    "street2": "P O BOX 186",
+    "zipcode": "49345-0186"
+   }
+  },
+  "filing_date": "2024-06-03",
+  "form": "8-K",
+  "issuer": null,
+  "items": [
+   "5.07"
+  ],
+  "period": "20240529",
+  "public_document_count": 13,
+  "reporting_owner": null,
+  "subject_company": null
+ },
+ "objectivecapital.form144-index-headers.html": {
+  "acceptance_datetime": "2024-06-05T14:37:19",
+  "accession_number": "0001924152-24-000002",
+  "date_of_filing_date_change": "2024-06-05",
+  "effectiveness_date": "20240605",
+  "filer": {
+   "business_address": {
+    "city": "PEPPER PIKE",
+    "state_or_country": "OH",
+    "state_or_country_description": null,
+    "street1": "29325 CHAGRIN BLVD., SUITE 204",
+    "street2": null,
+    "zipcode": "44122"
+   },
+   "company_data": {
+    "assigned_sic": null,
+    "cik": "0001924152",
+    "conformed_name": "Objective Capital Management, LLC",
+    "fiscal_year_end": "1231",
+    "irs_number": "274511658",
+    "organization_name": ""
+   },
+   "filing_values": {
+    "act": "34",
+    "file_number": "028-22421",
+    "film_number": "241021676",
+    "form_type": "13F-HR"
+   },
+   "former_company": [],
+   "mail_address": {
+    "city": "PEPPER PIKE",
+    "state_or_country": "OH",
+    "state_or_country_description": null,
+    "street1": "29325 CHAGRIN BLVD., SUITE 204",
+    "street2": null,
+    "zipcode": "44122"
+   }
+  },
+  "filing_date": "2024-06-05",
+  "form": "13F-HR",
+  "issuer": null,
+  "items": [],
+  "period": "20240331",
+  "public_document_count": 2,
+  "reporting_owner": null,
+  "subject_company": null
+ }
+}

--- a/tests/test_headers_characterization.py
+++ b/tests/test_headers_characterization.py
@@ -1,0 +1,145 @@
+"""Golden-file characterization of ``IndexHeaders.load`` (edgartools-07lk.11.4).
+
+Written while ``headers.py`` still ran on BeautifulSoup, so that the bs4 -> lxml
+port could be proved to change nothing. The baseline JSON is the full pydantic
+dump of every tracked header fixture, generated from the bs4 implementation and
+committed unchanged.
+
+WHY A GOLDEN FILE RATHER THAN FIELD ASSERTIONS. ``tests/test_headers.py`` checks
+a handful of fields on two fixtures. A parser swap can move anything -- a
+stripped space, a dropped tail, a null where a nested model used to be -- and
+field assertions only catch what someone thought to name. The dump catches the
+rest, which is the point: the epic's postmortem says Phase 1's only real
+regression came from an invisible behavioural contract, not from a coding error.
+
+The five fixtures are not uniform, deliberately. Four are the HTML
+``-index-headers.html`` form, where the SGML header sits inside an HTML comment.
+``form4.index-headers.html`` is bare SGML with no comment at all, and the loader
+raises ``IndexError`` on it -- see the test at the bottom, which pins that as it
+currently is rather than as it should be.
+"""
+import json
+import pathlib
+
+import pytest
+
+from edgar.headers import IndexHeaders
+
+pytestmark = pytest.mark.fast
+
+REPO = pathlib.Path(__file__).parent.parent
+HEADER_DIR = REPO / "data" / "headers"
+BASELINE = REPO / "tests" / "fixtures" / "headers" / "index_headers_baseline.json"
+
+# The one fixture whose content is not the format the loader parses.
+BARE_SGML = "form4.index-headers.html"
+
+
+def _baseline():
+    return json.loads(BASELINE.read_text())
+
+
+def _fixtures():
+    return sorted(HEADER_DIR.glob("*.html"))
+
+
+def test_the_corpus_and_baseline_line_up():
+    """A renamed or deleted fixture must fail loudly, not shrink the test silently."""
+    assert BASELINE.exists(), f"missing baseline {BASELINE}"
+    on_disk = {p.name for p in _fixtures()}
+
+    assert on_disk, f"no header fixtures under {HEADER_DIR}"
+    assert on_disk == set(_baseline()), (
+        "header fixtures and baseline have diverged; regenerate the baseline "
+        "deliberately rather than letting a fixture drop out of coverage"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(set(_baseline()) - {BARE_SGML}))
+def test_parsed_headers_match_the_baseline_exactly(name):
+    """Full model dump, not selected fields.
+
+    Compared as parsed JSON rather than as text so the failure message names the
+    differing key instead of showing two 1KB strings.
+    """
+    expected = _baseline()[name]
+    assert "__error__" not in expected, f"{name} is an error fixture; test it explicitly"
+
+    parsed = IndexHeaders.load((HEADER_DIR / name).read_text())
+    actual = json.loads(parsed.model_dump_json())
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("name", sorted(set(_baseline()) - {BARE_SGML}))
+def test_each_baseline_fixture_actually_carries_data(name):
+    """Guards the comparison above from passing on emptiness.
+
+    If a future parser returned a model with every field None, the dump would
+    still equal a baseline captured from that same broken parser. These are the
+    fields the loader exists to produce, so they must be populated for the
+    equality check to mean anything.
+    """
+    expected = _baseline()[name]
+
+    assert expected["form"], f"{name} has no form"
+    assert expected["accession_number"], f"{name} has no accession number"
+    assert expected["filing_date"], f"{name} has no filing date"
+
+
+def test_bare_sgml_without_an_html_comment_still_raises():
+    """Characterization, not endorsement.
+
+    This fixture is raw SGML header text with no enclosing HTML comment, and
+    ``load`` indexes ``[0]`` into the comment list without checking it. The
+    result is a bare ``IndexError`` rather than a message naming the problem.
+
+    Pinned so the lxml port is shown not to change it. No live path reaches this:
+    ``Filing.index_headers`` fetches the real ``-index-headers.html``, which is
+    always comment-wrapped, and no test references this fixture. Improving the
+    error is tracked separately -- doing it here would mean a behaviour change
+    riding along inside a parser port, which is exactly what makes ports hard to
+    review.
+    """
+    with pytest.raises(IndexError):
+        IndexHeaders.load((HEADER_DIR / BARE_SGML).read_text())
+
+
+class TestTheContractsTheParserSwapHadToPreserve:
+    """Edge cases where lxml and BeautifulSoup do NOT agree by default.
+
+    Found by running both parsers side by side over synthetic inputs rather than
+    by reading the migration notes: the epic's gotcha list predicted that an
+    unterminated comment would make lxml see an empty document, and on this file
+    it does the opposite — libxml2 recovers and returns the comment. Predictions
+    about parser behaviour are worth exactly what measuring them costs.
+    """
+
+    def test_empty_input_raises_indexerror_not_parsererror(self):
+        """bs4 returned an empty soup; lxml raises ParserError on empty input.
+
+        Left as IndexError so the swap is not silently also an exception-type
+        change for anyone catching it.
+        """
+        with pytest.raises(IndexError):
+            IndexHeaders.load("")
+
+    def test_whitespace_only_input_raises_indexerror_too(self):
+        with pytest.raises(IndexError):
+            IndexHeaders.load("   \n  ")
+
+    def test_a_comment_before_the_root_element_is_still_found(self):
+        """bs4 searched the whole document; an element-rooted xpath would not.
+
+        Today's SEC files put the comment inside <head>, so this passes either
+        way and would not have caught the mistake — it is here because the fix
+        (walking getroottree()) is invisible and easy to 'simplify' away later.
+        """
+        source = (HEADER_DIR / "23AndMe.index-headers.html").read_text()
+        start, end = source.index("<!--"), source.index("-->") + 3
+        relocated = source[start:end] + "\n<HTML><HEAD><TITLE>t</TITLE></HEAD></HTML>"
+
+        assert IndexHeaders.load(relocated).form == "8-K"
+        # and it parses to the same thing as when the comment sits inside <head>
+        assert (IndexHeaders.load(relocated).model_dump_json()
+                == IndexHeaders.load(source).model_dump_json())


### PR DESCRIPTION
Closes the first port of the **HTML half** of the bs4 → lxml migration (`edgartools-07lk.11.4`), which the parent epic uses to calibrate the remaining files.

## Measured

| | per header |
|---|---|
| before (bs4 `html.parser`) | 459.8 µs |
| after (lxml.html) | 66.2 µs |
| | **~7x** |

Median of 7 runs × 1,200 loads over the four parseable fixtures in `data/headers`, timing the whole `IndexHeaders.load` rather than just the parse step, since that is what a caller actually pays. Confirmed by restoring the bs4 implementation and re-running both sides.

**This is well above the 2–3x the bead projected**, so the remaining HTML-file estimates in `07lk.11` are worth revisiting rather than carrying forward.

## The file was a third of its described size

Of the three bs4 sites, only one is live. I checked callers rather than trusting the description:

- `_extract_documents_from_pre` — reachable only from a **commented-out** line, and its body discards its own result. Dead.
- `_extract_comment_text` — **no callers at all**. Dead.
- `IndexHeaders.load` — the sole live path, reached via `Filing.index_headers`.

Both dead methods existed only to keep `BeautifulSoup`, `Comment` and `Tag` imported, and are deleted.

## What the swap had to preserve

Running both parsers side by side over edge cases turned up three disagreements — **none of them the one the migration notes predict**. They say an unterminated comment makes lxml see an empty document; libxml2 actually recovers and returns it.

| input | bs4 | lxml default |
|---|---|---|
| unterminated `<!--` | `[]` → `IndexError` | recovers, content + trailing markup |
| empty string | `[]` → `IndexError` | **`ParserError`** |
| whitespace only | `[]` → `IndexError` | **`ParserError`** |

`ParserError` is mapped back to `IndexError` so this is not silently also an exception-type change for callers.

Two other deliberate choices:

- **`remove_comments=False`**, the opposite of the house default — here the comment **is** the payload, not noise. Copying `edgar/documents/parser.py`'s call verbatim into this file would delete exactly what it is trying to read.
- The xpath walks **`getroottree()`**, so a comment sitting before `<html>` is still found, as bs4's whole-document search did.

## Evidence

`tests/fixtures/headers/index_headers_baseline.json` is the full pydantic dump of every tracked header fixture, **generated from the BeautifulSoup implementation before any code changed**, then re-run unchanged against lxml. So the parse output is byte-identical, not merely "the assertions still pass" — the existing tests checked a handful of fields on two of five fixtures, which would not catch a stripped space or a dropped tail.

Also pins, as characterization rather than endorsement, that `form4.index-headers.html` raises `IndexError`: it is bare SGML with no comment wrapper, no live path reaches it, and no test referenced it. Fixing the error message inside a parser port is the kind of ride-along change that makes ports hard to review.

## Verification

- Full fast suite green (5563 passed), 17 tests in the new characterization file.
- ruff clean on both changed files, matching the `main` baseline.

## For the epic

Three things worth folding back into `07lk.11` before the next file is ported:

1. The gotcha list's unterminated-comment prediction is **wrong for this file** — the next porter will read that list and trust it.
2. Two of three bs4 sites here were dead code. If sibling beads were scoped the same way, the effort model is inflated for reasons unrelated to lxml.
3. `remove_comments` is a per-file decision, not a house default to copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)