### PR TITLE
chore(release): 5.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.53.0] - 2026-08-25
+
 ### Changed
 
 - **httpx is now capped below 0.29.** httpx upstream has been dormant since 0.28.1 (December 2024) and stopped accepting issues in February 2026, so any future release on PyPI would be unexpected and should not be adopted automatically. Installs resolve to 0.28.1 exactly as before; the planned successor is the httpx2 migration in 6.0.

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.52.0'
+__version__ = '5.53.0'


### PR DESCRIPTION
Release 5.53.0 — version bump and CHANGELOG fold, content already on main.

Highlights: the bs4→lxml performance wave (13 subsystems, 5.6x–20x, all pinned against baselines from the old implementations), 11 fixes including the pre-2013 13F TXT column-bleed recovery (GH #1072), the silent item-lookup misses (sx7y), and the MCP fund_portfolio empty-holdings fix (GH #1136), five legacy-parser removals toward 6.0, and the httpx <0.29 supply-chain cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)