### PR TITLE
chore: merge CHANGELOG.md with the union driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,13 @@ docs/* linguist-documentation
 # Mark notebooks as binary to avoid messy JSON diffs
 *.ipynb diff=jupyternotebook
 *.ipynb merge=jupyternotebook
+
+# Every branch adds its own bullets to the [Unreleased] block, at the same
+# place, so any two of them conflict on lines neither one actually disputes.
+# `union` keeps both sides of a conflicting hunk instead of stopping.
+#
+# This is right for a changelog that is only ever APPENDED to, and it is the
+# whole risk too: if two branches edit the SAME bullet, union keeps both
+# versions rather than choosing. That shows up as an obvious duplicate in
+# review, where a silently dropped bullet does not.
+CHANGELOG.md merge=union


### PR DESCRIPTION
One line in `.gitattributes`:

```
CHANGELOG.md merge=union
```

Every branch adds its own bullets to the `[Unreleased]` block at the same place, so any two of them conflict on lines neither actually disputes. Six of the ten bs4→lxml branches open right now do. Resolving those by hand is where a bullet gets silently dropped — which is the failure this removes.

## Verified, both directions

Git reads `.gitattributes` from the tree it is merging **into**, which makes this asymmetric:

| direction | conflicts? |
|---|---|
| merge PR #1125 **into** a branch carrying the line | **none** |
| merge a branch carrying the line **into** #1125, which lacks it | still conflicts on `CHANGELOG.md` |

The first row is the shape of "Merge pull request" — GitHub merges the PR into `main` — so landing this **first** is what makes the remaining nine merges clean. The second row means a branch that pulls `main` in locally still hits the conflict once; after that it carries the line itself and subsequent merges are clean.

Simulated over all ten open bs4→lxml PRs merged in sequence: every one clean, and the bullet count lands at 478 — `main`'s 468 plus exactly one per PR, none dropped, none duplicated.

## The tradeoff

`union` keeps both sides of a conflicting hunk. That is right for a file only ever appended to, and it is the risk too: two branches editing the **same** bullet get both versions rather than one. A duplicate is visible in review; a missing bullet is not — so this trades a silent failure for a loud one.

The repo already uses custom merge drivers for `.beads/beads.jsonl` and `*.ipynb`, so the mechanism is not new here; `union` is a git built-in rather than a configured driver, so it needs no setup on anyone's machine.

One caveat I could not verify from here: whether GitHub's server-side merge honours `.gitattributes`. It is a built-in driver rather than a custom one, so it very likely does, but the first PR merged after this lands is the real test — if it still conflicts, nothing is lost and local merges still benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)