### PR TITLE
test(reports): guard the __getitem__ miss against a sixth forgetful override

### DIFF
--- a/tests/issues/regression/test_sx7y_report_getitem_signals_miss.py
+++ b/tests/issues/regression/test_sx7y_report_getitem_signals_miss.py
@@ -16,17 +16,31 @@ and marked `network` -- deliberately, rather than letting it ride in the `fast`
 lane, because `test-strict-errors` runs that lane and exists to check 6.0 error
 behaviour "without a second pass over the SEC endpoint".
 
+Those behavioural tests pin the five report types that exist today. A SIXTH
+would slip straight through them, which is the failure this bug already
+demonstrated three times, so `test_every_getitem_override_announces_a_miss`
+below guards the shape rather than the behaviour: it walks the CompanyReport
+subclasses and refuses any override of `__getitem__` that never reaches
+`report_lookup_miss`.
+
 The three were independent mistakes with one cause: the base class's
 `report_lookup_miss` call is invisible at the override site, so every
 reimplementation of the miss path dropped it. That is why this asserts against
 the real class rather than grepping the source for the call.
 """
+import ast
+import importlib
+import inspect
+import pkgutil
+import textwrap
 import warnings
 from contextlib import contextmanager
 
 import pytest
 
+import edgar.company_reports
 from edgar import Filing
+from edgar.company_reports._base import CompanyReport, report_lookup_miss
 from edgar.exceptions import SectionNotFoundError
 
 # Avino Silver & Gold's 2023 40-F. "Nonexistent Section" is absent by
@@ -101,3 +115,114 @@ def test_get_stays_silent_in_both_modes(monkeypatch):
             f".get() warned with strict={strict_mode}; it promises a default, "
             f"so it stays quiet in both modes"
         )
+
+
+def _all_report_subclasses():
+    """Every CompanyReport subclass, importing the package so none hides.
+
+    `__subclasses__()` only sees classes that have been imported, and report
+    types are lazily imported by `obj()` dispatch. Importing every module in
+    `edgar.company_reports` first means a new report type is discovered whether
+    or not anything has touched it yet.
+    """
+    for mod in pkgutil.iter_modules(edgar.company_reports.__path__):
+        importlib.import_module(f"edgar.company_reports.{mod.name}")
+
+    seen = []
+
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            if sub not in seen:
+                seen.append(sub)
+                walk(sub)
+
+    walk(CompanyReport)
+    return seen
+
+
+def _reaches_the_miss(method) -> bool:
+    """True if this __getitem__ calls report_lookup_miss, or defers to the base."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(method)))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # report_lookup_miss(...)
+        if isinstance(func, ast.Name) and func.id == "report_lookup_miss":
+            return True
+        # super().__getitem__(...) -- the base announces on our behalf
+        if (isinstance(func, ast.Attribute) and func.attr == "__getitem__"
+                and isinstance(func.value, ast.Call)
+                and isinstance(func.value.func, ast.Name)
+                and func.value.func.id == "super"):
+            return True
+    return False
+
+
+def test_every_getitem_override_announces_a_miss():
+    """A report type that overrides __getitem__ must still announce a miss.
+
+    `CompanyReport.__getitem__` calls `report_lookup_miss` before returning
+    None, so `report[item]` on an absent item warns today and raises under
+    EDGARTOOLS_STRICT_ERRORS. That call is invisible at the override site, and
+    three subclasses reimplemented the miss path without it -- independently,
+    which is what makes this worth guarding rather than remembering.
+
+    This is a STRUCTURAL check and deliberately a weak one: it proves the call
+    is present in the source, not that every miss path reaches it. FortyF needs
+    TWO call sites and this test would pass with one. The behavioural tests
+    above and in test_3dp_groupb_fixture_corpus.py are what prove reachability
+    for the types that exist; this exists to catch the SIXTH type, which those
+    tests would never mention.
+
+    If this fails on a class you just wrote: call `report_lookup_miss(self,
+    key)` immediately before each `return None` that means "this filing has no
+    such item" -- and NOT before one that means the caller passed nonsense,
+    which is a different failure (see FortyF's empty-key branch).
+    """
+    offenders = [
+        cls.__name__
+        for cls in _all_report_subclasses()
+        if "__getitem__" in cls.__dict__ and not _reaches_the_miss(cls.__getitem__)
+    ]
+
+    assert not offenders, (
+        f"Overrides __getitem__ without ever reaching report_lookup_miss: "
+        f"{', '.join(offenders)}. A lookup for an absent item answers None in "
+        f"silence there -- no FutureWarning today, and no SectionNotFoundError "
+        f"under EDGARTOOLS_STRICT_ERRORS, so report[item] will not raise in 6.0 "
+        f"for that form. See edgartools-sx7y."
+    )
+
+
+def test_the_guard_can_actually_fail():
+    """The guard above must reject a class that forgets, or it guards nothing.
+
+    A structural test that only ever sees correct code proves nothing about
+    what it would do with incorrect code -- so this hands it exactly the shape
+    the three real subclasses had.
+    """
+    class ForgetfulReport(CompanyReport):
+        def __getitem__(self, item_or_part: str):
+            section = self.document.sections.get(item_or_part)
+            if section:
+                return section.text()
+            return None            # no report_lookup_miss -- the sx7y bug
+
+    class CorrectReport(CompanyReport):
+        def __getitem__(self, item_or_part: str):
+            section = self.document.sections.get(item_or_part)
+            if section:
+                return section.text()
+            report_lookup_miss(self, item_or_part)
+            return None
+
+    class DeferringReport(CompanyReport):
+        def __getitem__(self, item_or_part: str):
+            return super().__getitem__(item_or_part)
+
+    assert not _reaches_the_miss(ForgetfulReport.__getitem__)
+    assert _reaches_the_miss(CorrectReport.__getitem__)
+    assert _reaches_the_miss(DeferringReport.__getitem__), (
+        "deferring to the base is a legitimate way to announce a miss"
+    )


### PR DESCRIPTION
The behavioural tests for `edgartools-sx7y` pin the five report types that exist today. A **sixth would slip straight through them** — which is exactly the failure that bug demonstrated three times, independently, in `TwentyF`, `CurrentReport` and `FortyF`.

This guards the **shape** rather than the behaviour. It imports every module in `edgar.company_reports` (report types are lazily imported by `obj()` dispatch, so `__subclasses__()` alone would miss one nothing has touched yet), walks the `CompanyReport` subclasses, and refuses any override of `__getitem__` whose source never reaches `report_lookup_miss`. Deferring to `super().__getitem__()` counts, since the base announces on the override's behalf.

## Why a cheap guard rather than the refactor

The structural fix is to invert ownership — base owns `__getitem__` and therefore the miss, subclasses supply only the lookup — which makes forgetting impossible rather than merely detectable. That's a refactor across five classes including `TenK.__getitem__`, which is **176 lines** with its miss call 173 lines below the signature. It also needs `FortyF`'s empty-key branch resolved first, since that `return None` means "caller passed nonsense", not "no such section", and a template that reads every `None` as a miss would announce the wrong thing.

This test buys most of the protection for one file and no behaviour change. The inversion is still worth doing when a sixth report type actually needs `__getitem__`, or if `07lk.12.1` touches these files anyway.

## Deliberately weak, and it says so

A static check proves the call is *present*, not that every miss path *reaches* it. `FortyF` needs two call sites and this would pass with one. Reachability for the existing types is proved by the behavioural tests in this file and in `test_3dp_groupb_fixture_corpus.py`; this exists only to catch the type those tests will never mention.

## Mutation-probed against the real tree

Not just against a synthetic class:

- delete the call from `TwentyF` → fails, naming `TwentyF`
- delete both from `FortyF` → fails, naming `FortyF`
- restore either → passes

`test_the_guard_can_actually_fail` additionally pins the helper against all three shapes — forgetful, correct, and `super()`-deferring — so the guard can't rot into one that only ever sees correct code.

The failure message names the consequence rather than the rule, and says where the call goes *and where it does not*: not before a `return None` that means the caller passed nonsense.

## Lanes

Both new tests are offline and land in `fast`, so they gate every pull request. The three `FortyF` behavioural tests in this file stay `network`-marked.

**6346 pass in both lanes** (`test-fast` and `EDGARTOOLS_STRICT_ERRORS=1`). Provenance check: 303 regression files, all traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)