### PR TITLE
perf(attachments): parse filing index pages with lxml instead of bs4

### DIFF
--- a/edgar/_index_parsing.py
+++ b/edgar/_index_parsing.py
@@ -1,0 +1,174 @@
+"""
+lxml.html helpers for parsing SEC filing index pages.
+
+Part of the bs4 -> lxml migration (#931, #1102). These helpers adapt lxml's
+API to the find/text idioms the attachment index parser was written against,
+while preserving bs4-compatible behaviour on class attributes and whitespace.
+
+The house rules from edgar/documents/parser.py apply:
+
+- parse with recover=True so broken SEC HTML still yields a tree
+- never remove blank text: a whitespace-only node between two tags is a
+  word boundary ("Yes ☒", "three reportable")
+- strip any XML declaration first: lxml raises ValueError on a str that
+  starts with one (gotcha 4 in the #931 porting guide)
+- empty or unparseable input raises ParserError where bs4 returned an empty
+  soup; callers here translate that to IndexError, matching what the old
+  bs4-based code produced on those inputs
+"""
+
+from typing import List, Optional
+
+import lxml.html
+from lxml.etree import ParserError
+
+from edgar.documents.utils.html_utils import create_lxml_parser, remove_xml_declaration
+
+__all__ = [
+    'parse_index_html',
+    'find_all',
+    'find_one',
+    'element_text',
+    'class_tokens',
+]
+
+
+def parse_index_html(html: str) -> lxml.html.HtmlElement:
+    """
+    Parse an SEC filing index page into an lxml tree.
+
+    Uses the house parser settings (recover=True, remove_blank_text=False)
+    so that malformed filings still parse and whitespace-only text nodes
+    survive as word boundaries.
+    """
+    if html is None:
+        raise IndexError("No HTML content to parse")
+
+    cleaned = remove_xml_declaration(html)
+
+    # Whitespace-only input parsed fine under bs4 (empty soup) and then blew
+    # up downstream with IndexError when nothing could be found. Raise the
+    # same error directly rather than failing later with a ParserError.
+    if not cleaned or not cleaned.strip():
+        raise IndexError("No HTML content to parse")
+
+    try:
+        tree = lxml.html.fromstring(
+            cleaned,
+            parser=create_lxml_parser(remove_comments=False),
+        )
+    except ParserError as e:
+        # bs4 returned an empty soup for unparseable documents and the
+        # callers surfaced that as IndexError on the first lookup.
+        raise IndexError(f"Could not parse index page HTML: {e}") from e
+
+    return tree
+
+
+def _css_escape(value: str) -> str:
+    """Escape a string for use inside an XPath string literal."""
+    if "'" not in value:
+        return f"'{value}'"
+    if '"' not in value:
+        return f'"{value}"'
+    parts = value.split("'")
+    return "concat('" + "', \"'\", '".join(parts) + "')"
+
+
+def _match_predicate(tag: Optional[str], attrs: dict) -> str:
+    """Build an XPath predicate matching tag/attribute constraints."""
+    clauses = []
+    if attrs.get('id') is not None:
+        clauses.append(f"@id={_css_escape(attrs['id'])}")
+    classes = attrs.get('class_')
+    if classes is not None:
+        wanted = classes.split()
+        for cls in wanted:
+            # token test, not substring: class="infoHead" must not match "info"
+            clauses.append(
+                f"contains(concat(' ', normalize-space(@class), ' '), "
+                f"' {_css_escape(cls)[1:-1]} ')"
+                .replace("' '", "' '")  # keep quoting readable
+            )
+    return ' and '.join(clauses)
+
+
+def _xpath_for(tag: Optional[str], attrs: dict) -> str:
+    tag_test = tag if tag else '*'
+    predicate = _match_predicate(tag, attrs)
+    return f".//{tag_test}[{predicate}]" if predicate else f".//{tag_test}"
+
+
+def find_all(element, tag: Optional[str] = None, recursive: bool = True, **attrs) -> List:
+    """
+    Find descendant elements, matching class tokens exactly.
+
+    Mirrors soup.find_all(tag, class_=..., id=..., recursive=...). Class
+    matching is on whole tokens: class="infoHead" does NOT match class_='info'.
+    """
+    xpath = _xpath_for(tag, attrs)
+    if not recursive:
+        xpath = xpath.replace('.//', './', 1)
+    matches = element.xpath(xpath)
+    return list(matches)
+
+
+def find_one(element, tag: Optional[str] = None, **attrs):
+    """
+    Find the first matching descendant element, or None.
+
+    Mirrors soup.find(tag, class_=..., id=...).
+    """
+    matches = find_all(element, tag, **attrs)
+    return matches[0] if matches else None
+
+
+def element_text(element) -> str:
+    """
+    All text under the element, comment nodes excluded.
+
+    Equivalent to soup .text: bs4's .text walks the tree and joins each
+    node's text with the separator between its children preserved as-is,
+    which for HTML tables means the whitespace between cells' inline
+    children is kept. text_content() concatenates raw, so rebuild that
+    join: this element's text, then for every non-comment child its own
+    full subtree text, then the child's tail.
+    """
+    parts = []
+    if element.text:
+        parts.append(element.text)
+    for child in element.iterchildren():
+        if not isinstance(child.tag, str):
+            # Comment / PI nodes: skip the payload but keep the tail, which
+            # is real document text sitting after the comment.
+            if child.tail:
+                parts.append(child.tail)
+            continue
+        # Recurse rather than text_content(): text_content() would swallow
+        # comment payloads (their text counts) and drop nothing else, but
+        # recursing lets us skip comments exactly like bs4 does.
+        parts.append(element_text(child))
+        if child.tail:
+            parts.append(child.tail)
+    return ''.join(parts)
+
+
+def class_tokens(element) -> List[str]:
+    """
+    The element's class attribute as a list of tokens.
+
+    bs4 hands back a list; lxml hands back the raw string. Splitting on
+    whitespace restores list semantics so membership tests stay exact
+    ('info' must not match inside 'infoHead').
+    """
+    value = element.get('class')
+    if not value:
+        return []
+    return value.split()
+
+
+# Aliases used by attachments.py to make call sites read like the old bs4 code
+_find_all = find_all
+_find_one = find_one
+_text = element_text
+_class_tokens = class_tokens

--- a/edgar/attachments.py
+++ b/edgar/attachments.py
@@ -9,7 +9,6 @@ import time
 import warnings
 import webbrowser
 import zipfile
-
 from pathlib import Path
 from threading import Thread
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -20,7 +19,6 @@ if TYPE_CHECKING:
 
 import textwrap
 
-from bs4 import BeautifulSoup
 from pydantic import BaseModel
 from rich import box
 from rich.columns import Columns
@@ -30,8 +28,8 @@ from rich.table import Column, Table
 from rich.text import Text
 
 from edgar.config import SEC_BASE_URL
-from edgar.exceptions import AttachmentNotFoundError
 from edgar.core import binary_extensions, has_html_content, text_extensions
+from edgar.exceptions import AttachmentNotFoundError
 from edgar.files._deprecation import PAGE_BREAK_DEPRECATION
 from edgar.files.html_documents import get_clean_html
 from edgar.files.markdown import to_markdown
@@ -40,6 +38,15 @@ from edgar.httprequests import download_file, download_file_async, get_with_retr
 from edgar.richtools import print_rich, print_xml, repr_rich, rich_to_text
 
 xbrl_document_types = ['XBRL INSTANCE DOCUMENT', 'XBRL INSTANCE FILE', 'EXTRACTED XBRL INSTANCE DOCUMENT']
+
+# lxml.html helpers shared by the attachment index parser (#1102)
+from edgar._index_parsing import (  # noqa: E402
+    _class_tokens,
+    _find_all,
+    _find_one,
+    _text,
+    parse_index_html,
+)
 
 __all__ = ['Attachment', 'Attachments', 'FilingHomepage', 'FilerInfo', 'AttachmentServer', 'sec_document_url', 'get_document_type']
 
@@ -948,11 +955,14 @@ class Attachments:
         return repr_rich(self.__rich__())
 
     @classmethod
-    def load(cls, soup: BeautifulSoup):
+    def load(cls, soup):
         """
         Load the attachments from the SEC filing home page
+
+        Accepts a parsed lxml.html element (or any object exposing an
+        xpath() method). A bs4 soup is no longer accepted.
         """
-        tables = soup.find_all('table', class_='tableFile')
+        tables = _find_all(soup, 'table', class_='tableFile')
 
         def parse_table(table, documents: bool):
             min_seq = None
@@ -960,20 +970,20 @@ class Attachments:
             # Plus additional document with the same sequence number
             primary_documents: List[Attachment] = []
 
-            rows = table.find_all('tr')[1:]  # Skip header row
+            rows = _find_all(table, 'tr')[1:]  # Skip header row
             attachments = []
             for _index, row in enumerate(rows):
-                cols = row.find_all('td')
-                sequence_number = cols[0].text.strip().replace('\xa0', '-')
+                cols = _find_all(row, 'td')
+                sequence_number = _text(cols[0]).strip().replace('\xa0', '-')
 
-                description = cols[1].text.strip()
+                description = _text(cols[1]).strip()
                 # The document text is the text of the document link.
-                document_text = cols[2].text.strip()
+                document_text = _text(cols[2]).strip()
                 document = document_text.split(' ')[0].strip()
                 iXbrl = 'iXBRL' in document_text
-                path = cols[2].a['href'].strip()
-                document_type = cols[3].text.strip()
-                size = cols[4].text.strip()
+                path = cols[2].find('a').get('href').strip()
+                document_type = _text(cols[3]).strip()
+                size = _text(cols[4]).strip()
 
                 try:
                     size = int(size)
@@ -1070,7 +1080,7 @@ class FilingHomepage:
 
     def __init__(self,
                  url: str,
-                 soup: BeautifulSoup,
+                 soup,
                  attachments: Attachments):
         self.attachments = attachments
         self.url = url
@@ -1118,17 +1128,17 @@ class FilingHomepage:
     def get_filers(self):
         if hasattr(self, '_cached_filers'):
             return self._cached_filers
-        filer_divs = self._soup.find_all("div", id="filerDiv")
+        filer_divs = _find_all(self._soup, "div", id="filerDiv")
         filer_infos = []
         for filer_div in filer_divs:
 
             # Get the company name
-            company_info_div = filer_div.find("div", class_="companyInfo")
+            company_info_div = _find_one(filer_div, "div", class_="companyInfo")
 
-            company_name_span = company_info_div.find("span", class_="companyName")
+            company_name_span = _find_one(company_info_div, "span", class_="companyName")
 
             if company_name_span:
-                full_text = company_name_span.text.strip()
+                full_text = _text(company_name_span).strip()
                 # Split the text into company name and CIK
                 parts = full_text.split('CIK: ')
                 company_name = parts[0].strip()
@@ -1141,16 +1151,16 @@ class FilingHomepage:
                 cik = ""
 
             # Get the identification information
-            ident_info_div = company_info_div.find("p", class_="identInfo")
+            ident_info_div = _find_one(company_info_div, "p", class_="identInfo")
 
             # Replace <br> with newlines
-            for br in ident_info_div.find_all("br"):
-                br.replace_with("\n")
+            for br in ident_info_div.iter("br"):
+                br.tail = "\n" + (br.tail or "")
 
-            identification = ident_info_div.text
+            identification = _text(ident_info_div)
 
             # Get the mailing information
-            mailer_divs = filer_div.find_all("div", class_="mailer")
+            mailer_divs = _find_all(filer_div, "div", class_="mailer")
             # For each mailed_div.text remove multiple spaces after a newline
 
             addresses = [re.sub(r'\n\s+', '\n', mailer_div.text.strip())
@@ -1174,7 +1184,7 @@ class FilingHomepage:
         if hasattr(self, '_cached_filing_dates'):
             return self._cached_filing_dates
         # Find the form grouping divs
-        grouping_divs = self._soup.find_all("div", class_="formGrouping")
+        grouping_divs = _find_all(self._soup, "div", class_="formGrouping")
         if len(grouping_divs) == 0:
             return None
 
@@ -1186,16 +1196,16 @@ class FilingHomepage:
         # period of report, which then crashes downstream isoformat parsers.
         label_to_value: Dict[str, str] = {}
         for grouping in grouping_divs:
-            children = [c for c in grouping.find_all("div", recursive=False)
-                        if c.get("class")]
+            children = [c for c in _find_all(grouping, "div", recursive=False)
+                        if _class_tokens(c)]
             current_label: Optional[str] = None
             for child in children:
-                classes = child.get("class") or []
+                classes = _class_tokens(child)
                 if "infoHead" in classes:
-                    current_label = child.text.strip().lower()
+                    current_label = _text(child).strip().lower()
                 elif "info" in classes and current_label is not None:
                     # Only keep the first value for each label.
-                    label_to_value.setdefault(current_label, child.text.strip())
+                    label_to_value.setdefault(current_label, _text(child).strip())
                     current_label = None
 
         filing_date = label_to_value.get("filing date")
@@ -1205,11 +1215,11 @@ class FilingHomepage:
         # Fall back to the legacy positional layout if the label-based lookup
         # missed either of the always-present date fields.
         if filing_date is None or accepted_date is None:
-            info_divs = grouping_divs[0].find_all("div", class_="info")
+            info_divs = _find_all(grouping_divs[0], "div", class_="info")
             if filing_date is None and len(info_divs) >= 1:
-                filing_date = info_divs[0].text.strip()
+                filing_date = _text(info_divs[0]).strip()
             if accepted_date is None and len(info_divs) >= 2:
-                accepted_date = info_divs[1].text.strip()
+                accepted_date = _text(info_divs[1]).strip()
 
         result = filing_date, accepted_date, period
         self._cached_filing_dates = result
@@ -1218,7 +1228,7 @@ class FilingHomepage:
     @classmethod
     def load(cls, url: str):
         response = get_with_retry(url)
-        soup = BeautifulSoup(response.text, 'html.parser')
+        soup = parse_index_html(response.text)
         attachments = Attachments.load(soup)
         return cls(url, soup, attachments)
 

--- a/tests/fixtures/attachments/indexes/apple-10q-index.html
+++ b/tests/fixtures/attachments/indexes/apple-10q-index.html
@@ -1,0 +1,233 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 02 May 2025 10:00:46 GMT" />
+<title>EDGAR Filing Documents for 0000320193-25-000057</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 10-Q</strong> - Quarterly report [Sections 13 or 15(d)]: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0000320193-25-000057
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2025-05-02</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2025-05-02 06:00:46</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">60</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2025-03-29</div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+   <div style="padding: 4px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden" id="seriesDiv">
+      <a href="/cgi-bin/viewer?action=view&amp;cik=320193&amp;accession_number=0000320193-25-000057&amp;xbrl_type=v" id="interactiveDataBtn">&nbsp;<button type="button" class="btn btn-primary">Interactive Data</button></a>
+   </div>
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">10-Q</td>
+            <td scope="row"><a href="/ix?doc=/Archives/edgar/data/320193/000032019325000057/aapl-20250329.htm">aapl-20250329.htm</a> &nbsp;&nbsp;<span style="color: green">iXBRL</span></td>
+            <td scope="row">10-Q</td>
+            <td scope="row">889977</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row">EX-31.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/a10-qexhibit31103292025.htm">a10-qexhibit31103292025.htm</a></td>
+            <td scope="row">EX-31.1</td>
+            <td scope="row">10524</td>
+         </tr>
+         <tr>
+            <td scope="row">3</td>
+            <td scope="row">EX-31.2</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/a10-qexhibit31203292025.htm">a10-qexhibit31203292025.htm</a></td>
+            <td scope="row">EX-31.2</td>
+            <td scope="row">10563</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">4</td>
+            <td scope="row">EX-32.1</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/a10-qexhibit32103292025.htm">a10-qexhibit32103292025.htm</a></td>
+            <td scope="row">EX-32.1</td>
+            <td scope="row">8356</td>
+         </tr>
+         <tr>
+            <td scope="row">10</td>
+            <td scope="row"></td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_g1.jpg">aapl-20250329_g1.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">10963</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/0000320193-25-000057.txt">0000320193-25-000057.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">5299807</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Data Files</p>
+      <table class="tableFile" summary="Data Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">5</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION SCHEMA DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329.xsd">aapl-20250329.xsd</a></td>
+            <td scope="row">EX-101.SCH</td>
+            <td scope="row">33865</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">6</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION CALCULATION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_cal.xml">aapl-20250329_cal.xml</a></td>
+            <td scope="row">EX-101.CAL</td>
+            <td scope="row">75630</td>
+         </tr>
+         <tr>
+            <td scope="row">7</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION DEFINITION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_def.xml">aapl-20250329_def.xml</a></td>
+            <td scope="row">EX-101.DEF</td>
+            <td scope="row">153714</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">8</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION LABEL LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_lab.xml">aapl-20250329_lab.xml</a></td>
+            <td scope="row">EX-101.LAB</td>
+            <td scope="row">494720</td>
+         </tr>
+         <tr>
+            <td scope="row">9</td>
+            <td scope="row">XBRL TAXONOMY EXTENSION PRESENTATION LINKBASE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_pre.xml">aapl-20250329_pre.xml</a></td>
+            <td scope="row">EX-101.PRE</td>
+            <td scope="row">315516</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">63</td>
+            <td scope="row"><b>EXTRACTED</b> XBRL INSTANCE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/320193/000032019325000057/aapl-20250329_htm.xml">aapl-20250329_htm.xml</a></td>
+            <td scope="row">XML</td>
+            <td scope="row">758005</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">ONE APPLE PARK WAY</span>
+      <span class="mailerAddress">
+CUPERTINO       <span class="mailerAddress">CA</span>
+95014      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">ONE APPLE PARK WAY</span>
+      <span class="mailerAddress">
+CUPERTINO       <span class="mailerAddress">CA</span>
+95014      </span>
+      <span class="mailerAddress">(408) 996-1010</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">Apple Inc. (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0000320193&amp;action=getcompany">0000320193 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>942404110</strong> | State of Incorp.: <strong>CA</strong> | Fiscal Year End: <strong>0927</strong><br />Type: <strong>10-Q</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=001-36743&amp;action=getcompany"><strong>001-36743</strong></a> | Film No.: <strong>25905357</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=3571&amp;owner=include">3571</a></b> Electronic Computers<br />(CF Office: 06 Technology)</p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/fixtures/attachments/indexes/fund-485-index.html
+++ b/tests/fixtures/attachments/indexes/fund-485-index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Last-Modified" content="Fri, 19 Jan 2024 21:21:45 GMT" />
+<title>EDGAR Filing Documents for 0001213900-24-004875</title>
+<link  rel="stylesheet" href="/edgar/search/global/css/bootstrap/bootstrap.min.css" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/include/interactive2.css" />
+</head>
+<body style="margin: 0; font-size: 16px; ">
+<!-- SEC Web Analytics - For information please visit: https://www.sec.gov/privacy.htm#collectedinfo -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TD3BKV"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TD3BKV');</script>
+<!-- End SEC Web Analytics -->
+<noscript><div style="color:red; font-weight:bold; text-align:center;">This page uses Javascript. Your browser either doesn't support Javascript or you have it turned off. To see this page as it is meant to appear please use a Javascript enabled browser.</div></noscript>
+<!-- BEGIN BANNER -->
+<div  id="header" style="text-align: center;">
+   <nav id="main-navbar" class="navbar navbar-expand">
+      <ul class="navbar-nav">
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <img src="/edgar/search/images/edgar-logo-2x.png" alt="" style="height:6.25rem">
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__sec_link" href="https://www.sec.gov">
+               <span class="link-text d-inline">SEC.gov</span>
+            </a>
+         </li>
+         <li class="nav-item">
+            <a class="nav__link" href="//www.sec.gov/submit-filings/about-edgar" id="edgar-short-form"><span class="link-text">EDGAR</span></a>
+         </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+         <li class="nav-item">
+			<a href="/cgi-bin/browse-edgar?action=getcurrent" class="nav__link">Latest Filings</a> 
+         </li>
+         <li class="nav-item">
+            <a href="https://www.sec.gov/edgar/search-and-access" class="nav__link">Filings search tools</a>
+         </li>
+      </ul>
+   </nav>
+   <div style="position: absolute;width: 100%;"> <h1 style="position: relative;top: -60px;">Filing Detail</h1></div>
+</div>
+<!-- END BANNER -->
+
+
+<!-- BEGIN BREADCRUMBS -->
+<div id="breadCrumbs">
+   <ul>
+      <li><a href="/index.htm">SEC Home</a> &#187;</li>
+      <li><a href="/edgar/searchedgar/companysearch.html">Company Search</a> &#187;</li>
+      <li class="last">Current Page</li>
+   </ul>
+</div>
+<!-- END BREADCRUMBS -->
+
+<div id="contentDiv">
+<!-- START FILING DIV -->
+<div class="formDiv">
+   <div id="formHeader">
+      <div id="formName">
+         <strong>Form 8-K</strong> - Current report: 
+      </div>
+      <div id="secNum">
+         <strong><acronym title="Securities and Exchange Commission">SEC</acronym> Accession <acronym title="Number">No.</acronym></strong> 0001213900-24-004875
+      </div>
+   </div>
+   <div class="formContent">
+   
+      <div class="formGrouping">
+         <div class="infoHead">Filing Date</div>
+         <div class="info">2024-01-19</div>
+         <div class="infoHead">Accepted</div>
+         <div class="info">2024-01-19 16:21:45</div>
+         <div class="infoHead">Documents</div>
+         <div class="info">22</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Period of Report</div>
+         <div class="info">2024-01-16</div>
+      </div>
+      <div class="formGrouping">
+         <div class="infoHead">Items</div>
+         <div class="info">Item 1.01: Entry into a Material Definitive Agreement<br />Item 8.01: Other Events<br />Item 9.01: Financial Statements and Exhibits<br /></div>
+      </div>
+      <div style="clear:both"></div>
+<!-- END FILING DIV -->
+<!-- START DOCUMENT DIV -->
+   <div style="padding: 4px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden" id="seriesDiv">
+      <a href="/cgi-bin/viewer?action=view&amp;cik=1648960&amp;accession_number=0001213900-24-004875&amp;xbrl_type=v" id="interactiveDataBtn">&nbsp;<button type="button" class="btn btn-primary">Interactive Data</button></a>
+   </div>
+  </div>
+    </div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Document Format Files</p>
+      <table class="tableFile" summary="Document Format Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">1</td>
+            <td scope="row">CURRENT REPORT</td>
+            <td scope="row"><a href="/ix?doc=/Archives/edgar/data/1648960/000121390024004875/ea191807-8k_datchat.htm">ea191807-8k_datchat.htm</a> &nbsp;&nbsp;<span style="color: green">iXBRL</span></td>
+            <td scope="row">8-K</td>
+            <td scope="row">47202</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">2</td>
+            <td scope="row">UNDERWRITING AGREEMENT DATED JANUARY 16, 2024 BETWEEN DATCHAT, INC. AND EF HUTTO</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807ex1-1_datchat.htm">ea191807ex1-1_datchat.htm</a></td>
+            <td scope="row">EX-1.1</td>
+            <td scope="row">404518</td>
+         </tr>
+         <tr>
+            <td scope="row">3</td>
+            <td scope="row">OPINION OF SHEPPARD MULLIN RICHTER &amp; HAMPTON LLP</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807ex5-1_datchat.htm">ea191807ex5-1_datchat.htm</a></td>
+            <td scope="row">EX-5.1</td>
+            <td scope="row">15277</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">4</td>
+            <td scope="row">PRESS RELEASE DATED JANUARY 16, 2024</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807ex99-1_datchat.htm">ea191807ex99-1_datchat.htm</a></td>
+            <td scope="row">EX-99.1</td>
+            <td scope="row">9363</td>
+         </tr>
+         <tr>
+            <td scope="row">5</td>
+            <td scope="row">PRESS RELEASE DATED JANUARY 17, 2024</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807ex99-2_datchat.htm">ea191807ex99-2_datchat.htm</a></td>
+            <td scope="row">EX-99.2</td>
+            <td scope="row">9379</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">6</td>
+            <td scope="row">PRESS RELEASE DATED JANUARY 19, 2024</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807ex99-3_datchat.htm">ea191807ex99-3_datchat.htm</a></td>
+            <td scope="row">EX-99.3</td>
+            <td scope="row">11179</td>
+         </tr>
+         <tr>
+            <td scope="row">7</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ex5-1_001.jpg">ex5-1_001.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">6846</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">8</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ex99-1_001.jpg">ex99-1_001.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">14543</td>
+         </tr>
+         <tr>
+            <td scope="row">9</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ex99-2_001.jpg">ex99-2_001.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">14543</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">10</td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ex99-3_001.jpg">ex99-3_001.jpg</a></td>
+            <td scope="row">GRAPHIC</td>
+            <td scope="row">10894</td>
+         </tr>
+         <tr>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">Complete submission text file</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/0001213900-24-004875.txt">0001213900-24-004875.txt</a></td>
+            <td scope="row">&nbsp;</td>
+            <td scope="row">899769</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<div class="formDiv">
+   <div style="padding: 0px 0px 4px 0px; font-size: 12px; margin: 0px 2px 0px 5px; width: 100%; overflow:hidden">
+      <p>Data Files</p>
+      <table class="tableFile" summary="Data Files">
+         <tr>
+            <th scope="col" style="width: 5%;"><acronym title="Sequence Number">Seq</acronym></th>
+            <th scope="col" style="width: 40%;">Description</th>
+            <th scope="col" style="width: 20%;">Document</th>
+            <th scope="col" style="width: 10%;">Type</th>
+            <th scope="col">Size</th>
+         </tr>
+         <tr>
+            <td scope="row">11</td>
+            <td scope="row">XBRL SCHEMA FILE</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/dats-20240116.xsd">dats-20240116.xsd</a></td>
+            <td scope="row">EX-101.SCH</td>
+            <td scope="row">3837</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">12</td>
+            <td scope="row">XBRL DEFINITION FILE</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/dats-20240116_def.xml">dats-20240116_def.xml</a></td>
+            <td scope="row">EX-101.DEF</td>
+            <td scope="row">26724</td>
+         </tr>
+         <tr>
+            <td scope="row">13</td>
+            <td scope="row">XBRL LABEL FILE</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/dats-20240116_lab.xml">dats-20240116_lab.xml</a></td>
+            <td scope="row">EX-101.LAB</td>
+            <td scope="row">36916</td>
+         </tr>
+         <tr class="evenRow">
+            <td scope="row">14</td>
+            <td scope="row">XBRL PRESENTATION FILE</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/dats-20240116_pre.xml">dats-20240116_pre.xml</a></td>
+            <td scope="row">EX-101.PRE</td>
+            <td scope="row">25348</td>
+         </tr>
+         <tr>
+            <td scope="row">16</td>
+            <td scope="row"><b>EXTRACTED</b> XBRL INSTANCE DOCUMENT</td>
+            <td scope="row"><a href="/Archives/edgar/data/1648960/000121390024004875/ea191807-8k_datchat_htm.xml">ea191807-8k_datchat_htm.xml</a></td>
+            <td scope="row">XML</td>
+            <td scope="row">5413</td>
+         </tr>
+      </table>	
+   </div>
+</div>
+<!-- END DOCUMENT DIV -->
+<!-- START FILER DIV -->
+<div class="filerDiv">
+   <div class="mailer">Mailing Address
+      <span class="mailerAddress">204 NIELSON STREET</span>
+      <span class="mailerAddress">1ST FLOOR</span>
+      <span class="mailerAddress">
+NEW BRUNSWICK       <span class="mailerAddress">NJ</span>
+08901      </span>
+   </div>
+   <div class="mailer">Business Address
+      <span class="mailerAddress">204 NIELSON STREET</span>
+      <span class="mailerAddress">1ST FLOOR</span>
+      <span class="mailerAddress">
+NEW BRUNSWICK       <span class="mailerAddress">NJ</span>
+08901      </span>
+      <span class="mailerAddress">732-374-3529</span>
+   </div>
+<div class="companyInfo">
+  <span class="companyName">DatChat, Inc. (Filer)
+ <acronym title="Central Index Key">CIK</acronym>: <a href="/cgi-bin/browse-edgar?CIK=0001648960&amp;action=getcompany">0001648960 (see all company filings)</a></span>
+<p class="identInfo"><acronym title="Internal Revenue Service Number">EIN.</acronym>: <strong>472502264</strong> | State of Incorp.: <strong>NV</strong> | Fiscal Year End: <strong>1231</strong><br />Type: <strong>8-K</strong> | Act: <strong>34</strong> | File No.: <a href="/cgi-bin/browse-edgar?filenum=001-40729&amp;action=getcompany"><strong>001-40729</strong></a> | Film No.: <strong>24545873</strong><br /><acronym title="Standard Industrial Code">SIC</acronym>: <b><a href="/cgi-bin/browse-edgar?action=getcompany&amp;SIC=4822&amp;owner=include">4822</a></b> Telegraph &amp; Other Message Communications<br />(CF Office: 06 Technology)</p>
+</div>
+<div class="clear"></div>
+</div>
+<!-- END FILER DIV -->
+</div>

--- a/tests/issues/regression/test_issue_sc13g_period_of_report.py
+++ b/tests/issues/regression/test_issue_sc13g_period_of_report.py
@@ -13,15 +13,15 @@ GitHub PR: https://github.com/dgunning/edgartools/pull/787
 """
 
 import pytest
-from bs4 import BeautifulSoup
 
+from edgar._index_parsing import parse_index_html
 from edgar.attachments import Attachments, FilingHomepage
 
 pytestmark = pytest.mark.fast
 
 
 def _homepage_from_html(html: str) -> FilingHomepage:
-    soup = BeautifulSoup(html, "html.parser")
+    soup = parse_index_html(html)
     # Attachments is irrelevant for these tests; pass an empty instance.
     attachments = Attachments(document_files=[], data_files=[], primary_documents=[])
     return FilingHomepage(url="http://example/index.html", soup=soup, attachments=attachments)

--- a/tests/test_attachments_characterization.py
+++ b/tests/test_attachments_characterization.py
@@ -17,8 +17,8 @@ port must keep these green unchanged.
 """
 
 import pytest
-from bs4 import BeautifulSoup
 
+from edgar._index_parsing import parse_index_html
 from edgar.attachments import Attachment, Attachments, FilingHomepage
 
 pytestmark = pytest.mark.fast
@@ -31,7 +31,7 @@ def _soup(name):
         html = Path(name).read_text()
     else:
         html = Path(f"tests/fixtures/attachments/indexes/{name}").read_text()
-    return BeautifulSoup(html, "html.parser")
+    return parse_index_html(html)
 
 
 def _load(name):

--- a/tests/test_attachments_characterization.py
+++ b/tests/test_attachments_characterization.py
@@ -1,0 +1,158 @@
+"""
+Characterization tests for edgar.attachments (bs4 behaviour, pre-lxml port).
+
+Pins Attachments.load() and FilingHomepage filer/date extraction on real SEC
+filing index pages before the bs4 -> lxml.html port (#1102, part of #931).
+
+Fixtures:
+- tests/fixtures/attachments/indexes/apple-10q-index.html : 10-Q, iXBRL primary
+  doc, GRAPHIC rows, complete-submission row, 6-file XBRL datafiles table
+- tests/fixtures/attachments/indexes/fund-485-index.html  : 8-K with exhibits,
+  graphics and a 5-file XBRL datafiles table
+- data/troweprice.DEF14A.html                             : single-form proxy
+  statement, no datafiles table, 66 filer divs
+
+Every pinned value below is the observed output of the current bs4 code; the
+port must keep these green unchanged.
+"""
+
+import pytest
+from bs4 import BeautifulSoup
+
+from edgar.attachments import Attachment, Attachments, FilingHomepage
+
+pytestmark = pytest.mark.fast
+
+
+def _soup(name):
+    from pathlib import Path
+
+    if name.startswith("data/"):
+        html = Path(name).read_text()
+    else:
+        html = Path(f"tests/fixtures/attachments/indexes/{name}").read_text()
+    return BeautifulSoup(html, "html.parser")
+
+
+def _load(name):
+    return Attachments.load(_soup(name))
+
+
+def _homepage(name):
+    soup = _soup(name)
+    return FilingHomepage(url="http://x/index.html", soup=soup,
+                          attachments=Attachments.load(soup))
+
+
+# --- Attachments.load: document table ---------------------------------------
+
+def test_apple_10q_documents_pinned():
+    atts = _load("apple-10q-index.html")
+    assert [(a.sequence_number, a.description, a.document, a.ixbrl,
+             a.document_type, a.size) for a in atts.documents] == [
+        ("1", "10-Q", "aapl-20250329.htm", True, "10-Q", 889977),
+        ("2", "EX-31.1", "a10-qexhibit31103292025.htm", False, "EX-31.1", 10524),
+        ("3", "EX-31.2", "a10-qexhibit31203292025.htm", False, "EX-31.2", 10563),
+        ("4", "EX-32.1", "a10-qexhibit32103292025.htm", False, "EX-32.1", 8356),
+        ("10", "", "aapl-20250329_g1.jpg", False, "GRAPHIC", 10963),
+        ("", "Complete submission text file", "0000320193-25-000057.txt",
+         False, "", 5299807),
+    ]
+    assert isinstance(atts.documents[0], Attachment)
+    assert atts.documents[0].path == (
+        "/ix?doc=/Archives/edgar/data/320193/000032019325000057/"
+        "aapl-20250329.htm")
+
+
+def test_fund_485_documents_pinned():
+    atts = _load("fund-485-index.html")
+    docs = atts.documents
+    assert len(docs) == 11
+    assert docs[0].sequence_number == "1"
+    assert docs[0].document == "ea191807-8k_datchat.htm"
+    assert docs[0].ixbrl is True
+    assert docs[0].description == "CURRENT REPORT"
+    # Graphics keep their sequence numbers; the .txt row has none.
+    assert [a.sequence_number for a in docs][-4:] == ["8", "9", "10", ""]
+    assert docs[-1].document == "0001213900-24-004875.txt"
+    assert docs[-1].description == "Complete submission text file"
+
+
+def test_troweprice_single_form_proxy():
+    atts = _load("data/troweprice.DEF14A.html")
+    assert [(a.sequence_number, a.document, a.document_type, a.size)
+            for a in atts.documents] == [
+        ("1", "def14a.htm", "DEF 14A", 45348),
+        ("2", "img_6aeea0a435944f2.jpg", "GRAPHIC", 10846),
+        ("3", "img_9b20722f57ea4f2.jpg", "GRAPHIC", 9313),
+        ("4", "img_b79bea2c076a4f3.jpg", "GRAPHIC", 10846),
+        ("5", "img_ba5aa2940cb64f3.jpg", "GRAPHIC", 9313),
+        ("", "0001741773-23-002051.txt", "", 256875),
+    ]
+
+
+def test_primary_documents_share_minimum_sequence():
+    for name in ["apple-10q-index.html", "fund-485-index.html",
+                 "data/troweprice.DEF14A.html"]:
+        atts = _load(name)
+        seqs = [a.sequence_number for a in atts.primary_documents]
+        assert seqs == ["1"]
+
+
+# --- Attachments.load: datafiles table --------------------------------------
+
+def test_apple_10q_datafiles_pinned():
+    atts = _load("apple-10q-index.html")
+    assert [(a.sequence_number, a.document, a.document_type, a.size)
+            for a in atts.data_files] == [
+        ("5", "aapl-20250329.xsd", "EX-101.SCH", 33865),
+        ("6", "aapl-20250329_cal.xml", "EX-101.CAL", 75630),
+        ("7", "aapl-20250329_def.xml", "EX-101.DEF", 153714),
+        ("8", "aapl-20250329_lab.xml", "EX-101.LAB", 494720),
+        ("9", "aapl-20250329_pre.xml", "EX-101.PRE", 315516),
+        ("63", "aapl-20250329_htm.xml", "XML", 758005),
+    ]
+
+
+def test_fund_485_datafiles_pinned():
+    atts = _load("fund-485-index.html")
+    assert [(a.sequence_number, a.document, a.document_type)
+            for a in atts.data_files] == [
+        ("11", "dats-20240116.xsd", "EX-101.SCH"),
+        ("12", "dats-20240116_def.xml", "EX-101.DEF"),
+        ("13", "dats-20240116_lab.xml", "EX-101.LAB"),
+        ("14", "dats-20240116_pre.xml", "EX-101.PRE"),
+        ("16", "ea191807-8k_datchat_htm.xml", "XML"),
+    ]
+
+
+def test_troweprice_has_no_datafiles_table():
+    assert _load("data/troweprice.DEF14A.html").data_files is None
+
+
+# --- FilingHomepage.get_filing_dates ----------------------------------------
+
+def test_apple_10q_filing_dates():
+    assert _homepage("apple-10q-index.html").get_filing_dates() == (
+        "2025-05-02", "2025-05-02 06:00:46", "2025-03-29")
+
+
+def test_fund_485_filing_dates():
+    assert _homepage("fund-485-index.html").get_filing_dates() == (
+        "2024-01-19", "2024-01-19 16:21:45", "2024-01-16")
+
+
+def test_troweprice_filing_dates():
+    assert _homepage("data/troweprice.DEF14A.html").get_filing_dates() == (
+        "2023-06-16", "2023-06-16 12:18:40", "2023-07-24")
+
+
+# --- FilingHomepage.get_filers ----------------------------------------------
+
+def test_troweprice_66_filers_first_is_management_company():
+    filers = _homepage("data/troweprice.DEF14A.html").get_filers()
+    assert len(filers) == 66
+    first = filers[0]
+    assert first.company_name == "T. Rowe Price Small-Cap Stock Fund, Inc."
+    assert first.cik == "0000075170"
+    assert first.identification.startswith("IRS No.: 231622210")


### PR DESCRIPTION
Closes #1102. Part of the bs4 → lxml migration program (#931).

## What changed

- **New `edgar/_index_parsing.py`**: the house parser settings (`recover=True`, `remove_blank_text=False`, XML declaration stripped via `remove_xml_declaration`) plus small find/text helpers that keep bs4 semantics:
  - class matching is on **whole tokens** (XPath `concat(' ', @class, ' ')` trick), so `class="infoHead"` does not match `class_='info'` — the string-vs-list API false friend from gotcha 6
  - `element_text()` skips comment payloads exactly like bs4's `.text`, and preserves tails
  - empty/whitespace input raises `IndexError`, matching what the old code produced downstream on an empty soup (gotcha 5)
- `Attachments.load(soup)` and `FilingHomepage(soup=...)` now take a parsed lxml tree; `FilingHomepage.load(url)` parses with the house parser
- identInfo `<br>` newline handling sets tail text instead of `replace_with`, which lxml does not support
- The sc13g multi-filer regression test's fixture builder moved to the same helper (caller adjustment per the issue)

## Proof nothing changed

Characterization tests written **before** the port (`4a9d3dc`), pinning document tables, XBRL datafiles tables, filer extraction and filing dates on three real index pages:

| fixture | covers |
|---|---|
| apple 10-Q index | iXBRL primary doc, GRAPHIC rows, complete-submission row, 6-file datafiles table |
| fund 485 (8-K) index | exhibits, graphics, 5-file datafiles table |
| T. Rowe Price DEF 14A | single-form proxy, no datafiles, **66 filer divs** |

All green unchanged after the swap, plus the sc13g multi-filer regression suite and `test_filing.py`.

Full fast suite: 5578 passed, 13 failed — the same-by-name set that fails on pristine `main` on this Windows box (network-marked filing-text baselines + two file-lock tests), verified before any edits.

## Measured

Full caller path (parse + Attachments + get_filers + get_filing_dates), median of 200 runs per page:

| page | before (bs4) | after (lxml) | speedup | peak allocation |
|---|---|---|---|---|
| apple 10-Q index | 16.9 ms | 1.6 ms | **10.7x** | 22x less |
| fund 485 index | 20.1 ms | 1.9 ms | **10.4x** | 22x less |
| troweprice DEF 14A (66 filers) | 657.4 ms | 29.6 ms | **22.2x** | 30x less |

Memory measured with tracemalloc peak alongside wall time, since this path runs for every filing.