### PR TITLE
fix(attachments): get_filers() looked up the filer block by id, not class (jrmw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`FilingHomepage.get_filers()` returned an empty list for every filing.** It searched the filer block by `id="filerDiv"`, but SEC emits `class="filerDiv"`, so the selector never matched and the method returned before parsing anything — since 2024-05-28. The filer panel was missing from the homepage display for the same reason. Filer names, CIKs, identification lines and mailing/business addresses now come back, and a Form 4 correctly reports both its issuer and its reporting owner. A filer's name also no longer keeps its role suffix on some forms and not others: SEC writes an ordinary filer's role as plain text but a Form 4's as a link, and only the plain spelling was being stripped.
+
 - **A 10-K item lookup spelled in capitals came back empty.** `tenk["ITEM 7"]` and `get_item_with_part("Part II", "ITEM 7")` returned `None` while `"Item 7"` and `"item 7"` returned the section, because `TenK` matched the spelling case-sensitively in two places — deriving the item number, and mapping it to a friendly section name. The legacy parser underneath had been absorbing this, so removing it (below) made the gap visible. `TenQ`, `TwentyF` and `EightK` were already case-insensitive here. (GH #454)
 
 - **A line break the filer wrote was dropped, gluing the words either side.** A `<br>` between two inline elements — the shape of every 6-K and 8-K cover page — was pruned as an empty node, so `UNITED STATES<br/>SECURITIES AND EXCHANGE COMMISSION` came back as `UNITED STATESSECURITIES AND EXCHANGE COMMISSION`. `<br>` between bare text was never affected. Exelon's 8-K of 2005-04-27 regains two line breaks; its text is otherwise unchanged, at the same 2,629 characters.

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -239,6 +239,18 @@ def get_file_icon(file_type: str, sequence: Optional[str] = None, filename: Opti
     return icon
 
 
+# The role SEC appends to a filer's name on the filing index page. It renders
+# plain for an ordinary filer -- "Apple Inc. (Filer)" -- but as a LINK for the
+# roles a Form 4 carries: "UFP TECHNOLOGIES INC (<a ...>Issuer</a>)". Both come
+# out of .text the same way, so the old `.replace("(Filer)", "")` stripped one
+# and left the others, and company_name was inconsistent depending on form type.
+# Anchored to the end and limited to known roles so a company whose real name
+# contains parentheses keeps them.
+_FILER_ROLE_SUFFIX = re.compile(
+    r"\s*\((?:Filer|Issuer|Reporting|Subject|Filed by)\)\s*$", re.IGNORECASE
+)
+
+
 class FilerInfo(BaseModel):
     company_name: str
     cik:str
@@ -1118,7 +1130,7 @@ class FilingHomepage:
     def get_filers(self):
         if hasattr(self, '_cached_filers'):
             return self._cached_filers
-        filer_divs = self._soup.find_all("div", id="filerDiv")
+        filer_divs = self._soup.find_all("div", class_="filerDiv")
         filer_infos = []
         for filer_div in filer_divs:
 
@@ -1135,7 +1147,7 @@ class FilingHomepage:
                 cik = parts[1].split()[0] if len(parts) > 1 else ""
 
                 # Clean up the company name
-                company_name = re.sub("\n", "", company_name).replace("(Filer)", "").strip()
+                company_name = _FILER_ROLE_SUFFIX.sub("", re.sub("\n", "", company_name)).strip()
             else:
                 company_name = ""
                 cik = ""

--- a/tests/fixtures/homepages/aapl-10k-2024.html
+++ b/tests/fixtures/homepages/aapl-10k-2024.html
@@ -1,0 +1,317 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 01 Nov 2024 10:01:36 GMT" />
+<title>EDGAR Filing Documents for 0000320193-24-000123</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 10-K</strong> - Annual report [Section 13 and 15(d), not S-K Item 405]: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0000320193-24-000123
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2024-11-01</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2024-11-01 06:01:36</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">103</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2024-09-28</div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+   <div style="padding: 4px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden" id="seriesDiv">
+      <a href="/cgi-bin/viewer?action=view&amp;cik=320193&amp;accession_number=0000320193-24-000123&amp;xbrl_type=v" id="interactiveDataBtn">&nbsp;<button type="button" class="btn btn-primary">Interactive Data</button></a>
+   </div>
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">10-K</td>
+            <td scope="row"><a href="/ix?doc=/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm">aapl-20240928.htm</a> &nbsp;&nbsp;<span style="color: green">iXBRL</span></td>
+            <td scope="row">10-K</td>
+            <td scope="row">1503780</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row">EX-4.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit4109282024.htm">a10-kexhibit4109282024.htm</a></td>
+            <td scope="row">EX-4.1</td>
+            <td scope="row">120785</td>
+         </tr>
+         <tr>
+            <td scope="row">3</td>
+            <td scope="row">EX-10.19</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10199282024.htm">a10-kexhibit10199282024.htm</a></td>
+            <td scope="row">EX-10.19</td>
+            <td scope="row">56948</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">4</td>
+            <td scope="row">EX-10.20</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10209282024.htm">a10-kexhibit10209282024.htm</a></td>
+            <td scope="row">EX-10.20</td>
+            <td scope="row">74591</td>
+         </tr>
+         <tr>
+            <td scope="row">5</td>
+            <td scope="row">EX-10.21</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10219282024.htm">a10-kexhibit10219282024.htm</a></td>
+            <td scope="row">EX-10.21</td>
+            <td scope="row">60845</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">6</td>
+            <td scope="row">EX-10.22</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10229282024.htm">a10-kexhibit10229282024.htm</a></td>
+            <td scope="row">EX-10.22</td>
+            <td scope="row">75240</td>
+         </tr>
+         <tr>
+            <td scope="row">7</td>
+            <td scope="row">EX-19.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit1919282024.htm">a10-kexhibit1919282024.htm</a></td>
+            <td scope="row">EX-19.1</td>
+            <td scope="row">44108</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">8</td>
+            <td scope="row">EX-21.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit21109282024.htm">a10-kexhibit21109282024.htm</a></td>
+            <td scope="row">EX-21.1</td>
+            <td scope="row">11229</td>
+         </tr>
+         <tr>
+            <td scope="row">9</td>
+            <td scope="row">EX-23.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit23109282024.htm">a10-kexhibit23109282024.htm</a></td>
+            <td scope="row">EX-23.1</td>
+            <td scope="row">5018</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">10</td>
+            <td scope="row">EX-31.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit31109282024.htm">a10-kexhibit31109282024.htm</a></td>
+            <td scope="row">EX-31.1</td>
+            <td scope="row">10508</td>
+         </tr>
+         <tr>
+            <td scope="row">11</td>
+            <td scope="row">EX-31.2</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit31209282024.htm">a10-kexhibit31209282024.htm</a></td>
+            <td scope="row">EX-31.2</td>
+            <td scope="row">10544</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">12</td>
+            <td scope="row">EX-32.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit32109282024.htm">a10-kexhibit32109282024.htm</a></td>
+            <td scope="row">EX-32.1</td>
+            <td scope="row">8357</td>
+         </tr>
+         <tr>
+            <td scope="row">13</td>
+            <td scope="row">EX-97.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/a10-kexhibit97109282024.htm">a10-kexhibit97109282024.htm</a></td>
+            <td scope="row">EX-97.1</td>
+            <td scope="row">13555</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">19</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_g1.jpg">aapl-20240928_g1.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">10963</td>
+         </tr>
+         <tr>
+            <td scope="row">20</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_g2.jpg">aapl-20240928_g2.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">154498</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">21</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/image_0.jpg">image_0.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">2374</td>
+         </tr>
+         <tr>
+            <td scope="row">22</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/image_01.jpg">image_01.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">2563</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/0000320193-24-000123.txt">0000320193-24-000123.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">9759333</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Data Files</p>
+      <table class="tableFile" summary="Data Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">14</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION SCHEMA DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928.xsd">aapl-20240928.xsd</a></td>
+            <td scope="row">EX-101.SCH</td>
+            <td scope="row">58200</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">15</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION CALCULATION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_cal.xml">aapl-20240928_cal.xml</a></td>
+            <td scope="row">EX-101.CAL</td>
+            <td scope="row">150261</td>
+         </tr>
+         <tr>
+            <td scope="row">16</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION DEFINITION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_def.xml">aapl-20240928_def.xml</a></td>
+            <td scope="row">EX-101.DEF</td>
+            <td scope="row">232678</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">17</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION LABEL LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_lab.xml">aapl-20240928_lab.xml</a></td>
+            <td scope="row">EX-101.LAB</td>
+            <td scope="row">779708</td>
+         </tr>
+         <tr>
+            <td scope="row">18</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION PRESENTATION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_pre.xml">aapl-20240928_pre.xml</a></td>
+            <td scope="row">EX-101.PRE</td>
+            <td scope="row">509625</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">106</td>
+            <td scope="row"><b>EXTRACTED</b> XBRL INSTANCE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019324000123/aapl-20240928_htm.xml">aapl-20240928_htm.xml</a></td>
+            <td scope="row">XML</td>
+            <td scope="row">1355849</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">ONE APPLE PARK WAY</span>
+      <span class="mailerAddress">
+CUPERTINO       <span class="mailerAddress">CA</span>
+95014      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">ONE APPLE PARK WAY</span>
+      <span class="mailerAddress">
+CUPERTINO       <span class="mailerAddress">CA</span>
+95014      </span>
+      <span class="mailerAddress">(408) 996-1010</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">Apple Inc. (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0000320193&amp;action=getcompany">0000320193 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>942404110</strong> | State of Incorp.: <strong>CA</strong> | Fiscal Year End: <strong>0928</strong><br />Type: <strong>10-K</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=001-36743&amp;action=getcompany"><strong>001-36743</strong></a> | Film No.: <strong>241416806</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=3571&amp;owner=include">3571</a></b> Electronic Computers<br />(CF Office: 06 Technology)</p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/fixtures/homepages/eightk-2005.html
+++ b/tests/fixtures/homepages/eightk-2005.html
@@ -1,0 +1,159 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 18 Mar 2005 15:07:40 GMT" />
+<title>EDGAR Filing Documents for 0001047469-05-006981</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 8-K</strong> - Current report: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0001047469-05-006981
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2005-03-18</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2005-03-18 10:07:40</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">2</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2005-03-17</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Items</div>
+         <div class="info">Item 8.01: Other Events<br />Item 9.01: Financial Statements and Exhibits<br /></div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">8-K</td>
+            <td scope="row"><a href="/Archives/edgar/data/1168054/000104746905006981/a2153970z8-k.htm">a2153970z8-k.htm</a></td>
+            <td scope="row">8-K</td>
+            <td scope="row">11946</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row">EX 99.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/1168054/000104746905006981/a2153970zex-99_1.htm">a2153970zex-99_1.htm</a></td>
+            <td scope="row">EX-99.1</td>
+            <td scope="row">7295</td>
+         </tr>
+         <tr>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/1168054/000104746905006981/0001047469-05-006981.txt">0001047469-05-006981.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">21100</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">1700 LINCOLN STREET</span>
+      <span class="mailerAddress">SUITE 1800</span>
+      <span class="mailerAddress">
+DENVER       <span class="mailerAddress">CO</span>
+80203-4518      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">1700 LINCOLN STREET</span>
+      <span class="mailerAddress">SUITE 1800</span>
+      <span class="mailerAddress">
+DENVER       <span class="mailerAddress">CO</span>
+80203-4518      </span>
+      <span class="mailerAddress">303-295-3995</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">CIMAREX ENERGY CO (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0001168054&amp;action=getcompany">0001168054 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>450466694</strong> | State of Incorp.: <strong>DE</strong> | Fiscal Year End: <strong>1231</strong><br />Type: <strong>8-K</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=001-31446&amp;action=getcompany"><strong>001-31446</strong></a> | Film No.: <strong>05690525</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=1311&amp;owner=include">1311</a></b> Crude Petroleum &amp; Natural Gas</p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/fixtures/homepages/form4-reporting-owner.html
+++ b/tests/fixtures/homepages/form4-reporting-owner.html
@@ -1,0 +1,169 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 07 Jun 2024 22:10:30 GMT" />
+<title>EDGAR Filing Documents for 0001062993-24-012217</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 4</strong> - Statement of changes in beneficial ownership of securities: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0001062993-24-012217
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2024-06-07</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2024-06-07 18:10:30</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">1</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2024-06-05</div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES</td>
+            <td scope="row"><a href="/Archives/edgar/data/914156/000106299324012217/xslF345X05/form4.xml">form4.html</a></td>
+            <td scope="row">4</td>
+            <td scope="row">&nbsp;</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">1</td>
+            <td scope="row">STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES</td>
+            <td scope="row"><a href="/Archives/edgar/data/914156/000106299324012217/form4.xml">form4.xml</a></td>
+            <td scope="row">4</td>
+            <td scope="row">5393</td>
+         </tr>
+         <tr>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/914156/000106299324012217/0001062993-24-012217.txt">0001062993-24-012217.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">6848</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">100 HALE STREET</span>
+      <span class="mailerAddress">
+NEWBURYPORT       <span class="mailerAddress">MA</span>
+01950      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">100 HALE STREET</span>
+      <span class="mailerAddress">
+NEWBURYPORT       <span class="mailerAddress">MA</span>
+01950      </span>
+      <span class="mailerAddress">978-352-2200</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">UFP TECHNOLOGIES INC (<a href="/cgi-bin/own-disp?CIK=0000914156&amp;action=getissuer">Issuer</a>)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0000914156&amp;action=getcompany">0000914156 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>042314970</strong> | State of Incorp.: <strong>DE</strong> | Fiscal Year End: <strong>1231</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=3841&amp;owner=include">3841</a></b> Surgical &amp; Medical Instruments &amp; Apparatus<br />(CF Office: 08 Industrial Applications and Services)</p>
+</div>
+<div class="clear"></div>
+</div>
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">ONE TECHNOLOGY WAY</span>
+      <span class="mailerAddress">
+NORWOOD       <span class="mailerAddress">MA</span>
+02062      </span>
+   </div>
+   <div class="mailer">Business Address
+   </div>
+<div class="companyInfo">
+  <span class="companyName">Hassett Joseph (<a href="/cgi-bin/own-disp?CIK=0001641388&amp;action=getowner">Reporting</a>)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0001641388&amp;action=getcompany">0001641388 (see all company filings)</a></span>
+<p class="identInfo">Type: <strong>4</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=001-12648&amp;action=getcompany"><strong>001-12648</strong></a> | Film No.: <strong>241030989</strong></p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/fixtures/homepages/s4-multifiler.html
+++ b/tests/fixtures/homepages/s4-multifiler.html
@@ -1,0 +1,354 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 28 Jun 2024 21:29:32 GMT" />
+<title>EDGAR Filing Documents for 0001213900-24-057319</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form S-4</strong> - Registration of securities, business combinations: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0001213900-24-057319
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2024-06-28</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2024-06-28 17:29:32</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">31</div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">REGISTRATION STATEMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea0201675-04.htm">ea0201675-04.htm</a></td>
+            <td scope="row">S-4</td>
+            <td scope="row">13643022</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row">CERTIFICATE OF INCORPORATION OF PURCHASER</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex3-3_acricap1.htm">ea020167504ex3-3_acricap1.htm</a></td>
+            <td scope="row">EX-3.3</td>
+            <td scope="row">5161</td>
+         </tr>
+         <tr>
+            <td scope="row">3</td>
+            <td scope="row">CONSENT OF MARCUM LLP, INDEPENDENT REGISTERED PUBLIC ACCOUNTING FIRM TO ACAC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex23-1_acricap1.htm">ea020167504ex23-1_acricap1.htm</a></td>
+            <td scope="row">EX-23.1</td>
+            <td scope="row">2220</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">4</td>
+            <td scope="row">CONSENT OF MARCUM LLP, INDEPENDENT REGISTERED PUBLIC ACCOUNTING FIRM TO FOXX</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex23-2_acricap1.htm">ea020167504ex23-2_acricap1.htm</a></td>
+            <td scope="row">EX-23.2</td>
+            <td scope="row">2549</td>
+         </tr>
+         <tr>
+            <td scope="row">5</td>
+            <td scope="row">CONSENT OF &quot;EVA&quot; YIQING MIAO (PUBCO&#39;S DIRECTOR NOMINEE)</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-1_acricap1.htm">ea020167504ex99-1_acricap1.htm</a></td>
+            <td scope="row">EX-99.1</td>
+            <td scope="row">2780</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">6</td>
+            <td scope="row">CONSENT OF EDMUND R. MILLER (PUBCO&#39;S DIRECTOR NOMINEE)</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-2_acricap1.htm">ea020167504ex99-2_acricap1.htm</a></td>
+            <td scope="row">EX-99.2</td>
+            <td scope="row">3007</td>
+         </tr>
+         <tr>
+            <td scope="row">7</td>
+            <td scope="row">CONSENT OF &quot;JEFF&quot; FENG JIANG (PUBCO&#39;S DIRECTOR NOMINEE)</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-3_acricap1.htm">ea020167504ex99-3_acricap1.htm</a></td>
+            <td scope="row">EX-99.3</td>
+            <td scope="row">2722</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">8</td>
+            <td scope="row">FILING FEE TABLE</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/ea020167504ex-fee_acricap1.htm">ea020167504ex-fee_acricap1.htm</a></td>
+            <td scope="row">EX-FILING FEES</td>
+            <td scope="row">102217</td>
+         </tr>
+         <tr>
+            <td scope="row">9</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/tflowchart_001.jpg">tflowchart_001.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">157679</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">10</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/tflowchart_002.jpg">tflowchart_002.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">93770</td>
+         </tr>
+         <tr>
+            <td scope="row">11</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_002.jpg">timage_002.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">518944</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">12</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_005.jpg">timage_005.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">246454</td>
+         </tr>
+         <tr>
+            <td scope="row">13</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_006.jpg">timage_006.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">184355</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">14</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_007.jpg">timage_007.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">172516</td>
+         </tr>
+         <tr>
+            <td scope="row">15</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_008.jpg">timage_008.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">188564</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">16</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_009.jpg">timage_009.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">413510</td>
+         </tr>
+         <tr>
+            <td scope="row">17</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_010.jpg">timage_010.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">468782</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">18</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_011.jpg">timage_011.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">190721</td>
+         </tr>
+         <tr>
+            <td scope="row">19</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_012.jpg">timage_012.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">363740</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">20</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_013.jpg">timage_013.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">534592</td>
+         </tr>
+         <tr>
+            <td scope="row">21</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_014.jpg">timage_014.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">485930</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">22</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_016.jpg">timage_016.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">501361</td>
+         </tr>
+         <tr>
+            <td scope="row">23</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_022.jpg">timage_022.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">408932</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">24</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_017.jpg">timage_017.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">215306</td>
+         </tr>
+         <tr>
+            <td scope="row">25</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_023.jpg">timage_023.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">128721</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">26</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_024.jpg">timage_024.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">242800</td>
+         </tr>
+         <tr>
+            <td scope="row">27</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_020.jpg">timage_020.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">435269</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">28</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/timage_021.jpg">timage_021.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">532161</td>
+         </tr>
+         <tr>
+            <td scope="row">29</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/tfoxxd_text.jpg">tfoxxd_text.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">11636</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">30</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/tfoxxd_logo.jpg">tfoxxd_logo.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">13151</td>
+         </tr>
+         <tr>
+            <td scope="row">31</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/tmiro_text.jpg">tmiro_text.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">13322</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/2013807/000121390024057319/0001213900-24-057319.txt">0001213900-24-057319.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">22751245</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">13284 POND SPRINGS RD</span>
+      <span class="mailerAddress">STE 405</span>
+      <span class="mailerAddress">
+AUSTIN       <span class="mailerAddress">TX</span>
+78729      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">13284 POND SPRINGS RD</span>
+      <span class="mailerAddress">STE 405</span>
+      <span class="mailerAddress">
+AUSTIN       <span class="mailerAddress">TX</span>
+78729      </span>
+      <span class="mailerAddress">512-666-1277</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">Acri Capital Merger Sub I Inc. (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0002013807&amp;action=getcompany">0002013807 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>000000000</strong> | State of Incorp.: <strong>DE</strong> | Fiscal Year End: <strong>1231</strong><br />Type: <strong>S-4</strong> | Act: <strong>33</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=333-280613&amp;action=getcompany"><strong>333-280613</strong></a> | Film No.: <strong>241087082</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=3576&amp;owner=include">3576</a></b> Computer Communications Equipment<br />(CF Office: 06 Technology)</p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/fixtures/homepages/thirteenf-2023.html
+++ b/tests/fixtures/homepages/thirteenf-2023.html
@@ -1,0 +1,169 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Tue, 14 Nov 2023 14:38:54 GMT" />
+<title>EDGAR Filing Documents for 0001894188-23-000007</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 13F-HR</strong> - Quarterly report filed by institutional managers, Holdings: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0001894188-23-000007
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2023-11-14</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2023-11-14 09:38:54</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">2</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2023-09-30</div>
+         <div class="infoHead">Effectiveness Date</div>
+         <div class="info">2023-11-14</div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/1894188/000189418823000007/xslForm13F_X02/primary_doc.xml">primary_doc.html</a></td>
+            <td scope="row">13F-HR</td>
+            <td scope="row">&nbsp;</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">1</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/1894188/000189418823000007/primary_doc.xml">primary_doc.xml</a></td>
+            <td scope="row">13F-HR</td>
+            <td scope="row">2028</td>
+         </tr>
+         <tr>
+            <td scope="row">2</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/1894188/000189418823000007/xslForm13F_X02/index.xml">index.html</a></td>
+            <td scope="row">INFORMATION TABLE</td>
+            <td scope="row">&nbsp;</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/1894188/000189418823000007/index.xml">index.xml</a></td>
+            <td scope="row">INFORMATION TABLE</td>
+            <td scope="row">7578</td>
+         </tr>
+         <tr>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/1894188/000189418823000007/0001894188-23-000007.txt">0001894188-23-000007.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">10769</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">650 MADISON AVENUE, 15TH FLOOR</span>
+      <span class="mailerAddress">
+NEW YORK       <span class="mailerAddress">NY</span>
+10022      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">650 MADISON AVENUE, 15TH FLOOR</span>
+      <span class="mailerAddress">
+NEW YORK       <span class="mailerAddress">NY</span>
+10022      </span>
+      <span class="mailerAddress">646-860-0181</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">LTS One Management LP (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0001894188&amp;action=getcompany">0001894188 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>871396377</strong> | State of Incorp.: <strong>DE</strong> | Fiscal Year End: <strong>1231</strong><br />Type: <strong>13F-HR</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=028-22111&amp;action=getcompany"><strong>028-22111</strong></a> | Film No.: <strong>231402140</strong></p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/issues/regression/test_jrmw_filing_homepage_filers.py
+++ b/tests/issues/regression/test_jrmw_filing_homepage_filers.py
@@ -1,0 +1,153 @@
+"""FilingHomepage.get_filers() actually returns filers (edgartools-jrmw).
+
+It returned ``[]`` for every filing from 2024-05-28 until this fix.
+``attachments.py`` searched ``find_all("div", id="filerDiv")`` while SEC emits
+``<div class="filerDiv">`` -- id versus class -- so the selector matched nothing
+and the method returned before reaching any of its body. ``git log -S`` shows
+the line was wrong when it was introduced, so this is not SEC markup drift.
+
+WHY THIS MATTERED MORE THAN AN EMPTY LIST. Roughly 35 lines sit below that
+selector -- the companyName parse, the CIK split, the identInfo <br>-to-newline
+replacement, the mailer address cleanup -- and none of them had ever executed on
+real input. ``FilingHomepage.__rich__`` also renders the filer panel from this
+list, so the homepage display was silently missing it.
+
+The bug was found while building fixtures for the bs4->lxml port of this file
+(edgartools-07lk.11.5). Porting first would have been worse than useless: a
+characterization baseline taken then would have recorded ``[]`` as correct and
+pinned the bug, and the never-executed block would have been translated with no
+working output to check the translation against.
+
+ASSERTIONS ARE GROUND TRUTH, not shape checks. Each value below was read off the
+filing's own index page. A test that only asserted ``len(filers) > 0`` would
+pass on a selector that matched the wrong div.
+"""
+import pathlib
+
+import pytest
+from bs4 import BeautifulSoup
+
+from edgar.attachments import Attachments, FilingHomepage
+
+pytestmark = pytest.mark.fast
+
+FIXTURES = pathlib.Path(__file__).parent.parent.parent / "fixtures" / "homepages"
+
+
+def _homepage(stem: str) -> FilingHomepage:
+    path = FIXTURES / f"{stem}.html"
+    assert path.exists(), f"missing fixture {path}"
+    soup = BeautifulSoup(path.read_text(), "html.parser")
+    return FilingHomepage(f"file://{path}", soup, Attachments.load(soup))
+
+
+def test_the_fixture_corpus_is_present():
+    """These are the only coverage this code path has; a glob miss must be loud."""
+    assert len({p.stem for p in FIXTURES.glob("*.html")}) >= 5
+
+
+@pytest.mark.parametrize("stem", [
+    "aapl-10k-2024", "eightk-2005", "form4-reporting-owner",
+    "s4-multifiler", "thirteenf-2023",
+])
+def test_every_filing_reports_at_least_one_filer(stem):
+    """The bug, stated directly: this was [] on all five."""
+    assert _homepage(stem).get_filers()
+
+
+def test_an_ordinary_filing_reports_its_filer():
+    filer, = _homepage("aapl-10k-2024").get_filers()
+
+    assert filer.company_name == "Apple Inc."
+    assert filer.cik == "0000320193"
+    assert "EIN.: 942404110" in filer.identification
+    assert "State of Incorp.: CA" in filer.identification
+
+
+def test_identification_keeps_the_line_breaks_the_filer_wrote():
+    """The <br>-to-newline replacement, which had never run on real input.
+
+    Asserted as separate lines rather than as a substring of the whole blob: the
+    failure mode of a bad <br> translation is not missing text, it is text glued
+    together across the break -- the word-boundary family that has bitten this
+    codebase repeatedly. A substring check on 'Type: 10-K' passes either way.
+    """
+    filer, = _homepage("aapl-10k-2024").get_filers()
+    lines = filer.identification.split("\n")
+
+    assert len(lines) >= 3, filer.identification
+    assert lines[0].startswith("EIN.:")
+    assert any(line.startswith("Type: 10-K") for line in lines), lines
+    assert any(line.startswith("SIC: 3571") for line in lines), lines
+    # Nothing glued: no line should carry two fields that belong on separate ones.
+    assert not any("Fiscal Year End" in line and "Type:" in line for line in lines)
+
+
+def test_a_form4_reports_both_the_issuer_and_the_reporting_owner():
+    """Two filerDivs, and the reason the count matters."""
+    filers = _homepage("form4-reporting-owner").get_filers()
+
+    assert len(filers) == 2
+    issuer, owner = filers
+    assert issuer.company_name == "UFP TECHNOLOGIES INC"
+    assert issuer.cik == "0000914156"
+    assert owner.company_name == "Hassett Joseph"
+    assert owner.cik == "0001641388"
+
+
+def test_the_role_suffix_is_stripped_whether_sec_links_it_or_not():
+    """The half-fix that was already in the code.
+
+    SEC renders an ordinary filer's role as plain text -- "Apple Inc. (Filer)" --
+    but a Form 4's roles as links: "UFP TECHNOLOGIES INC (<a>Issuer</a>)". Both
+    reach .text identically, so the old ``.replace("(Filer)", "")`` stripped one
+    spelling and left the others, making company_name inconsistent by form type.
+    Fixed here rather than later because this method has never returned data, so
+    there is no caller yet to break -- once one exists, the wart is permanent.
+    """
+    names = [f.company_name for stem in
+             ("aapl-10k-2024", "eightk-2005", "form4-reporting-owner",
+              "s4-multifiler", "thirteenf-2023")
+             for f in _homepage(stem).get_filers()]
+
+    assert names, "no filers parsed at all"
+    for name in names:
+        assert not name.endswith(")"), f"{name!r} kept its role suffix"
+
+
+def test_a_company_name_containing_parentheses_would_survive():
+    """The risk the role-stripping regex takes on.
+
+    Anchored to the end AND limited to known role words, so a real name like
+    'Acme (Holdings) Inc.' is untouched. Guarded directly because no fixture
+    happens to have such a name, and a looser regex would pass every other test
+    in this file.
+    """
+    from edgar.attachments import _FILER_ROLE_SUFFIX
+
+    assert _FILER_ROLE_SUFFIX.sub("", "Acme (Holdings) Inc.") == "Acme (Holdings) Inc."
+    assert _FILER_ROLE_SUFFIX.sub("", "Acme Inc. (Filer)") == "Acme Inc."
+    assert _FILER_ROLE_SUFFIX.sub("", "Acme (Holdings) Inc. (Issuer)") == "Acme (Holdings) Inc."
+
+
+def test_addresses_are_parsed_and_indented_continuations_collapsed():
+    filer, = _homepage("thirteenf-2023").get_filers()
+
+    assert len(filer.addresses) == 2
+    mailing, business = filer.addresses
+    assert mailing.startswith("Mailing Address")
+    assert business.startswith("Business Address")
+    assert "650 MADISON AVENUE, 15TH FLOOR" in mailing
+    # The re.sub(r'\n\s+', '\n', ...) cleanup: no line starts with whitespace.
+    assert not any(line[:1].isspace() for line in mailing.split("\n") if line)
+
+
+def test_the_homepage_renders_with_real_filer_data():
+    """__rich__ builds the filer panel from get_filers() and indexes
+    ``addresses[1]``. That index never ran before this fix, so rendering is
+    exercised here rather than assumed."""
+    from rich.console import Console
+
+    console = Console(file=open(pathlib.os.devnull, "w"), width=200)
+    for stem in ("aapl-10k-2024", "form4-reporting-owner", "thirteenf-2023"):
+        console.print(_homepage(stem))

--- a/tests/issues/regression/test_jrmw_filing_homepage_filers.py
+++ b/tests/issues/regression/test_jrmw_filing_homepage_filers.py
@@ -146,8 +146,12 @@ def test_the_homepage_renders_with_real_filer_data():
     """__rich__ builds the filer panel from get_filers() and indexes
     ``addresses[1]``. That index never ran before this fix, so rendering is
     exercised here rather than assumed."""
+    import io
+
     from rich.console import Console
 
-    console = Console(file=open(pathlib.os.devnull, "w"), width=200)
+    # StringIO rather than os.devnull: nothing to close, and `pathlib.os` is an
+    # import artifact that 3.13's pathlib package no longer exposes.
+    console = Console(file=io.StringIO(), width=200)
     for stem in ("aapl-10k-2024", "form4-reporting-owner", "thirteenf-2023"):
         console.print(_homepage(stem))


### PR DESCRIPTION
`FilingHomepage.get_filers()` has returned `[]` for **every filing since 2024-05-28**.

```python
filer_divs = self._soup.find_all("div", id="filerDiv")
```

SEC emits `<div class="filerDiv">`. `git log -S` shows the line was wrong on the commit that introduced it, so this is not SEC markup drift.

## Measured

Over the five real filing homepages added here as fixtures:

| fixture | `id="filerDiv"` | `class="filerDiv"` | `get_filers()` before | after |
|---|---|---|---|---|
| `aapl-10k-2024` | 0 | 1 | `[]` | Apple Inc., CIK 0000320193 |
| `eightk-2005` | 0 | 1 | `[]` | Cimarex Energy Co |
| `form4-reporting-owner` | 0 | **2** | `[]` | **UFP Technologies (issuer) + Hassett Joseph (owner)** |
| `s4-multifiler` | 0 | 1 | `[]` | Acri Capital Merger Sub I |
| `thirteenf-2023` | 0 | 1 | `[]` | LTS One Management LP |

## The empty list was the smaller half

Roughly **35 lines sit below that selector** — the companyName parse, the CIK split, the identInfo `<br>`→newline replacement, the mailer address cleanup — and none had ever executed on real input, so none were *known* to work. They do, and the fixtures now pin what they produce.

`FilingHomepage.__rich__` builds its filer panel from this list and indexes `addresses[1]` unguarded. That index had never run either, so rendering is exercised on real data rather than assumed — SEC emits both a mailing and a business block, and all five render.

Users were affected twice: `get_filers()` silently returned `[]` rather than failing (the silence failure the verification constitution calls out — a caller cannot distinguish "no filers" from "the parser is broken"), and the homepage display has been missing its filer panel for ~15 months.

## Also fixed, deliberately and now rather than later

`company_name` kept its role suffix on some forms and not others. SEC writes an ordinary filer's role as plain text — `Apple Inc. (Filer)` — but a Form 4's roles as **links**: `UFP TECHNOLOGIES INC (<a>Issuer</a>)`. Both reach `.text` identically, so the existing `.replace("(Filer)", "")` stripped one spelling and left the rest.

Completing that line's evident intent rather than leaving it, because **this method has never returned data**: there is no caller to break today, and once there is one the inconsistency is permanent. The replacement regex is anchored to the end and limited to known role words so a company whose real name contains parentheses keeps them — guarded by its own test, since no fixture has such a name.

## Verification

13 tests, **ground-truth values read off each filing's index page**, not shape checks — a `len(filers) > 0` test would pass on a selector matching the wrong div. Verified by reverting the selector: **10 of the 13 go red**.

The identification test asserts separate *lines* rather than a substring, because the failure mode of a bad `<br>` translation is text glued across the break, not text going missing — a substring check on `Type: 10-K` passes either way.

- Full fast suite green (5596 passed).
- ruff identical to the `main` baseline (same four pre-existing findings, line numbers shifted).
- Fixture corpus is 60KB total.

## Why this came first

Found while building characterization fixtures for the bs4 → lxml port of this file (`edgartools-07lk.11.5`), which I marked **blocked** on it. Porting first would have been actively harmful: the baseline would have captured `[]` as correct and **pinned the bug as intended behaviour**, and 35 never-executed lines would have been translated to lxml with no working output to check the translation against. That `<br>`→newline block is the riskiest thing in the file to port, and it was the part with zero real coverage.

The fixtures serve both tasks, so `07lk.11.5` is unblocked once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)