### PR TITLE
docs(contributing): document the regression-test provenance rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,46 @@ Cassettes are loaded as plain data — recorded requests, headers and response
 bodies only. `hatch run check-cassettes` verifies this and runs in CI ahead of
 the test jobs; run it locally if you are about to run a branch you did not write.
 
+## Regression Tests
+
+A regression test is a claim that one specific bug stays fixed. A year from now
+the assertion is the only surviving record of what that bug was, and the only
+question that justifies ever deleting the test is "is this bug still
+reachable?" — which nobody can answer without the report.
+
+**Every file under `tests/issues/regression/` must name its origin in the module
+docstring**, as one of these three shapes:
+
+```
+GitHub Issue: https://github.com/dgunning/edgartools/issues/<n>
+GitHub PR:    https://github.com/dgunning/edgartools/pull/<n>
+Bead:         edgartools-<id>
+```
+
+Anywhere in the docstring is fine; directly under the summary line is the usual
+place.
+
+**A bare `#819` in prose does not count, and that is the point rather than an
+oversight.** 109 files here once named their issue in prose and nothing else.
+The number was present, but it was not a link and the form varied — "GH #812",
+"GitHub issue #488", "issue #762" — so no tool could follow it. Requiring one
+canonical shape is what makes "which of these bugs are still open?" answerable
+by a script instead of by reading 300 docstrings. The filename is not enough
+either: it carries the number for some of the tree and silently not for the
+rest.
+
+**This runs in CI ahead of the test jobs**, as a step inside `test-fast`, so a
+missing line fails your pull request before a single test executes. The failure
+names the exact line to add. Check it before pushing:
+
+```bash
+hatch run check-regression-provenance
+```
+
+Place new regression tests in `tests/issues/regression/test_issue_NNN.py`, and
+assert specific values rather than mere existence — a ground-truth number taken
+from a real filing, verified by hand.
+
 ## Changelog Entries
 
 `CHANGELOG.md` is read by someone deciding whether an upgrade affects them. An

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ smoke-filings = "python scripts/batch/batch_filings.py {args}"
 # machine the moment a test touches it. CI gates on this too.
 check-cassettes = "python scripts/check_cassettes.py {args}"
 check-regression-skips = "python scripts/check_regression_skips.py {args}"
+check-regression-provenance = "python scripts/check_regression_provenance.py {args}"
 # Test categorization commands (sequential execution)
 test-fast = "pytest -m 'fast' {args}"
 test-slow = "pytest -m 'slow' {args}"


### PR DESCRIPTION
Every file under `tests/issues/regression/` has to name its origin in the module docstring as a canonical link or bead id, and CI enforces it inside `test-fast` **ahead of the test jobs**. Until now that rule was written down only in the workflow YAML and in the checker's own docstring — so a contributor could not learn it before being rejected by it.

## Why now

#1116 is the case in point. The docstring said *"Regression tests for GH issue #1072"* and carried a hand-verified ground-truth table of accession numbers and cover-page "Entry Total" counts — exactly the diligence the verification constitution asks for and rarely gets. CI refused it because the number was prose rather than a link, and no contributor-facing document named the requirement anywhere.

Zero tests failed on that PR. The whole red was one missing line.

## What this adds

A **Regression Tests** section in `CONTRIBUTING.md`, placed next to the cassettes section since both cover artifacts committed alongside a test. It gives:

- the three accepted shapes (`GitHub Issue:` / `GitHub PR:` / `Bead:`)
- why prose is rejected — 109 files once carried `GH #812`, `GitHub issue #488`, `issue #762`, none followable by a tool — so the rule reads as deliberate rather than pedantic
- the command to run before pushing

It also adds a `check-regression-provenance` script alias. `check-cassettes` and `check-regression-skips` already had one; this checker did not, and the workflow invoked it as a raw `python scripts/...` call. Documenting `hatch run check-regression-provenance` next to `hatch run check-cassettes` needed the alias to exist. The workflow is left calling the script directly, so CI behaviour is unchanged.

## Verification

`hatch run check-regression-provenance` → *"OK: 301 regression file(s) scanned, every one traceable to its bug."*
`hatch run check-cassettes` still passes, confirming the neighbouring alias is unaffected.

No CHANGELOG entry — contributor tooling, nothing a user upgrading would see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)