### PR TITLE
refactor(headers): port edgar/headers.py to lxml.html (GH #1101)

### DIFF
--- a/edgar/headers.py
+++ b/edgar/headers.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, List, Optional
 
 import orjson as json
 import pandas as pd
-from bs4 import BeautifulSoup, Comment, Tag
+from lxml import etree
+from lxml import html as lxml_html
 from pydantic import BaseModel
 from rich import box
 from rich.console import Group
@@ -14,6 +15,7 @@ from rich.text import Text
 from edgar._party import Address, get_addresses_as_columns
 from edgar.config import SEC_BASE_URL
 from edgar.display.formatting import display_size
+from edgar.documents.utils.html_utils import remove_xml_declaration
 from edgar.httprequests import download_file
 from edgar.reference import describe_form
 from edgar.richtools import repr_rich
@@ -256,18 +258,45 @@ class IndexHeaders(BaseModel):
         address_dict['state_or_country'] = address_dict.pop('state', '')
         return Address(**address_dict)
 
+    @staticmethod
+    def _extract_sec_header_comment(html_text: str) -> Optional[str]:
+        """
+        Extract the SEC-HEADER payload from the HTML comment that embeds it.
+        Parsed with lxml.html in recover mode, matching the pattern used by
+        edgar.documents for broken SEC HTML (see create_lxml_parser).
+        """
+        # lxml refuses str input carrying an XML encoding declaration
+        # (gotcha 4 in the #931 porting guide); SEC XHTML carries them.
+        html_text = remove_xml_declaration(html_text)
+        parser = lxml_html.HTMLParser(remove_blank_text=False,
+                                      remove_comments=False,
+                                      recover=True)
+        try:
+            tree = lxml_html.fromstring(html_text, parser=parser)
+        except (etree.ParserError, etree.XMLSyntaxError) as exc:
+            # bs4 tolerated empty/whitespace-only input (empty soup, then
+            # IndexError on comment access); keep that contract under lxml,
+            # which raises on an empty or unusable document.
+            raise IndexError('No SEC-HEADER comment found in the provided HTML content.') from exc
+
+        # Comment nodes carry the etree.Comment callable as their .tag,
+        # unlike regular elements whose .tag is a string.
+        for node in tree.iter():
+            if node.tag is etree.Comment:
+                return node.text.strip() if node.text else None
+        return None
+
     @classmethod
     def load(cls, header_text: str):
         """
         Load the IndexHeaders from the HTML file content.
         """
-        soup = BeautifulSoup(header_text, 'html.parser')
+        header_comment = cls._extract_sec_header_comment(header_text)
+        if header_comment is None:
+            # Preserve the current contract: no SEC-HEADER comment -> IndexError.
+            raise IndexError('No SEC-HEADER comment found in the provided HTML content.')
 
-        # The SEC-HEADER tag contains the filing header information
-        header_text = soup.find_all(string=lambda text: isinstance(text, Comment))[0].strip()
-
-
-        lines = header_text.strip().split("\n")
+        lines = header_comment.strip().split("\n")
         data: Dict[str, Any] = {}
         stack = [data]
 
@@ -473,25 +502,10 @@ class IndexHeaders(BaseModel):
         }
 
         # The <PRE> block contains the HTML for the documents
-        #documents = IndexHeaders._extract_documents_from_pre(soup.find("pre"))
+        # (extraction of the document list from the PRE block is not implemented)
 
         # Initialize IndexHeaders with the parsed data
         return cls(**sec_header_data)
-
-    @staticmethod
-    def _extract_documents_from_pre(pre_tag:Tag):
-        soup = BeautifulSoup(pre_tag.text)
-        document_tags = soup.find_all("document")
-        for document_tag in document_tags:
-            document_tag.find("type")
-
-
-    @staticmethod
-    def _extract_comment_text(soup):
-        comments = soup.find_all(string=lambda text: isinstance(text, Comment))
-        if comments:
-            return comments[0].strip()
-        return None
 
     @staticmethod
     def _extract_accession_number(title: str):

--- a/tests/test_headers_characterization.py
+++ b/tests/test_headers_characterization.py
@@ -1,0 +1,193 @@
+"""
+Characterization tests for edgar.headers.IndexHeaders.load().
+
+These pin the exact behaviour of the bs4-based implementation *before* the
+lxml.html port (#1101, part of #931). The SEC-HEADER payload lives inside an
+HTML comment, so the comment-handling semantics are the risk area of the
+port. Each test asserts specific values from real fixtures per the repo's
+verification constitution.
+"""
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from edgar.headers import IndexHeaders
+
+HEADERS_DIR = Path('data/headers')
+
+
+def _load(name):
+    return IndexHeaders.load((HEADERS_DIR / name).read_text())
+
+
+def _flatten(obj, prefix='', out=None):
+    """Flatten a pydantic model into {dotted.path: value} for exact comparison."""
+    if out is None:
+        out = {}
+    if isinstance(obj, BaseModel):
+        for name, value in obj:
+            _flatten(value, f'{prefix}.{name}' if prefix else name, out)
+    elif isinstance(obj, dict):
+        for name, value in obj.items():
+            _flatten(value, f'{prefix}.{name}', out)
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            _flatten(value, f'{prefix}[{i}]', out)
+    else:
+        out[prefix] = obj
+    return out
+
+
+# --- Real fixtures: full structure pinned field-by-field -------------------
+
+@pytest.mark.fast
+def test_8k_header_full_structure():
+    header = _load('23AndMe.index-headers.html')
+    fields = _flatten(header)
+    assert fields == {
+        'acceptance_datetime': datetime(2024, 6, 3, 8, 6, 2),
+        'accession_number': '0001193125-24-152391',
+        'date_of_filing_date_change': '2024-06-03',
+        'effectiveness_date': None,
+        'filer.business_address.city': 'SOUTH SAN FRANCISCO',
+        'filer.business_address.state_or_country': 'CA',
+        'filer.business_address.state_or_country_description': None,
+        'filer.business_address.street1': '349 OYSTER POINT BOULEVARD',
+        'filer.business_address.street2': None,
+        'filer.business_address.zipcode': '94080',
+        'filer.company_data.assigned_sic': '2834',
+        'filer.company_data.cik': '0001804591',
+        'filer.company_data.conformed_name': '23andMe Holding Co.',
+        'filer.company_data.fiscal_year_end': '0331',
+        'filer.company_data.irs_number': '871240344',
+        'filer.company_data.organization_name': '03 Life Sciences',
+        'filer.filing_values.act': '34',
+        'filer.filing_values.file_number': '001-39587',
+        'filer.filing_values.film_number': '241012050',
+        'filer.filing_values.form_type': '8-K',
+        'filer.mail_address.city': 'SOUTH SAN FRANCISCO',
+        'filer.mail_address.state_or_country': 'CA',
+        'filer.mail_address.state_or_country_description': None,
+        'filer.mail_address.street1': '349 OYSTER POINT BOULEVARD',
+        'filer.mail_address.street2': None,
+        'filer.mail_address.zipcode': '94080',
+        'filing_date': '2024-06-03',
+        'form': '8-K',
+        'issuer': None,
+        'items[0]': '7.01',
+        'items[1]': '9.01',
+        'period': '20240603',
+        'public_document_count': 14,
+        'reporting_owner': None,
+        'subject_company': None,
+    }
+
+
+@pytest.mark.fast
+def test_form4_with_reporting_owner_structure():
+    # This fixture is bare SGML (no <HTML> wrapper and no HTML comment), so it
+    # exercises the "comment missing" path of load() today.
+    text = (HEADERS_DIR / 'form4.index-headers.html').read_text()
+    with pytest.raises(IndexError):
+        IndexHeaders.load(text)
+
+
+@pytest.mark.fast
+def test_144_header_full_structure():
+    header = _load('0001971857-23-000246-index-headers.html')
+    fields = _flatten(header)
+    assert fields == {
+        'acceptance_datetime': datetime(2023, 6, 12, 15, 5, 50),
+        'accession_number': '0001971857-23-000246',
+        'date_of_filing_date_change': '2023-06-12',
+        'effectiveness_date': None,
+        'filer': None,
+        'filing_date': '2023-06-12',
+        'form': '144',
+        'issuer': None,
+        'period': None,
+        'public_document_count': 1,
+        'reporting_owner.company_data.assigned_sic': None,
+        'reporting_owner.company_data.cik': '0001701746',
+        'reporting_owner.company_data.conformed_name': 'Hendrian Catherine A',
+        'reporting_owner.company_data.fiscal_year_end': None,
+        'reporting_owner.company_data.irs_number': None,
+        'reporting_owner.company_data.organization_name': None,
+        'reporting_owner.filing_values.act': '',
+        'reporting_owner.filing_values.file_number': '',
+        'reporting_owner.filing_values.film_number': '',
+        'reporting_owner.filing_values.form_type': '144',
+        'reporting_owner.mail_address.city': 'JACKSON',
+        'reporting_owner.mail_address.state_or_country': 'MI',
+        'reporting_owner.mail_address.state_or_country_description': None,
+        'reporting_owner.mail_address.street1': 'ONE ENERGY PLAZA',
+        'reporting_owner.mail_address.street2': None,
+        'reporting_owner.mail_address.zipcode': '49201',
+        'reporting_owner.owner_data': None,
+        'subject_company.business_address.city': 'JACKSON',
+        'subject_company.business_address.state_or_country': 'MI',
+        'subject_company.business_address.state_or_country_description': None,
+        'subject_company.business_address.street1': 'ONE ENERGY PLAZA',
+        'subject_company.business_address.street2': None,
+        'subject_company.business_address.zipcode': '49201',
+        'subject_company.company_data.assigned_sic': '4931',
+        'subject_company.company_data.cik': '0000201533',
+        'subject_company.company_data.conformed_name': 'CONSUMERS ENERGY CO',
+        'subject_company.company_data.fiscal_year_end': '1231',
+        'subject_company.company_data.irs_number': '380442310',
+        'subject_company.company_data.organization_name': None,
+        'subject_company.filing_values.act': '33',
+        'subject_company.filing_values.file_number': '001-05611',
+        'subject_company.filing_values.film_number': '231007818',
+        'subject_company.filing_values.form_type': '144',
+        'subject_company.mail_address.city': 'JACKSON',
+        'subject_company.mail_address.state_or_country': 'MI',
+        'subject_company.mail_address.state_or_country_description': None,
+        'subject_company.mail_address.street1': 'ONE ENERGY PLAZA',
+        'subject_company.mail_address.street2': None,
+        'subject_company.mail_address.zipcode': '49201',
+    }
+    assert fields['subject_company.company_data.conformed_name'] == 'CONSUMERS ENERGY CO'
+    assert header.form == '144'
+
+
+@pytest.mark.fast
+def test_13f_header_parses():
+    header = _load('objectivecapital.form144-index-headers.html')
+    assert header.form == '13F-HR'
+    assert header.filer.company_data.conformed_name == 'Objective Capital Management, LLC'
+
+
+@pytest.mark.fast
+def test_8k_choiceone_items_list():
+    header = _load('index-headers.html')
+    assert header.form == '8-K'
+    assert header.items == ['5.07']
+
+
+# --- Edge cases: current contract is IndexError ----------------------------
+
+@pytest.mark.fast
+def test_empty_input_raises_index_error():
+    with pytest.raises(IndexError):
+        IndexHeaders.load('')
+
+
+@pytest.mark.fast
+def test_whitespace_only_input_raises_index_error():
+    with pytest.raises(IndexError):
+        IndexHeaders.load('   ')
+
+
+@pytest.mark.fast
+def test_html_without_comment_raises_index_error():
+    with pytest.raises(IndexError):
+        IndexHeaders.load('<HTML><HEAD><TITLE>x</TITLE></HEAD><BODY>hi</BODY></HTML>')
+
+
+@pytest.mark.fast
+def test_result_is_pydantic_model():
+    header = _load('23AndMe.index-headers.html')
+    assert isinstance(header, BaseModel)


### PR DESCRIPTION
Closes #1101. Part of the bs4 → lxml migration program (#931).

## What changed

`IndexHeaders.load()` no longer uses BeautifulSoup. The SEC-HEADER payload is extracted from the HTML comment by a new `IndexHeaders._extract_sec_header_comment()` helper built on `lxml.html.HTMLParser(remove_blank_text=False, remove_comments=False, recover=True)`, the same pattern as `edgar/documents/parser.py:create_lxml_parser` per the [porting guide](https://github.com/dgunning/edgartools/issues/931#issuecomment-5387920956).

- `from bs4 import ...` is gone; `edgar/headers.py` now imports only lxml.
- The two dead bs4-typed helpers (`_extract_documents_from_pre`, `_extract_comment_text`) are removed. Neither was referenced except from a commented-out line; keeping either would have kept the bs4 import alive.
- Empty / whitespace-only / comment-less input still raises `IndexError`, matching the behaviour pinned before the port. Under lxml an empty document raises `etree.ParserError`, so that path is mapped explicitly.

## Characterisation first

Per the guide, the pre-port output was pinned before the swap: `tests/test_headers_characterization.py` (commit 48f5b24) holds field-by-field assertions over four real fixtures plus the edge-case contracts:

- 23andMe 8-K (`0001193125-24-152391`) and Consumers Energy 144 (`0001971857-23-000246`) pinned for every leaf including nested `filing_values` on the subject company
- bare-SGML Form 4 fixture exercising the comment-missing path
- empty input, whitespace-only input, and HTML-without-comment all pinned to `IndexError`

All 15 tests (9 characterisation + 6 existing in `test_headers.py`) pass unchanged after the port.

## Measured before/after

Fixture workload: the five real index-header pages in `data/headers/`, best of repeated runs, Python 3.12, Windows.

| scope | bs4 | lxml.html | change |
|---|---|---|---|
| parse + extract step only | 0.109 ms | 0.060 ms | **1.84x** |
| full `IndexHeaders.load()` end-to-end | 0.117 ms | 0.066 ms | **1.78x** |

In line with the guide's ~2-3x projection for the HTML half. Side benefit: the spurious `MarkupResemblesLocatorWarning` bs4 emitted on small headers is gone.

## Guide gotchas encountered

Two of the six bit during the port, both handled: fragment auto-detection raising on empty input where bs4 returned an empty soup (gotcha 5, mapped to the pinned IndexError), and comment nodes' callable `.tag` (gotcha 6, compared directly against `etree.Comment`).

## Verification

- `pytest tests/test_headers_characterization.py tests/test_headers.py`: 15 passed
- `ruff check edgar/headers.py`: clean (ruff 0.12.8 per .pre-commit-config.yaml)
- No new bs4 imports; net one fewer file importing bs4