### PR TITLE
perf(attachments): parse the filing homepage with lxml instead of BeautifulSoup (07lk.11.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Filing homepage parsing is about 9x faster.** The filing index page — the source of `filing.attachments`, `filing.homepage.get_filers()` and the filing dates — was parsed with BeautifulSoup's pure-Python `html.parser`; it now uses lxml, measured at 15.8ms to 1.8ms across the five tracked homepage fixtures. Output is unchanged: the whole parse of every fixture, down to each attachment's size and each filer's identification lines, is pinned against a baseline captured from the previous implementation. A blank or truncated index page still yields a homepage with nothing on it rather than raising.
+
+  `FilingHomepage(...)` and `Attachments.load(...)` take an lxml tree now, from the new `edgar.attachments.parse_homepage_html(html)`. Both still accept a BeautifulSoup, and `FilingHomepage(soup=...)` still works, with a `DeprecationWarning`; both go in 6.0. Neither is on the path you take through `filing.homepage`.
+
 - **Filing header parsing is about 7x faster.** `Filing.index_headers` parsed the header page with BeautifulSoup's pure-Python `html.parser`; it now uses lxml, measured at 460µs to 66µs per header across the tracked header corpus. Output is unchanged — the full parsed model is pinned against a baseline captured from the previous implementation. Malformed input behaves as before, including the `IndexError` an empty page has always raised.
 
 - **`PressRelease.text()` now reads through the modern parser.** Output changes slightly, all of it in your favour: the old path leaked raw `<img>` markup into the text and left `&amp;` undecoded as a literal "amp", both of which are gone. Across 12 real 8-K press releases no word is lost that is not one of those artifacts. Table cells no longer repeat the `$` that filers put in their own column; the figures and the header's units are unchanged.

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -20,7 +20,8 @@ if TYPE_CHECKING:
 
 import textwrap
 
-from bs4 import BeautifulSoup
+import lxml.html
+from lxml.etree import ParserError
 from pydantic import BaseModel
 from rich import box
 from rich.columns import Columns
@@ -30,6 +31,7 @@ from rich.table import Column, Table
 from rich.text import Text
 
 from edgar.config import SEC_BASE_URL
+from edgar.documents.utils.html_utils import create_lxml_parser
 from edgar.exceptions import AttachmentNotFoundError
 from edgar.core import binary_extensions, has_html_content, text_extensions
 from edgar.files._deprecation import PAGE_BREAK_DEPRECATION
@@ -249,6 +251,83 @@ def get_file_icon(file_type: str, sequence: Optional[str] = None, filename: Opti
 _FILER_ROLE_SUFFIX = re.compile(
     r"\s*\((?:Filer|Issuer|Reporting|Subject|Filed by)\)\s*$", re.IGNORECASE
 )
+
+
+def parse_homepage_html(html: Union[str, bytes]) -> lxml.html.HtmlElement:
+    """Parse a filing index page into an lxml tree.
+
+    Bytes rather than str is the safe input: ``lxml.html.fromstring`` raises
+    ValueError on a str that opens with an encoding declaration, which SEC
+    markup carries routinely, and the parser is told the encoding anyway.
+
+    Empty and whitespace-only input raise ParserError in lxml where bs4 built an
+    empty soup. That is not a distinction any caller here wants -- a truncated
+    or blank response should yield a homepage with no attachments and no filers,
+    the way it always has -- so it is mapped back to an empty document.
+    """
+    if isinstance(html, str):
+        html = html.encode("utf-8", errors="replace")
+    # remove_blank_text stays off: a whitespace-only node between two tags is a
+    # word boundary, and libxml2 deletes rather than collapses it. See
+    # create_lxml_parser's docstring and the vfwp bug family.
+    parser = create_lxml_parser(remove_blank_text=False, remove_comments=True,
+                                recover=True, encoding="utf-8")
+    try:
+        tree = lxml.html.fromstring(html, parser=parser)
+    except ParserError:
+        # "Document is empty" -- bs4 returned an empty soup for this input.
+        return lxml.html.fromstring(b"<html><body></body></html>", parser=parser)
+    if tree.tag != "html":
+        # fromstring can root a fragment at the fragment itself; every selector
+        # below is a descendant search, so give them a document to search.
+        wrapper = lxml.html.Element("html")
+        body = lxml.html.Element("body")
+        body.append(tree)
+        wrapper.append(body)
+        tree = wrapper
+    return tree
+
+
+def _by_class(element, tag: str, class_name: str) -> List:
+    """Elements of `tag` carrying `class_name` among their classes.
+
+    `class` is a space-separated list, so a plain ``@class='mailer'`` test would
+    miss ``class="mailer foo"`` that bs4's class_= matched, and a `contains`
+    test on the raw string would wrongly match ``class="mailerFoo"``. Padding
+    both sides with spaces matches whole tokens only.
+    """
+    return element.xpath(
+        f'.//{tag}[contains(concat(" ", normalize-space(@class), " "), " {class_name} ")]'
+    )
+
+
+def _first_by_class(element, tag: str, class_name: str):
+    """The first matching element, or None -- bs4's ``find`` semantics."""
+    found = _by_class(element, tag, class_name)
+    return found[0] if found else None
+
+
+def _as_lxml_root(root, api: str):
+    """Accept the BeautifulSoup this API used to take, for one more major version.
+
+    `Attachments` and `FilingHomepage` are both exported from `edgar`, so the
+    tree they are handed is part of a public signature; it was a BeautifulSoup
+    until this release. Duck-typed on ``xpath`` rather than isinstance, so that
+    checking does not re-import the bs4 this module no longer depends on.
+
+    ``callable``, not ``hasattr``: a BeautifulSoup answers any unknown attribute
+    with the first child tag of that name, or None -- so ``hasattr(soup,
+    "xpath")`` is True, and the soup would sail past the check and fail later
+    inside a selector with "'NoneType' object is not callable".
+    """
+    if root is None or callable(getattr(root, "xpath", None)):
+        return root
+    warnings.warn(
+        f"Passing a BeautifulSoup to {api} is deprecated and will be removed in v6.0; "
+        f"it is re-parsed with lxml, which costs a second parse. Pass "
+        f"edgar.attachments.parse_homepage_html(html) instead.",
+        DeprecationWarning, stacklevel=3)
+    return parse_homepage_html(str(root))
 
 
 class FilerInfo(BaseModel):
@@ -960,11 +1039,12 @@ class Attachments:
         return repr_rich(self.__rich__())
 
     @classmethod
-    def load(cls, soup: BeautifulSoup):
+    def load(cls, root: lxml.html.HtmlElement):
         """
         Load the attachments from the SEC filing home page
         """
-        tables = soup.find_all('table', class_='tableFile')
+        root = _as_lxml_root(root, "Attachments.load")
+        tables = _by_class(root, 'table', 'tableFile')
 
         def parse_table(table, documents: bool):
             min_seq = None
@@ -972,20 +1052,22 @@ class Attachments:
             # Plus additional document with the same sequence number
             primary_documents: List[Attachment] = []
 
-            rows = table.find_all('tr')[1:]  # Skip header row
+            rows = table.xpath('.//tr')[1:]  # Skip header row
             attachments = []
             for _index, row in enumerate(rows):
-                cols = row.find_all('td')
-                sequence_number = cols[0].text.strip().replace('\xa0', '-')
+                cols = row.xpath('.//td')
+                # text_content(), not .text: lxml's .text is only the node's own
+                # leading text, where bs4's .text was every descendant's.
+                sequence_number = cols[0].text_content().strip().replace('\xa0', '-')
 
-                description = cols[1].text.strip()
+                description = cols[1].text_content().strip()
                 # The document text is the text of the document link.
-                document_text = cols[2].text.strip()
+                document_text = cols[2].text_content().strip()
                 document = document_text.split(' ')[0].strip()
                 iXbrl = 'iXBRL' in document_text
-                path = cols[2].a['href'].strip()
-                document_type = cols[3].text.strip()
-                size = cols[4].text.strip()
+                path = cols[2].find('.//a').get('href').strip()
+                document_type = cols[3].text_content().strip()
+                size = cols[4].text_content().strip()
 
                 try:
                     size = int(size)
@@ -1082,11 +1164,23 @@ class FilingHomepage:
 
     def __init__(self,
                  url: str,
-                 soup: BeautifulSoup,
-                 attachments: Attachments):
+                 root: lxml.html.HtmlElement = None,
+                 attachments: Attachments = None,
+                 *,
+                 soup=None):
+        # The second argument was named `soup` and typed BeautifulSoup until
+        # this release. Both halves of the old call keep working -- the keyword
+        # spelling here, the old type in _as_lxml_root -- and both warn; both go
+        # in 6.0.
+        if soup is not None:
+            warnings.warn(
+                "FilingHomepage(soup=...) is deprecated and will be removed in v6.0. "
+                "Pass the tree as `root`.",
+                DeprecationWarning, stacklevel=2)
+            root = soup
         self.attachments = attachments
         self.url = url
-        self._soup = soup
+        self._root = _as_lxml_root(root, "FilingHomepage")
 
     def open(self):
         webbrowser.open(self.url)
@@ -1130,17 +1224,19 @@ class FilingHomepage:
     def get_filers(self):
         if hasattr(self, '_cached_filers'):
             return self._cached_filers
-        filer_divs = self._soup.find_all("div", class_="filerDiv")
+        filer_divs = _by_class(self._root, "div", "filerDiv")
         filer_infos = []
         for filer_div in filer_divs:
 
             # Get the company name
-            company_info_div = filer_div.find("div", class_="companyInfo")
+            company_info_div = _first_by_class(filer_div, "div", "companyInfo")
 
-            company_name_span = company_info_div.find("span", class_="companyName")
+            company_name_span = _first_by_class(company_info_div, "span", "companyName")
 
-            if company_name_span:
-                full_text = company_name_span.text.strip()
+            # `is not None`, not truthiness: an lxml element with no children is
+            # falsy, and a companyName span holding only text has none.
+            if company_name_span is not None:
+                full_text = company_name_span.text_content().strip()
                 # Split the text into company name and CIK
                 parts = full_text.split('CIK: ')
                 company_name = parts[0].strip()
@@ -1153,19 +1249,30 @@ class FilingHomepage:
                 cik = ""
 
             # Get the identification information
-            ident_info_div = company_info_div.find("p", class_="identInfo")
+            ident_info_div = _first_by_class(company_info_div, "p", "identInfo")
 
-            # Replace <br> with newlines
-            for br in ident_info_div.find_all("br"):
-                br.replace_with("\n")
+            # Replace <br> with newlines. lxml has no replace_with, and dropping
+            # an element DELETES its tail -- the text between this <br> and the
+            # next -- so the tail is spliced onto whatever precedes the <br>
+            # first, with the newline in front of it. Losing it would glue the
+            # identification lines together, which is the hxtd/2h2s bug family.
+            for br in ident_info_div.xpath(".//br"):
+                parent = br.getparent()
+                text = "\n" + (br.tail or "")
+                previous = br.getprevious()
+                if previous is not None:
+                    previous.tail = (previous.tail or "") + text
+                else:
+                    parent.text = (parent.text or "") + text
+                parent.remove(br)
 
-            identification = ident_info_div.text
+            identification = ident_info_div.text_content()
 
             # Get the mailing information
-            mailer_divs = filer_div.find_all("div", class_="mailer")
-            # For each mailed_div.text remove multiple spaces after a newline
+            mailer_divs = _by_class(filer_div, "div", "mailer")
+            # For each mailer div's text remove multiple spaces after a newline
 
-            addresses = [re.sub(r'\n\s+', '\n', mailer_div.text.strip())
+            addresses = [re.sub(r'\n\s+', '\n', mailer_div.text_content().strip())
                          for mailer_div in mailer_divs]
 
             # Create the filer info
@@ -1186,7 +1293,7 @@ class FilingHomepage:
         if hasattr(self, '_cached_filing_dates'):
             return self._cached_filing_dates
         # Find the form grouping divs
-        grouping_divs = self._soup.find_all("div", class_="formGrouping")
+        grouping_divs = _by_class(self._root, "div", "formGrouping")
         if len(grouping_divs) == 0:
             return None
 
@@ -1198,16 +1305,18 @@ class FilingHomepage:
         # period of report, which then crashes downstream isoformat parsers.
         label_to_value: Dict[str, str] = {}
         for grouping in grouping_divs:
-            children = [c for c in grouping.find_all("div", recursive=False)
-                        if c.get("class")]
+            children = [c for c in grouping.xpath("./div") if c.get("class")]
             current_label: Optional[str] = None
             for child in children:
-                classes = child.get("class") or []
+                # bs4 returned class as a list of tokens; lxml returns the raw
+                # string, so split it -- an `in` test against the string would
+                # match "infoHeadline" as well as "infoHead".
+                classes = (child.get("class") or "").split()
                 if "infoHead" in classes:
-                    current_label = child.text.strip().lower()
+                    current_label = child.text_content().strip().lower()
                 elif "info" in classes and current_label is not None:
                     # Only keep the first value for each label.
-                    label_to_value.setdefault(current_label, child.text.strip())
+                    label_to_value.setdefault(current_label, child.text_content().strip())
                     current_label = None
 
         filing_date = label_to_value.get("filing date")
@@ -1217,11 +1326,11 @@ class FilingHomepage:
         # Fall back to the legacy positional layout if the label-based lookup
         # missed either of the always-present date fields.
         if filing_date is None or accepted_date is None:
-            info_divs = grouping_divs[0].find_all("div", class_="info")
+            info_divs = _by_class(grouping_divs[0], "div", "info")
             if filing_date is None and len(info_divs) >= 1:
-                filing_date = info_divs[0].text.strip()
+                filing_date = info_divs[0].text_content().strip()
             if accepted_date is None and len(info_divs) >= 2:
-                accepted_date = info_divs[1].text.strip()
+                accepted_date = info_divs[1].text_content().strip()
 
         result = filing_date, accepted_date, period
         self._cached_filing_dates = result
@@ -1230,9 +1339,9 @@ class FilingHomepage:
     @classmethod
     def load(cls, url: str):
         response = get_with_retry(url)
-        soup = BeautifulSoup(response.text, 'html.parser')
-        attachments = Attachments.load(soup)
-        return cls(url, soup, attachments)
+        root = parse_homepage_html(response.content)
+        attachments = Attachments.load(root)
+        return cls(url, root, attachments)
 
     def __repr__(self):
         return repr_rich(self.__rich__())

--- a/tests/fixtures/homepages/homepage_baseline.json
+++ b/tests/fixtures/homepages/homepage_baseline.json
@@ -1,0 +1,867 @@
+{
+  "aapl-10k-2024.html": {
+    "data_files": [
+      {
+        "description": "XBRL TAXONOMY EXTENSION SCHEMA DOCUMENT",
+        "document": "aapl-20240928.xsd",
+        "document_type": "EX-101.SCH",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928.xsd",
+        "purpose": null,
+        "sequence_number": "14",
+        "size": 58200
+      },
+      {
+        "description": "XBRL TAXONOMY EXTENSION CALCULATION LINKBASE DOCUMENT",
+        "document": "aapl-20240928_cal.xml",
+        "document_type": "EX-101.CAL",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_cal.xml",
+        "purpose": null,
+        "sequence_number": "15",
+        "size": 150261
+      },
+      {
+        "description": "XBRL TAXONOMY EXTENSION DEFINITION LINKBASE DOCUMENT",
+        "document": "aapl-20240928_def.xml",
+        "document_type": "EX-101.DEF",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_def.xml",
+        "purpose": null,
+        "sequence_number": "16",
+        "size": 232678
+      },
+      {
+        "description": "XBRL TAXONOMY EXTENSION LABEL LINKBASE DOCUMENT",
+        "document": "aapl-20240928_lab.xml",
+        "document_type": "EX-101.LAB",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_lab.xml",
+        "purpose": null,
+        "sequence_number": "17",
+        "size": 779708
+      },
+      {
+        "description": "XBRL TAXONOMY EXTENSION PRESENTATION LINKBASE DOCUMENT",
+        "document": "aapl-20240928_pre.xml",
+        "document_type": "EX-101.PRE",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_pre.xml",
+        "purpose": null,
+        "sequence_number": "18",
+        "size": 509625
+      },
+      {
+        "description": "EXTRACTED XBRL INSTANCE DOCUMENT",
+        "document": "aapl-20240928_htm.xml",
+        "document_type": "XML",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_htm.xml",
+        "purpose": null,
+        "sequence_number": "106",
+        "size": 1355849
+      }
+    ],
+    "documents": [
+      {
+        "description": "10-K",
+        "document": "aapl-20240928.htm",
+        "document_type": "10-K",
+        "ixbrl": true,
+        "path": "/ix?doc=/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 1503780
+      },
+      {
+        "description": "EX-4.1",
+        "document": "a10-kexhibit4109282024.htm",
+        "document_type": "EX-4.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit4109282024.htm",
+        "purpose": null,
+        "sequence_number": "2",
+        "size": 120785
+      },
+      {
+        "description": "EX-10.19",
+        "document": "a10-kexhibit10199282024.htm",
+        "document_type": "EX-10.19",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10199282024.htm",
+        "purpose": null,
+        "sequence_number": "3",
+        "size": 56948
+      },
+      {
+        "description": "EX-10.20",
+        "document": "a10-kexhibit10209282024.htm",
+        "document_type": "EX-10.20",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10209282024.htm",
+        "purpose": null,
+        "sequence_number": "4",
+        "size": 74591
+      },
+      {
+        "description": "EX-10.21",
+        "document": "a10-kexhibit10219282024.htm",
+        "document_type": "EX-10.21",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10219282024.htm",
+        "purpose": null,
+        "sequence_number": "5",
+        "size": 60845
+      },
+      {
+        "description": "EX-10.22",
+        "document": "a10-kexhibit10229282024.htm",
+        "document_type": "EX-10.22",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit10229282024.htm",
+        "purpose": null,
+        "sequence_number": "6",
+        "size": 75240
+      },
+      {
+        "description": "EX-19.1",
+        "document": "a10-kexhibit1919282024.htm",
+        "document_type": "EX-19.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit1919282024.htm",
+        "purpose": null,
+        "sequence_number": "7",
+        "size": 44108
+      },
+      {
+        "description": "EX-21.1",
+        "document": "a10-kexhibit21109282024.htm",
+        "document_type": "EX-21.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit21109282024.htm",
+        "purpose": null,
+        "sequence_number": "8",
+        "size": 11229
+      },
+      {
+        "description": "EX-23.1",
+        "document": "a10-kexhibit23109282024.htm",
+        "document_type": "EX-23.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit23109282024.htm",
+        "purpose": null,
+        "sequence_number": "9",
+        "size": 5018
+      },
+      {
+        "description": "EX-31.1",
+        "document": "a10-kexhibit31109282024.htm",
+        "document_type": "EX-31.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit31109282024.htm",
+        "purpose": null,
+        "sequence_number": "10",
+        "size": 10508
+      },
+      {
+        "description": "EX-31.2",
+        "document": "a10-kexhibit31209282024.htm",
+        "document_type": "EX-31.2",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit31209282024.htm",
+        "purpose": null,
+        "sequence_number": "11",
+        "size": 10544
+      },
+      {
+        "description": "EX-32.1",
+        "document": "a10-kexhibit32109282024.htm",
+        "document_type": "EX-32.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit32109282024.htm",
+        "purpose": null,
+        "sequence_number": "12",
+        "size": 8357
+      },
+      {
+        "description": "EX-97.1",
+        "document": "a10-kexhibit97109282024.htm",
+        "document_type": "EX-97.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/a10-kexhibit97109282024.htm",
+        "purpose": null,
+        "sequence_number": "13",
+        "size": 13555
+      },
+      {
+        "description": "",
+        "document": "aapl-20240928_g1.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_g1.jpg",
+        "purpose": null,
+        "sequence_number": "19",
+        "size": 10963
+      },
+      {
+        "description": "",
+        "document": "aapl-20240928_g2.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/aapl-20240928_g2.jpg",
+        "purpose": null,
+        "sequence_number": "20",
+        "size": 154498
+      },
+      {
+        "description": "",
+        "document": "image_0.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/image_0.jpg",
+        "purpose": null,
+        "sequence_number": "21",
+        "size": 2374
+      },
+      {
+        "description": "",
+        "document": "image_01.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/image_01.jpg",
+        "purpose": null,
+        "sequence_number": "22",
+        "size": 2563
+      },
+      {
+        "description": "Complete submission text file",
+        "document": "0000320193-24-000123.txt",
+        "document_type": "",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/320193/000032019324000123/0000320193-24-000123.txt",
+        "purpose": null,
+        "sequence_number": "",
+        "size": 9759333
+      }
+    ],
+    "filers": [
+      {
+        "addresses": [
+          "Mailing Address\nONE APPLE PARK WAY\nCUPERTINO       CA\n95014",
+          "Business Address\nONE APPLE PARK WAY\nCUPERTINO       CA\n95014      \n(408) 996-1010"
+        ],
+        "cik": "0000320193",
+        "company_name": "Apple Inc.",
+        "identification": "EIN.: 942404110 | State of Incorp.: CA | Fiscal Year End: 0928\nType: 10-K | Act: 34 | File No.: 001-36743 | Film No.: 241416806\nSIC: 3571 Electronic Computers\n(CF Office: 06 Technology)"
+      }
+    ],
+    "filing_dates": [
+      "2024-11-01",
+      "2024-11-01 06:01:36",
+      "2024-09-28"
+    ],
+    "primary_documents": [
+      {
+        "description": "10-K",
+        "document": "aapl-20240928.htm",
+        "document_type": "10-K",
+        "ixbrl": true,
+        "path": "/ix?doc=/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 1503780
+      }
+    ]
+  },
+  "eightk-2005.html": {
+    "data_files": [],
+    "documents": [
+      {
+        "description": "8-K",
+        "document": "a2153970z8-k.htm",
+        "document_type": "8-K",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1168054/000104746905006981/a2153970z8-k.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 11946
+      },
+      {
+        "description": "EX 99.1",
+        "document": "a2153970zex-99_1.htm",
+        "document_type": "EX-99.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1168054/000104746905006981/a2153970zex-99_1.htm",
+        "purpose": null,
+        "sequence_number": "2",
+        "size": 7295
+      },
+      {
+        "description": "Complete submission text file",
+        "document": "0001047469-05-006981.txt",
+        "document_type": "",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1168054/000104746905006981/0001047469-05-006981.txt",
+        "purpose": null,
+        "sequence_number": "",
+        "size": 21100
+      }
+    ],
+    "filers": [
+      {
+        "addresses": [
+          "Mailing Address\n1700 LINCOLN STREET\nSUITE 1800\nDENVER       CO\n80203-4518",
+          "Business Address\n1700 LINCOLN STREET\nSUITE 1800\nDENVER       CO\n80203-4518      \n303-295-3995"
+        ],
+        "cik": "0001168054",
+        "company_name": "CIMAREX ENERGY CO",
+        "identification": "EIN.: 450466694 | State of Incorp.: DE | Fiscal Year End: 1231\nType: 8-K | Act: 34 | File No.: 001-31446 | Film No.: 05690525\nSIC: 1311 Crude Petroleum & Natural Gas"
+      }
+    ],
+    "filing_dates": [
+      "2005-03-18",
+      "2005-03-18 10:07:40",
+      "2005-03-17"
+    ],
+    "primary_documents": [
+      {
+        "description": "8-K",
+        "document": "a2153970z8-k.htm",
+        "document_type": "8-K",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1168054/000104746905006981/a2153970z8-k.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 11946
+      }
+    ]
+  },
+  "form4-reporting-owner.html": {
+    "data_files": [],
+    "documents": [
+      {
+        "description": "STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES",
+        "document": "form4.html",
+        "document_type": "4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/914156/000106299324012217/xslF345X05/form4.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": null
+      },
+      {
+        "description": "STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES",
+        "document": "form4.xml",
+        "document_type": "4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/914156/000106299324012217/form4.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 5393
+      },
+      {
+        "description": "Complete submission text file",
+        "document": "0001062993-24-012217.txt",
+        "document_type": "",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/914156/000106299324012217/0001062993-24-012217.txt",
+        "purpose": null,
+        "sequence_number": "",
+        "size": 6848
+      }
+    ],
+    "filers": [
+      {
+        "addresses": [
+          "Mailing Address\n100 HALE STREET\nNEWBURYPORT       MA\n01950",
+          "Business Address\n100 HALE STREET\nNEWBURYPORT       MA\n01950      \n978-352-2200"
+        ],
+        "cik": "0000914156",
+        "company_name": "UFP TECHNOLOGIES INC",
+        "identification": "EIN.: 042314970 | State of Incorp.: DE | Fiscal Year End: 1231\nSIC: 3841 Surgical & Medical Instruments & Apparatus\n(CF Office: 08 Industrial Applications and Services)"
+      },
+      {
+        "addresses": [
+          "Mailing Address\nONE TECHNOLOGY WAY\nNORWOOD       MA\n02062",
+          "Business Address"
+        ],
+        "cik": "0001641388",
+        "company_name": "Hassett Joseph",
+        "identification": "Type: 4 | Act: 34 | File No.: 001-12648 | Film No.: 241030989"
+      }
+    ],
+    "filing_dates": [
+      "2024-06-07",
+      "2024-06-07 18:10:30",
+      "2024-06-05"
+    ],
+    "primary_documents": [
+      {
+        "description": "STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES",
+        "document": "form4.html",
+        "document_type": "4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/914156/000106299324012217/xslF345X05/form4.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": null
+      },
+      {
+        "description": "STATEMENT OF CHANGES IN BENEFICIAL OWNERSHIP OF SECURITIES",
+        "document": "form4.xml",
+        "document_type": "4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/914156/000106299324012217/form4.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 5393
+      }
+    ]
+  },
+  "s4-multifiler.html": {
+    "data_files": [],
+    "documents": [
+      {
+        "description": "REGISTRATION STATEMENT",
+        "document": "ea0201675-04.htm",
+        "document_type": "S-4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea0201675-04.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 13643022
+      },
+      {
+        "description": "CERTIFICATE OF INCORPORATION OF PURCHASER",
+        "document": "ea020167504ex3-3_acricap1.htm",
+        "document_type": "EX-3.3",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex3-3_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "2",
+        "size": 5161
+      },
+      {
+        "description": "CONSENT OF MARCUM LLP, INDEPENDENT REGISTERED PUBLIC ACCOUNTING FIRM TO ACAC",
+        "document": "ea020167504ex23-1_acricap1.htm",
+        "document_type": "EX-23.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex23-1_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "3",
+        "size": 2220
+      },
+      {
+        "description": "CONSENT OF MARCUM LLP, INDEPENDENT REGISTERED PUBLIC ACCOUNTING FIRM TO FOXX",
+        "document": "ea020167504ex23-2_acricap1.htm",
+        "document_type": "EX-23.2",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex23-2_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "4",
+        "size": 2549
+      },
+      {
+        "description": "CONSENT OF \"EVA\" YIQING MIAO (PUBCO'S DIRECTOR NOMINEE)",
+        "document": "ea020167504ex99-1_acricap1.htm",
+        "document_type": "EX-99.1",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-1_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "5",
+        "size": 2780
+      },
+      {
+        "description": "CONSENT OF EDMUND R. MILLER (PUBCO'S DIRECTOR NOMINEE)",
+        "document": "ea020167504ex99-2_acricap1.htm",
+        "document_type": "EX-99.2",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-2_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "6",
+        "size": 3007
+      },
+      {
+        "description": "CONSENT OF \"JEFF\" FENG JIANG (PUBCO'S DIRECTOR NOMINEE)",
+        "document": "ea020167504ex99-3_acricap1.htm",
+        "document_type": "EX-99.3",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex99-3_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "7",
+        "size": 2722
+      },
+      {
+        "description": "FILING FEE TABLE",
+        "document": "ea020167504ex-fee_acricap1.htm",
+        "document_type": "EX-FILING FEES",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea020167504ex-fee_acricap1.htm",
+        "purpose": null,
+        "sequence_number": "8",
+        "size": 102217
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "tflowchart_001.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/tflowchart_001.jpg",
+        "purpose": null,
+        "sequence_number": "9",
+        "size": 157679
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "tflowchart_002.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/tflowchart_002.jpg",
+        "purpose": null,
+        "sequence_number": "10",
+        "size": 93770
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_002.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_002.jpg",
+        "purpose": null,
+        "sequence_number": "11",
+        "size": 518944
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_005.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_005.jpg",
+        "purpose": null,
+        "sequence_number": "12",
+        "size": 246454
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_006.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_006.jpg",
+        "purpose": null,
+        "sequence_number": "13",
+        "size": 184355
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_007.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_007.jpg",
+        "purpose": null,
+        "sequence_number": "14",
+        "size": 172516
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_008.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_008.jpg",
+        "purpose": null,
+        "sequence_number": "15",
+        "size": 188564
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_009.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_009.jpg",
+        "purpose": null,
+        "sequence_number": "16",
+        "size": 413510
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_010.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_010.jpg",
+        "purpose": null,
+        "sequence_number": "17",
+        "size": 468782
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_011.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_011.jpg",
+        "purpose": null,
+        "sequence_number": "18",
+        "size": 190721
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_012.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_012.jpg",
+        "purpose": null,
+        "sequence_number": "19",
+        "size": 363740
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_013.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_013.jpg",
+        "purpose": null,
+        "sequence_number": "20",
+        "size": 534592
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_014.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_014.jpg",
+        "purpose": null,
+        "sequence_number": "21",
+        "size": 485930
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_016.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_016.jpg",
+        "purpose": null,
+        "sequence_number": "22",
+        "size": 501361
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_022.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_022.jpg",
+        "purpose": null,
+        "sequence_number": "23",
+        "size": 408932
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_017.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_017.jpg",
+        "purpose": null,
+        "sequence_number": "24",
+        "size": 215306
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_023.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_023.jpg",
+        "purpose": null,
+        "sequence_number": "25",
+        "size": 128721
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_024.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_024.jpg",
+        "purpose": null,
+        "sequence_number": "26",
+        "size": 242800
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_020.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_020.jpg",
+        "purpose": null,
+        "sequence_number": "27",
+        "size": 435269
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "timage_021.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/timage_021.jpg",
+        "purpose": null,
+        "sequence_number": "28",
+        "size": 532161
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "tfoxxd_text.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/tfoxxd_text.jpg",
+        "purpose": null,
+        "sequence_number": "29",
+        "size": 11636
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "tfoxxd_logo.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/tfoxxd_logo.jpg",
+        "purpose": null,
+        "sequence_number": "30",
+        "size": 13151
+      },
+      {
+        "description": "GRAPHIC",
+        "document": "tmiro_text.jpg",
+        "document_type": "GRAPHIC",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/tmiro_text.jpg",
+        "purpose": null,
+        "sequence_number": "31",
+        "size": 13322
+      },
+      {
+        "description": "Complete submission text file",
+        "document": "0001213900-24-057319.txt",
+        "document_type": "",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/0001213900-24-057319.txt",
+        "purpose": null,
+        "sequence_number": "",
+        "size": 22751245
+      }
+    ],
+    "filers": [
+      {
+        "addresses": [
+          "Mailing Address\n13284 POND SPRINGS RD\nSTE 405\nAUSTIN       TX\n78729",
+          "Business Address\n13284 POND SPRINGS RD\nSTE 405\nAUSTIN       TX\n78729      \n512-666-1277"
+        ],
+        "cik": "0002013807",
+        "company_name": "Acri Capital Merger Sub I Inc.",
+        "identification": "EIN.: 000000000 | State of Incorp.: DE | Fiscal Year End: 1231\nType: S-4 | Act: 33 | File No.: 333-280613 | Film No.: 241087082\nSIC: 3576 Computer Communications Equipment\n(CF Office: 06 Technology)"
+      }
+    ],
+    "filing_dates": [
+      "2024-06-28",
+      "2024-06-28 17:29:32",
+      null
+    ],
+    "primary_documents": [
+      {
+        "description": "REGISTRATION STATEMENT",
+        "document": "ea0201675-04.htm",
+        "document_type": "S-4",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/2013807/000121390024057319/ea0201675-04.htm",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 13643022
+      }
+    ]
+  },
+  "thirteenf-2023.html": {
+    "data_files": [],
+    "documents": [
+      {
+        "description": "",
+        "document": "primary_doc.html",
+        "document_type": "13F-HR",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/xslForm13F_X02/primary_doc.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": null
+      },
+      {
+        "description": "",
+        "document": "primary_doc.xml",
+        "document_type": "13F-HR",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/primary_doc.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 2028
+      },
+      {
+        "description": "",
+        "document": "index.html",
+        "document_type": "INFORMATION TABLE",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/xslForm13F_X02/index.xml",
+        "purpose": null,
+        "sequence_number": "2",
+        "size": null
+      },
+      {
+        "description": "",
+        "document": "index.xml",
+        "document_type": "INFORMATION TABLE",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/index.xml",
+        "purpose": null,
+        "sequence_number": "2",
+        "size": 7578
+      },
+      {
+        "description": "Complete submission text file",
+        "document": "0001894188-23-000007.txt",
+        "document_type": "",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/0001894188-23-000007.txt",
+        "purpose": null,
+        "sequence_number": "",
+        "size": 10769
+      }
+    ],
+    "filers": [
+      {
+        "addresses": [
+          "Mailing Address\n650 MADISON AVENUE, 15TH FLOOR\nNEW YORK       NY\n10022",
+          "Business Address\n650 MADISON AVENUE, 15TH FLOOR\nNEW YORK       NY\n10022      \n646-860-0181"
+        ],
+        "cik": "0001894188",
+        "company_name": "LTS One Management LP",
+        "identification": "EIN.: 871396377 | State of Incorp.: DE | Fiscal Year End: 1231\nType: 13F-HR | Act: 34 | File No.: 028-22111 | Film No.: 231402140"
+      }
+    ],
+    "filing_dates": [
+      "2023-11-14",
+      "2023-11-14 09:38:54",
+      "2023-09-30"
+    ],
+    "primary_documents": [
+      {
+        "description": "",
+        "document": "primary_doc.html",
+        "document_type": "13F-HR",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/xslForm13F_X02/primary_doc.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": null
+      },
+      {
+        "description": "",
+        "document": "primary_doc.xml",
+        "document_type": "13F-HR",
+        "ixbrl": false,
+        "path": "/Archives/edgar/data/1894188/000189418823000007/primary_doc.xml",
+        "purpose": null,
+        "sequence_number": "1",
+        "size": 2028
+      }
+    ]
+  }
+}

--- a/tests/issues/regression/test_issue_sc13g_period_of_report.py
+++ b/tests/issues/regression/test_issue_sc13g_period_of_report.py
@@ -13,18 +13,17 @@ GitHub PR: https://github.com/dgunning/edgartools/pull/787
 """
 
 import pytest
-from bs4 import BeautifulSoup
 
-from edgar.attachments import Attachments, FilingHomepage
+from edgar.attachments import Attachments, FilingHomepage, parse_homepage_html
 
 pytestmark = pytest.mark.fast
 
 
 def _homepage_from_html(html: str) -> FilingHomepage:
-    soup = BeautifulSoup(html, "html.parser")
+    root = parse_homepage_html(html)
     # Attachments is irrelevant for these tests; pass an empty instance.
     attachments = Attachments(document_files=[], data_files=[], primary_documents=[])
-    return FilingHomepage(url="http://example/index.html", soup=soup, attachments=attachments)
+    return FilingHomepage(url="http://example/index.html", root=root, attachments=attachments)
 
 
 _FILING_AND_ACCEPTED = """

--- a/tests/issues/regression/test_jrmw_filing_homepage_filers.py
+++ b/tests/issues/regression/test_jrmw_filing_homepage_filers.py
@@ -25,9 +25,8 @@ pass on a selector that matched the wrong div.
 import pathlib
 
 import pytest
-from bs4 import BeautifulSoup
 
-from edgar.attachments import Attachments, FilingHomepage
+from edgar.attachments import Attachments, FilingHomepage, parse_homepage_html
 
 pytestmark = pytest.mark.fast
 
@@ -37,8 +36,8 @@ FIXTURES = pathlib.Path(__file__).parent.parent.parent / "fixtures" / "homepages
 def _homepage(stem: str) -> FilingHomepage:
     path = FIXTURES / f"{stem}.html"
     assert path.exists(), f"missing fixture {path}"
-    soup = BeautifulSoup(path.read_text(), "html.parser")
-    return FilingHomepage(f"file://{path}", soup, Attachments.load(soup))
+    root = parse_homepage_html(path.read_bytes())
+    return FilingHomepage(f"file://{path}", root, Attachments.load(root))
 
 
 def test_the_fixture_corpus_is_present():

--- a/tests/test_homepage_characterization.py
+++ b/tests/test_homepage_characterization.py
@@ -1,0 +1,166 @@
+"""Golden-file characterization of the filing-homepage parse (edgartools-07lk.11.5).
+
+Generated while ``attachments.py`` still ran on BeautifulSoup, so that the
+bs4 -> lxml port could be proved to change nothing. ``homepage_baseline.json``
+is the committed output of the bs4 implementation over every fixture in
+``tests/fixtures/homepages``; the tests below re-derive it through lxml and
+compare, so the parse output is identical rather than merely "the assertions
+still pass".
+
+WHY A GOLDEN FILE AND NOT FIELD ASSERTIONS. ``test_jrmw_filing_homepage_filers``
+already asserts ground truth on the filer fields, which is the right shape for a
+bug fix. A parser swap is different: it can move anything -- a stripped space, a
+dropped tail, a None where a string used to be -- and field assertions only
+catch what someone thought to name. Three of this file's translations are
+exactly the invisible kind:
+
+  * ``.text`` -> ``.text_content()``. lxml's ``.text`` is only a node's own
+    leading text; bs4's was every descendant's. The wrong one still returns a
+    string, and for a single-text-node cell it returns the RIGHT string, so it
+    fails only on the nested cells.
+  * ``br.replace_with("\\n")`` -> splice-and-remove. Dropping an element in lxml
+    deletes its tail, which is the text between this <br> and the next, so a
+    naive translation silently glues the identification lines together. Same
+    family as hxtd and 2h2s.
+  * ``child.get("class")`` returned a token LIST in bs4 and returns the raw
+    string in lxml, so ``"info" in classes`` quietly became a substring test.
+"""
+import json
+import pathlib
+
+import pytest
+
+from edgar.attachments import Attachments, FilingHomepage, parse_homepage_html
+
+pytestmark = pytest.mark.fast
+
+REPO = pathlib.Path(__file__).parent.parent
+HOMEPAGE_DIR = REPO / "tests" / "fixtures" / "homepages"
+BASELINE = HOMEPAGE_DIR / "homepage_baseline.json"
+
+
+def _fixtures():
+    return sorted(HOMEPAGE_DIR.glob("*.html"))
+
+
+def _attachment_dump(attachment):
+    return {
+        "sequence_number": attachment.sequence_number,
+        "description": attachment.description,
+        "document": attachment.document,
+        "ixbrl": attachment.ixbrl,
+        "path": attachment.path,
+        "document_type": attachment.document_type,
+        "size": attachment.size,
+        "purpose": attachment.purpose,
+    }
+
+
+def _parse(path: pathlib.Path):
+    root = parse_homepage_html(path.read_bytes())
+    attachments = Attachments.load(root)
+    return FilingHomepage(f"file://{path}", root, attachments), attachments
+
+
+def _capture(path: pathlib.Path):
+    homepage, attachments = _parse(path)
+    return {
+        "documents": [_attachment_dump(a) for a in (attachments.documents or [])],
+        "data_files": [_attachment_dump(a) for a in (attachments.data_files or [])],
+        "primary_documents": [_attachment_dump(a) for a in (attachments.primary_documents or [])],
+        "filers": [f.model_dump() for f in homepage.get_filers()],
+        "filing_dates": list(homepage.get_filing_dates() or []),
+    }
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    return json.loads(BASELINE.read_text())
+
+
+def test_every_fixture_is_in_the_baseline(baseline):
+    """A fixture added without regenerating the baseline would otherwise be
+    parsed by nothing and prove nothing."""
+    assert sorted(baseline) == [p.name for p in _fixtures()]
+
+
+@pytest.mark.parametrize("path", _fixtures(), ids=lambda p: p.stem)
+def test_the_parse_matches_the_bs4_baseline(path, baseline):
+    assert _capture(path) == baseline[path.name]
+
+
+def test_the_baseline_is_not_vacuous(baseline):
+    """A baseline of empty lists would compare equal to a parser that found
+    nothing at all -- which is the bug jrmw just fixed."""
+    assert sum(len(f["documents"]) for f in baseline.values()) > 50
+    assert sum(len(f["filers"]) for f in baseline.values()) >= 6
+    assert all(f["filing_dates"][0] for f in baseline.values())
+
+
+# --------------------------------------------------------------- edge inputs
+#
+# The three inputs where lxml does not behave as bs4 did, pinned here because
+# `FilingHomepage.load` feeds it whatever the SEC returned.
+
+
+@pytest.mark.parametrize("html", ["", "   \n\t  ", b""])
+def test_empty_input_yields_an_empty_document_rather_than_raising(html):
+    """bs4 built an empty soup for these; lxml raises ParserError. A truncated
+    or blank response has always produced a homepage with nothing on it, and
+    still does."""
+    root = parse_homepage_html(html)
+    assert Attachments.load(root).documents == []
+    assert FilingHomepage("http://example/x", root, Attachments.load(root)).get_filers() == []
+
+
+def test_an_encoding_declaration_does_not_raise():
+    """``lxml.html.fromstring`` refuses a *str* that opens with an encoding
+    declaration -- SEC markup carries them routinely, so the parse takes bytes."""
+    html = ('<?xml version="1.0" encoding="UTF-8"?>'
+            '<html><body><div class="filerDiv">x</div></body></html>')
+    assert len(parse_homepage_html(html).xpath('//div[@class="filerDiv"]')) == 1
+
+
+def test_sec_error_pages_parse_to_nothing_rather_than_crashing():
+    """SEC answers a bad accession with a 200 and an apology page."""
+    root = parse_homepage_html("<html><body><h1>File Unavailable</h1></body></html>")
+    homepage = FilingHomepage("http://example/x", root, Attachments.load(root))
+    assert homepage.get_filers() == []
+    assert homepage.get_filing_dates() is None
+
+
+def test_a_class_is_matched_by_token_not_by_substring():
+    """The xpath translation of bs4's ``class_=`` has to match whole tokens:
+    ``contains(@class, "mailer")`` would also match ``class="mailerAddress"``,
+    and ``@class="mailer"`` would miss ``class="mailer extra"``."""
+    root = parse_homepage_html(
+        '<html><body>'
+        '<div class="filerDiv extra"><div class="companyInfo">'
+        '<span class="companyName">Widget Co (Filer) CIK: 0000000001</span>'
+        '<p class="identInfo">SIC: 1234</p></div>'
+        '<div class="mailerAddress">not an address</div>'
+        '</div></body></html>')
+    filers = FilingHomepage("http://example/x", root, None).get_filers()
+    assert len(filers) == 1, "class='filerDiv extra' must still match"
+    assert filers[0].company_name == "Widget Co"
+    assert filers[0].addresses == [], "class='mailerAddress' must not match 'mailer'"
+
+
+def test_a_soup_is_still_accepted_and_says_so():
+    """`FilingHomepage` and `Attachments` are exported from `edgar`, and took a
+    BeautifulSoup until this release. The old call keeps working through 5.x."""
+    from bs4 import BeautifulSoup
+
+    html = (HOMEPAGE_DIR / "aapl-10k-2024.html").read_text()
+    soup = BeautifulSoup(html, "html.parser")
+
+    with pytest.warns(DeprecationWarning, match="removed in v6.0"):
+        attachments = Attachments.load(soup)
+    with pytest.warns(DeprecationWarning, match="removed in v6.0"):
+        homepage = FilingHomepage("http://example/x", soup, attachments)
+    with pytest.warns(DeprecationWarning, match="soup="):
+        FilingHomepage(url="http://example/x", soup=soup, attachments=attachments)
+
+    # And produces the same answer as the supported call, not a degraded one.
+    assert [f.model_dump() for f in homepage.get_filers()] == \
+        _capture(HOMEPAGE_DIR / "aapl-10k-2024.html")["filers"]


### PR DESCRIPTION
Second port of the HTML half of the bs4 → lxml migration (`edgartools-07lk.11.5`), on top of #1108.

## Measured

**15.8ms → 1.8ms over the five homepage fixtures, ~8.9x.** Both sides timed on the same machine in the same session, by stashing the port and re-running the identical script — not a comparison against numbers recorded earlier.

| fixture | bs4 | lxml |
|---|---|---|
| aapl-10k-2024 | 4395µs | 494µs |
| eightk-2005 | 2037µs | 224µs |
| form4-reporting-owner | 2197µs | 259µs |
| s4-multifiler | 5027µs | 556µs |
| thirteenf-2023 | 2135µs | 239µs |
| **total** | **15791µs** | **1772µs** |

Matches headers.py's ~7x (#1105) and is again well above the 2–3x the bead projected, so the remaining HTML estimates on the epic are worth revisiting.

## Scope was larger than the bead said

The bead lists 4 bs4 sites; there are 16. Beyond `load()`/`soup`/`BeautifulSoup()` it includes the nested `companyInfo`/`companyName`/`identInfo` lookups, the mailer divs, the `formGrouping`/`info` divs, and a `find_all("div", recursive=False)` that has no lxml equivalent.

The only production construction path is `FilingHomepage.load(url)` (`_filings.py:2288`). `tests/perf/perf_attachments2.py:8` calls `Attachments.load(url)` with a URL where a soup was expected — already broken before this change, left alone.

## What the swap had to preserve

Three translations fail *silently* rather than loudly, which is why the evidence is a golden file rather than assertions:

- **`.text` → `.text_content()`** — lxml's `.text` is only a node's own leading text; bs4's was every descendant's. The wrong one still returns a string, and for a single-text-node cell it returns the *right* string, so it would have failed only on the nested cells.
- **`br.replace_with("\n")` → splice-and-remove** — removing an element in lxml deletes its tail, the text between this `<br>` and the next. The tail is spliced onto the preceding sibling, newline first, before the `<br>` goes. A naive translation glues the identification lines together: the hxtd/2h2s bug family.
- **`child.get("class")`** returned a token list in bs4 and returns the raw string in lxml, so `"info" in classes` quietly became a substring test. All class lookups now go through one helper that matches whole tokens — `class="mailer foo"` still matches, `class="mailerAddress"` still does not.

Edge probe over both parsers found two disagreements that matter, the same two headers.py hit:

| input | bs4 | lxml default |
|---|---|---|
| empty / whitespace-only | empty soup | `ParserError` |
| `str` opening with `<?xml …?>` | parsed | `ValueError` |

Both are absorbed in `parse_homepage_html` rather than pushed onto callers: the parse takes bytes, and `ParserError` maps back to an empty document, so a blank or truncated index page still yields a homepage with nothing on it. The migration notes' claim that an unterminated `<!--` makes lxml see an empty document is again not what libxml2 does — both parsers treat the rest as commented out, and agree.

## Evidence

`tests/fixtures/homepages/homepage_baseline.json` is the full parse of every fixture — each attachment's sequence, description, path, type and size; each filer's name, CIK, identification lines and both addresses; the filing dates — generated from the **BeautifulSoup** implementation before any code changed, then re-run unchanged against lxml. It compares byte-identical, so this is not merely "the assertions still pass."

A test asserts the baseline is not vacuous, because a baseline of empty lists would have compared equal to the bug #1108 just fixed.

Also verified live end-to-end on MSFT 10-K, KO 8-K, BRK-B 13F-HR and a PLTR Form 4 (issuer + reporting owner). Full fast suite: 5610 passed.

## Public signature

`FilingHomepage` and `Attachments` are both exported from `edgar`, and the tree they take was a `BeautifulSoup`. Rather than break that silently in a 5.x release, a soup passed either positionally or as `soup=` is re-parsed with a `DeprecationWarning`; both go in 6.0, and neither is on the path through `filing.homepage`.

The check is `callable(getattr(root, "xpath", None))`, not `hasattr`. A BeautifulSoup answers *any* unknown attribute with the first child tag of that name, or `None` — so `hasattr(soup, "xpath")` is `True`, and the hasattr version let every soup through to fail later inside a selector with `'NoneType' object is not callable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)