### PR TITLE
chore(deps): cap httpx below 0.29 (supply-chain hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **httpx is now capped below 0.29.** httpx upstream has been dormant since 0.28.1 (December 2024) and stopped accepting issues in February 2026, so any future release on PyPI would be unexpected and should not be adopted automatically. Installs resolve to 0.28.1 exactly as before; the planned successor is the httpx2 migration in 6.0.
+
 - **Filing homepage parsing is about 9x faster.** The filing index page — the source of `filing.attachments`, `filing.homepage.get_filers()` and the filing dates — was parsed with BeautifulSoup's pure-Python `html.parser`; it now uses lxml, measured at 15.8ms to 1.8ms across the five tracked homepage fixtures. Output is unchanged: the whole parse of every fixture, down to each attachment's size and each filer's identification lines, is pinned against a baseline captured from the previous implementation. A blank or truncated index page still yields a homepage with nothing on it rather than raising.
 
   `FilingHomepage(...)` and `Attachments.load(...)` take an lxml tree now, from the new `edgar.attachments.parse_homepage_html(html)`. Both still accept a BeautifulSoup, and `FilingHomepage(soup=...)` still works, with a `DeprecationWarning`; both go in 6.0. Neither is on the path you take through `filing.homepage`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,11 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 dependencies = [
-  "httpx>=0.25.0",
+  # Upper cap is deliberate: httpx upstream is dormant (last release 0.28.1,
+  # Dec 2024; issues and discussions closed Feb 2026). Any future release would
+  # be unexpected — do not auto-adopt it. The migration path is httpx2
+  # (edgartools-q2iz); lift or retarget this cap there, not here.
+  "httpx>=0.25.0,<0.29",
   "pandas>=2.0.0",
   "tabulate>=0.9.0",
   "pyarrow>=17.0.0",


### PR DESCRIPTION
## Why

httpx upstream is effectively frozen and locked down: no release since 0.28.1 (December 2024), and the maintainer closed all issues and discussions in February 2026, leaving no channel for coordinated disclosure. All active development happens in the pydantic/httpx2 fork. In that state, any future httpx release on PyPI would be unexpected — a classic account-compromise signature — and our uncapped `httpx>=0.25.0` would auto-install it on every fresh `pip install edgartools`.

Today the only thing preventing that is `httpxthrottlecache[httpx]`'s exact `==0.28.1` pin — a guard that lives in a third-party dependency and could loosen in any of its releases. edgartools should carry its own cap.

## What

- `pyproject.toml`: `httpx>=0.25.0` → `httpx>=0.25.0,<0.29`, with a comment explaining the cap is deliberate and gets lifted/retargeted by the httpx2 migration (edgartools-q2iz), not raised in place.
- `CHANGELOG.md`: entry under Unreleased.

## Verification

`pip install --dry-run -e .` resolves to httpx 0.28.1 exactly as before, no conflict with `httpxthrottlecache[httpx]>=0.6.1`. No code changes; no behavior change for any user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)