### PR TITLE
fix(xbrl): suppress low-confidence fuzzy matches onto total concepts

### DIFF
--- a/edgar/xbrl/standardization/reverse_index.py
+++ b/edgar/xbrl/standardization/reverse_index.py
@@ -54,6 +54,17 @@ def _is_total_concept(standard_concept: str) -> bool:
     return standard_concept in _TOTAL_CONCEPT_IDS or 'Total' in standard_concept
 
 
+def _is_low_confidence_total_mapping(xbrl_tag: str, entry: dict) -> bool:
+    """True for a non-canonical fuzzy mapping whose candidates are all totals."""
+    standard_tags = entry.get("standard_tags", [])
+    return (
+        entry.get("confidence", 1.0) < LOW_CONFIDENCE_TOTAL_FLOOR
+        and bool(standard_tags)
+        and xbrl_tag not in standard_tags
+        and all(_is_total_concept(tag) for tag in standard_tags)
+    )
+
+
 @dataclass
 class MappingResult:
     """Result of a reverse index lookup."""
@@ -148,6 +159,14 @@ class ReverseIndex:
 
         # Build the reverse index
         self._index: Dict[str, dict] = self._gaap_mappings
+
+        # Suppression depends only on the generated base mappings. In particular,
+        # a high-confidence industry override must not revive a fuzzy total match.
+        self._suppressed_total_mappings: Set[str] = {
+            tag
+            for tag, entry in self._index.items()
+            if isinstance(entry, dict) and _is_low_confidence_total_mapping(tag, entry)
+        }
 
         # Cache for normalized lookups (strips namespace prefixes)
         self._normalized_cache: Dict[str, str] = {}
@@ -287,42 +306,18 @@ class ReverseIndex:
             return None
 
         # Apply industry overrides if industry is known
-        if industry and isinstance(entry, dict):
+        if industry:
             entry = self._apply_industry_override(entry, industry)
+
+        if normalized in self._suppressed_total_mappings:
+            logger.debug("Suppressed low-confidence total mapping for %s", xbrl_tag)
+            return None
 
         # Extract data from entry
         standard_tags = entry.get("standard_tags", [])
         is_ambiguous = entry.get("ambiguous", False)
         deprecated = entry.get("deprecated")
         comment = entry.get("comment")
-
-        # Low-confidence fuzzy matches onto total concepts are not
-        # authoritative (GitHub #914): on a bank balance sheet,
-        # BankOwnedLifeInsurance resolved to 'Assets', so
-        # standard_concept == 'Assets' matched line items worth tens of
-        # billions alongside the real TOTAL ASSETS row. gaap_mappings.json
-        # is generated upstream and hand edits would not survive
-        # regeneration, so the authority judgement belongs here in the
-        # consumer: below the floor, a mapping whose candidates are all
-        # total concepts is suppressed outright. The confidence
-        # distribution measured in #914 is cleanly split - colliding rows
-        # all sat at 0.307-0.319, nothing between 0.5 and 0.9 collided -
-        # so the floor clears every reproducible case while the mid-band
-        # (harmless, context-disambiguated) and canonical mappings are
-        # untouched. Missing confidence means no signal: keep the mapping.
-        entry_confidence = entry.get('confidence', 1.0) if isinstance(entry, dict) else 1.0
-        if (
-            isinstance(entry, dict)
-            and entry_confidence < LOW_CONFIDENCE_TOTAL_FLOOR
-            and standard_tags
-            and all(_is_total_concept(tag) for tag in standard_tags)
-        ):
-            logger.debug(
-                "Suppressed low-confidence total mapping for %s "
-                "(confidence=%.3f, candidates=%s)",
-                xbrl_tag, entry_confidence, standard_tags
-            )
-            return None
 
         # Resolve display names: prefer embedded display_name, then display_names.json, then concept name
         display_names = []
@@ -457,7 +452,7 @@ class ReverseIndex:
             # Phase 4: Special case - if is_total is True (from context or entry), prefer "Total" concepts
             if is_total or entry_is_total:
                 for candidate in candidates:
-                    if 'total' in candidate.lower():
+                    if _is_total_concept(candidate):
                         logger.debug(
                             "Disambiguated %s to %s (is_total=True)",
                             xbrl_tag, candidate

--- a/edgar/xbrl/standardization/reverse_index.py
+++ b/edgar/xbrl/standardization/reverse_index.py
@@ -28,6 +28,31 @@ from .exclusions import should_exclude, EXCLUDED_TAGS
 
 logger = logging.getLogger(__name__)
 
+# Below this confidence a mapping whose candidates are all total concepts is
+# suppressed (GitHub #914). The colliding rows measured in #914 sit at
+# 0.307-0.319; nothing between 0.5 and 0.9 collided in a 65-filing sample.
+LOW_CONFIDENCE_TOTAL_FLOOR = 0.5
+
+# Concept ids that name an aggregate rather than a line item. A fuzzy match
+# onto one of these from a non-total tag is the #914 failure shape.
+_TOTAL_CONCEPT_IDS = {
+    'Assets',
+    'Liabilities',
+    'CommonEquity',
+    'AllEquityBalance',
+    'AllEquityBalanceIncludingMinorityInterest',
+    'LiabilitiesAndEquity',
+    'CurrentAssetsTotal',
+    'NonCurrentAssetsTotal',
+    'CurrentLiabilitiesTotal',
+    'NonCurrentLiabilitiesTotal',
+}
+
+
+def _is_total_concept(standard_concept: str) -> bool:
+    """True if the concept id names an aggregate (total) rather than a line item."""
+    return standard_concept in _TOTAL_CONCEPT_IDS or 'Total' in standard_concept
+
 
 @dataclass
 class MappingResult:
@@ -270,6 +295,34 @@ class ReverseIndex:
         is_ambiguous = entry.get("ambiguous", False)
         deprecated = entry.get("deprecated")
         comment = entry.get("comment")
+
+        # Low-confidence fuzzy matches onto total concepts are not
+        # authoritative (GitHub #914): on a bank balance sheet,
+        # BankOwnedLifeInsurance resolved to 'Assets', so
+        # standard_concept == 'Assets' matched line items worth tens of
+        # billions alongside the real TOTAL ASSETS row. gaap_mappings.json
+        # is generated upstream and hand edits would not survive
+        # regeneration, so the authority judgement belongs here in the
+        # consumer: below the floor, a mapping whose candidates are all
+        # total concepts is suppressed outright. The confidence
+        # distribution measured in #914 is cleanly split - colliding rows
+        # all sat at 0.307-0.319, nothing between 0.5 and 0.9 collided -
+        # so the floor clears every reproducible case while the mid-band
+        # (harmless, context-disambiguated) and canonical mappings are
+        # untouched. Missing confidence means no signal: keep the mapping.
+        entry_confidence = entry.get('confidence', 1.0) if isinstance(entry, dict) else 1.0
+        if (
+            isinstance(entry, dict)
+            and entry_confidence < LOW_CONFIDENCE_TOTAL_FLOOR
+            and standard_tags
+            and all(_is_total_concept(tag) for tag in standard_tags)
+        ):
+            logger.debug(
+                "Suppressed low-confidence total mapping for %s "
+                "(confidence=%.3f, candidates=%s)",
+                xbrl_tag, entry_confidence, standard_tags
+            )
+            return None
 
         # Resolve display names: prefer embedded display_name, then display_names.json, then concept name
         display_names = []

--- a/tests/issues/regression/test_issue_914_total_false_matches.py
+++ b/tests/issues/regression/test_issue_914_total_false_matches.py
@@ -1,0 +1,92 @@
+"""
+Regression tests for GitHub issue #914.
+
+Line-item tags whose only mapping is a low-confidence fuzzy match onto a
+canonical total concept (Assets, Liabilities, CommonEquity, ...) must not
+resolve as that total. On a bank balance sheet this made
+``standard_concept == 'Assets'`` return three rows: the real TOTAL ASSETS
+line plus DebtSecuritiesHeldToMaturity... and BankOwnedLifeInsurance,
+whose values are line items in the tens of billions, not the total.
+
+Root cause (per the #914 thread): ``gaap_mappings.json`` carries 59 entries
+at confidence < 0.5 whose standard_tags are canonical totals. The generator
+is upstream and hand-edits do not survive regeneration, so the authority
+judgement belongs in the consumer: ``ReverseIndex.lookup`` suppresses
+mappings whose confidence sits below the low-confidence floor when every
+candidate concept is a Total concept. The distribution measured in #914 is
+cleanly bimodal - colliding rows all sit at 0.307-0.319, nothing between
+0.5 and 0.9 collided - so a 0.5 floor clears every reproducible case while
+the middle band (harmless, context-disambiguated) is untouched.
+"""
+
+import pytest
+
+from edgar.xbrl.standardization.reverse_index import ReverseIndex
+
+pytestmark = pytest.mark.fast
+
+
+# The tags from the #914 report + follow-up sampling, all fuzzy-matched at
+# confidence 0.307-0.319 onto canonical totals.
+LOW_CONFIDENCE_TOTAL_COLLISIONS = [
+    # tag, must NOT resolve to
+    ("us-gaap_DebtSecuritiesHeldToMaturityExcludingAccruedInterestAfterAllowanceForCreditLoss", "Assets"),
+    ("us-gaap_BankOwnedLifeInsurance", "Assets"),
+    ("us-gaap_AccruedInvestmentIncomeReceivable", "Assets"),
+    ("us-gaap_CashCashEquivalentsAndFederalFundsSold", "Assets"),
+    ("us-gaap_UnearnedPremiums", "Liabilities"),
+    ("us-gaap_SubordinatedDebt", "Liabilities"),
+    ("us-gaap_AdvancesFromFederalHomeLoanBanks", "Liabilities"),
+    ("us-gaap_SecuredDebt", "Liabilities"),
+    ("us-gaap_SecuritiesSoldUnderAgreementsToRepurchase", "Liabilities"),
+    ("us-gaap_OtherBorrowings", "Liabilities"),
+]
+
+
+@pytest.mark.parametrize("tag,total_concept", LOW_CONFIDENCE_TOTAL_COLLISIONS)
+def test_low_confidence_line_items_do_not_resolve_as_totals(tag, total_concept):
+    idx = ReverseIndex()
+    assert idx.get_standard_concept(tag) != total_concept
+
+
+def test_ifrs_line_item_does_not_resolve_via_gaap_total():
+    """ifrs-full_ tags resolve against the GAAP index by bare name (#914)."""
+    idx = ReverseIndex()
+    assert idx.get_standard_concept("ifrs-full_IntangibleAssetsAndGoodwill") != (
+        "NonCurrentAssetsTotal"
+    )
+
+
+# Canonical mappings must be untouched by the guard.
+
+
+def test_canonical_assets_tag_still_resolves():
+    idx = ReverseIndex()
+    assert idx.get_standard_concept("us-gaap_Assets") == "Assets"
+    assert idx.get_standard_concept("us-gaap_AssetsCurrent") == "CurrentAssetsTotal"
+    assert idx.get_standard_concept("us-gaap_Liabilities") == "Liabilities"
+
+
+def test_assetsnet_at_exact_floor_still_resolves():
+    """AssetsNet maps to Assets at exactly confidence 0.5 - on the floor, kept."""
+    idx = ReverseIndex()
+    assert idx.get_standard_concept("us-gaap_AssetsNet") == "Assets"
+
+
+def test_mid_band_tag_still_resolves():
+    """CommonStocksIncludingAdditionalPaidInCapital sits at exactly 0.5 and
+    resolves to CommonEquity; the guard must not touch it."""
+    idx = ReverseIndex()
+    assert idx.get_standard_concept(
+        "us-gaap_CommonStocksIncludingAdditionalPaidInCapital"
+    ) == "CommonEquity"
+
+
+def test_non_total_low_confidence_mapping_survives():
+    """Low-confidence mappings whose candidates are NOT totals are out of
+    scope for this guard and keep resolving."""
+    idx = ReverseIndex()
+    # AdministrativeFeesExpense -> TotalOperatingExpenses IS in scope...
+    assert idx.get_standard_concept("us-gaap_AdministrativeFeesExpense") != (
+        "TotalOperatingExpenses"
+    )

--- a/tests/issues/regression/test_issue_914_total_false_matches.py
+++ b/tests/issues/regression/test_issue_914_total_false_matches.py
@@ -19,6 +19,9 @@ cleanly bimodal - colliding rows all sit at 0.307-0.319, nothing between
 the middle band (harmless, context-disambiguated) is untouched.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 from edgar.xbrl.standardization.reverse_index import ReverseIndex
@@ -29,32 +32,46 @@ pytestmark = pytest.mark.fast
 # The tags from the #914 report + follow-up sampling, all fuzzy-matched at
 # confidence 0.307-0.319 onto canonical totals.
 LOW_CONFIDENCE_TOTAL_COLLISIONS = [
-    # tag, must NOT resolve to
-    ("us-gaap_DebtSecuritiesHeldToMaturityExcludingAccruedInterestAfterAllowanceForCreditLoss", "Assets"),
-    ("us-gaap_BankOwnedLifeInsurance", "Assets"),
-    ("us-gaap_AccruedInvestmentIncomeReceivable", "Assets"),
-    ("us-gaap_CashCashEquivalentsAndFederalFundsSold", "Assets"),
-    ("us-gaap_UnearnedPremiums", "Liabilities"),
-    ("us-gaap_SubordinatedDebt", "Liabilities"),
-    ("us-gaap_AdvancesFromFederalHomeLoanBanks", "Liabilities"),
-    ("us-gaap_SecuredDebt", "Liabilities"),
-    ("us-gaap_SecuritiesSoldUnderAgreementsToRepurchase", "Liabilities"),
-    ("us-gaap_OtherBorrowings", "Liabilities"),
+    "us-gaap_DebtSecuritiesHeldToMaturityExcludingAccruedInterestAfterAllowanceForCreditLoss",
+    "us-gaap_BankOwnedLifeInsurance",
+    "us-gaap_AccruedInvestmentIncomeReceivable",
+    "us-gaap_CashCashEquivalentsAndFederalFundsSold",
+    "us-gaap_UnearnedPremiums",
+    "us-gaap_SubordinatedDebt",
+    "us-gaap_AdvancesFromFederalHomeLoanBanks",
+    "us-gaap_SecuredDebt",
+    "us-gaap_SecuritiesSoldUnderAgreementsToRepurchase",
+    "us-gaap_OtherBorrowings",
 ]
 
 
-@pytest.mark.parametrize("tag,total_concept", LOW_CONFIDENCE_TOTAL_COLLISIONS)
-def test_low_confidence_line_items_do_not_resolve_as_totals(tag, total_concept):
+@pytest.mark.parametrize("tag", LOW_CONFIDENCE_TOTAL_COLLISIONS)
+def test_low_confidence_line_items_are_not_standardized(tag):
     idx = ReverseIndex()
-    assert idx.get_standard_concept(tag) != total_concept
+    assert idx.get_standard_concept(tag) is None
+
+
+@pytest.mark.parametrize(
+    ("tag", "industry"),
+    [
+        ("us-gaap_SubordinatedDebt", "Banks"),
+        ("us-gaap_SecuredDebt", "Banks"),
+        ("us-gaap_SecuredDebt", "Fin"),
+        ("us-gaap_SecuredDebt", "RlEst"),
+        ("us-gaap_UnearnedPremiums", "Insur"),
+        ("ifrs-full_IntangibleAssetsAndGoodwill", "Chips"),
+    ],
+)
+def test_industry_override_cannot_resurrect_suppressed_total_mapping(tag, industry):
+    """Using override confidence instead of base confidence returns a false total."""
+    idx = ReverseIndex()
+    assert idx.get_standard_concept(tag, industry=industry) is None
 
 
 def test_ifrs_line_item_does_not_resolve_via_gaap_total():
     """ifrs-full_ tags resolve against the GAAP index by bare name (#914)."""
     idx = ReverseIndex()
-    assert idx.get_standard_concept("ifrs-full_IntangibleAssetsAndGoodwill") != (
-        "NonCurrentAssetsTotal"
-    )
+    assert idx.get_standard_concept("ifrs-full_IntangibleAssetsAndGoodwill") is None
 
 
 # Canonical mappings must be untouched by the guard.
@@ -67,6 +84,12 @@ def test_canonical_assets_tag_still_resolves():
     assert idx.get_standard_concept("us-gaap_Liabilities") == "Liabilities"
 
 
+def test_low_confidence_canonical_self_match_survives():
+    """Removing the self-match exemption suppresses this canonical total."""
+    idx = ReverseIndex()
+    assert idx.get_standard_concept("us-gaap_LiabilitiesAndEquity") == "LiabilitiesAndEquity"
+
+
 def test_assetsnet_at_exact_floor_still_resolves():
     """AssetsNet maps to Assets at exactly confidence 0.5 - on the floor, kept."""
     idx = ReverseIndex()
@@ -77,16 +100,32 @@ def test_mid_band_tag_still_resolves():
     """CommonStocksIncludingAdditionalPaidInCapital sits at exactly 0.5 and
     resolves to CommonEquity; the guard must not touch it."""
     idx = ReverseIndex()
-    assert idx.get_standard_concept(
-        "us-gaap_CommonStocksIncludingAdditionalPaidInCapital"
-    ) == "CommonEquity"
+    assert idx.get_standard_concept("us-gaap_CommonStocksIncludingAdditionalPaidInCapital") == "CommonEquity"
 
 
 def test_non_total_low_confidence_mapping_survives():
     """Low-confidence mappings whose candidates are NOT totals are out of
     scope for this guard and keep resolving."""
     idx = ReverseIndex()
-    # AdministrativeFeesExpense -> TotalOperatingExpenses IS in scope...
-    assert idx.get_standard_concept("us-gaap_AdministrativeFeesExpense") != (
-        "TotalOperatingExpenses"
-    )
+    assert idx.get_standard_concept("us-gaap_AccountsReceivableGrossNoncurrent") == ("OtherOperatingNonCurrentAssets")
+
+
+def test_all_shipped_low_confidence_total_mappings_follow_the_guard():
+    """The generated mapping data must not introduce an unrecognised total id."""
+    data_dir = Path(__file__).parents[3] / "edgar" / "xbrl" / "standardization"
+    mappings = json.loads((data_dir / "gaap_mappings.json").read_text(encoding="utf-8"))
+    display_names = json.loads((data_dir / "display_names.json").read_text(encoding="utf-8"))
+    idx = ReverseIndex()
+
+    guarded_tags = []
+    for tag, entry in mappings.items():
+        if tag == "_metadata" or entry.get("confidence", 1.0) >= 0.5:
+            continue
+        standard_tags = entry.get("standard_tags", [])
+        if standard_tags and all(display_names.get(candidate, "").startswith("Total ") for candidate in standard_tags):
+            guarded_tags.append(tag)
+
+    assert guarded_tags
+    for tag in guarded_tags:
+        expected = tag if mappings[tag]["standard_tags"] == [tag] else None
+        assert idx.get_standard_concept(tag) == expected


### PR DESCRIPTION
Fixes #914 (the GAAP half; tracked as `edgartools-gnx5`).

## The bug

On Citizens Financial Group's balance sheet, `standard_concept == 'Assets'` returned **three rows**:

| concept | label | 2025-12-31 |
|---|---|---:|
| `us-gaap_DebtSecuritiesHeldToMaturityExcludingAccruedInterestAfterAllowanceForCreditLoss` | Debt securities held to maturity | 7,933,000,000 |
| `us-gaap_BankOwnedLifeInsurance` | Bank-owned life insurance | 3,441,000,000 |
| `us-gaap_Assets` | TOTAL ASSETS | 226,351,000,000 |

Selecting the standardized total reported **$7.9B as total assets** instead of $226.4B.

## Root cause (per the #914 thread)

`gaap_mappings.json` carries 59 entries at confidence < 0.5 whose `standard_tags` are canonical totals (`Assets`, `Liabilities`, `CurrentAssetsTotal`, ...). The file is generated upstream (`edgar-storage StandardizedConcepts` v3.0.0) and hand edits would not survive regeneration, so the authority judgement belongs in the consumer.

## The change

`ReverseIndex.lookup` now suppresses a mapping when **confidence < 0.5 and every candidate concept is a total concept**. The floor comes from the distribution measured in the #914 thread: in the 65-filing sample, every colliding row sat at confidence 0.307–0.319 and nothing between 0.5 and 0.9 collided — the mid band is harmless because context disambiguation catches it before it surfaces (`CommonStocksIncludingAdditionalPaidInCapital` at exactly 0.5 resolves correctly to `CommonEquity`).

Scope on the current index: **59 of 2,924 entries** suppressed, all in the 0.307–0.499 band with exclusively-total candidates. Untouched: canonical mappings (`Assets`/`Liabilities`/`AssetsCurrent` at ≥ 0.9), `AssetsNet` at exactly the 0.5 floor, non-total low-confidence mappings, and entries with no confidence field (treated as no signal).

## Tests

New `tests/issues/regression/test_issue_914_total_false_matches.py` (written first, RED on `main` — 12 failing bug assertions, 3 passing guards):

- the 10 colliding tags from the issue report + follow-up sampling must not resolve to their total
- the IFRS half of #914: `ifrs-full_IntangibleAssetsAndGoodwill` no longer lands on `NonCurrentAssetsTotal` via its 0.314-confidence GAAP entry (a namespace-aware IFRS index remains upstream work)
- canonical tags still resolve; `AssetsNet` at exactly 0.5 still resolves; mid-band tag still resolves

`test_standardization.py` (33 tests) + `test_standardization_integration.py` green unchanged.

## Verification

Full fast suite on this branch: **5906 passed, 19 failed**. The 19 are the 13 known environmental failures on this Windows box (verified against clean `main` earlier: network-marked filing-text baselines + file locks) **plus 6 in upstream's own new characterization files** (`test_homepage_characterization.py`, `test_drs_characterization.py`), which I verified fail identically on pristine `3e910f8` — unrelated to this change, they came in with the #1110–#1115 lxml ports.

Offline acceptance (no network): the CFG three-row repro now yields exactly one row claiming `Assets` — the canonical one.