### PR TITLE
fix(financials): get_financials() stops going quiet on a filing with no XBRL (07lk.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`get_financials()` no longer goes quiet on a filing that has no XBRL.** A company whose latest annual report predates SEC's 2009-2011 XBRL phase-in got a `Financials` object back — a truthy one, so the documented `if financials is not None:` guard passed — whose `income_statement()`, `balance_sheet()` and `cash_flow_statement()` then all returned `None` with nothing said at any level. `Company(104599).get_financials()`, Circuit City's 2008 10-K, is the case. That path now emits a `FutureWarning` naming the filing and raises `XBRLFilingWithNoXbrlData` in 6.0; set `EDGARTOOLS_STRICT_ERRORS=1` for the 6.0 behaviour today. The object itself is unchanged in 5.x, so nothing you branch on today moves.
+
+  `XBRLFilingWithNoXbrlData` was never actually raised anywhere, which is why this was silent: the two `except` clauses written for it — in `Financials.extract` and `Filing.xbrl` — were dead code that read as handling. Both are gone, and the error is raised for the first time. `filing.xbrl()` still answers `None` for a filing without XBRL, quietly, in 5.x and in 6.0: that is a true absence rather than a failure.
+
 ## [5.53.0] - 2026-08-25
 
 ### Changed

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -445,10 +445,23 @@ still a 5.x release to fix it in.
 | `find("123456-99")` — malformed accession | warns, returns `None` | raises `ValidationError` |
 | `filing.obj()` on a modelled form whose data will not read | warns, returns `None` | raises `DataObjectError` |
 | `tenk.document` when the parser fails | warns, returns `None` | raises the parser's `ParsingError` |
+| `get_financials()` on a filing with no XBRL | warns, returns a `Financials` whose accessors all answer `None` | raises `XBRLFilingWithNoXbrlData` |
 
 `filing.obj()` on a form edgartools does not model still returns `None`, and
 so does `filing.xbrl()` on a filing without XBRL. Those are answers, not
 failures, and that distinction is the point of the whole change.
+
+The `get_financials()` row is on the other side of exactly that line, which is
+worth spelling out because the two look alike. `filing.xbrl()` is *asking
+whether there is XBRL*, so "there is none" is an answer. `get_financials()` is
+asking for statements, and it did not answer — it returned an object that
+**passes** `if financials is not None:` and then yields `None` from
+`income_statement()`, `balance_sheet()` and `cash_flow_statement()`. A company
+whose latest annual report predates SEC's 2009-2011 XBRL phase-in reaches this;
+`Company(104599)` — Circuit City, last 10-K filed 2008 — is one.
+
+Nothing about that object changes in 5.x. You get the warning, and the code you
+have keeps working; 6.0 raises instead.
 
 Where the raising form is the only form, 5.x ships a non-raising one beside it:
 `report.get(item, default)` is to `report[item]` what `dict.get` is to

--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -72,7 +72,7 @@ from edgar.richtools import Docs, print_rich, repr_rich
 from edgar.search import BM25Search, RegexSearch
 from edgar.sgml import FilingHeader, FilingSGML, Reports, Statements
 from edgar.storage import is_using_local_storage, local_filing_path, resolve_local_filing_path
-from edgar.xbrl import XBRL, XBRLFilingWithNoXbrlData
+from edgar.xbrl import XBRL
 
 """ Contain functionality for working with SEC filing indexes and filings
 
@@ -1859,12 +1859,17 @@ class Filing:
     def xbrl(self) -> Optional[XBRL]:
         """
         Get the XBRL document for the filing, parsed and as a FilingXbrl object
-        :return: Get the XBRL document for the filing, parsed and as a FilingXbrl object, or None
+
+        :return: The parsed XBRL, or `None` when the filing carries no XBRL
+            attachments — a property of the filing, not a failure to read it,
+            and one this keeps answering quietly in 6.0 (docs/upgrade/6.0.md).
         """
+        # The `except XBRLFilingWithNoXbrlData` that used to sit here was dead:
+        # nothing in the library raised that error, and `from_filing` signals
+        # the no-XBRL case by returning None. Removed rather than left as
+        # decoration, so this function's None has one visible source.
         try:
             return XBRL.from_filing(self)
-        except XBRLFilingWithNoXbrlData:
-            return None
         except (*UNREACHABLE_ERRORS, TransportError) as e:
             # Provide helpful message when local storage is enabled but filing content is missing
             if is_unreachable(e) and is_using_local_storage():

--- a/edgar/entity/core.py
+++ b/edgar/entity/core.py
@@ -611,6 +611,13 @@ class Company(Entity):
             ``TransportError`` propagates; if the filing was there but would not
             parse, a ``ParsingError`` does.
 
+            One case is neither: an annual report that predates SEC's 2009-2011
+            XBRL phase-in carries no XBRL, so there is nothing to build
+            statements from. You get a ``Financials`` back — not None, so the
+            guard above passes — whose every accessor answers None. That path
+            now warns, and raises ``XBRLFilingWithNoXbrlData`` in 6.0. Set
+            ``EDGARTOOLS_STRICT_ERRORS=1`` for the 6.0 behaviour today.
+
         Example::
 
             financials = Company("AAPL").get_financials()
@@ -641,6 +648,11 @@ class Company(Entity):
             Financials object, or None — and None means exactly one thing: this
             company has filed no 10-Q or 6-K that we can see. It is never how a
             failure is reported; a transport or parsing failure raises.
+
+            As with ``get_financials()``, a quarterly report with no XBRL is
+            neither: it returns a ``Financials`` whose accessors all answer
+            None. That path warns, and raises ``XBRLFilingWithNoXbrlData`` in
+            6.0.
 
         Example::
 

--- a/edgar/financials.py
+++ b/edgar/financials.py
@@ -5,11 +5,12 @@ from typing import Any, Dict, List, Optional, Union
 import pandas as pd
 
 from edgar.core import log
+from edgar.exceptions import warn_will_raise
 from edgar.richtools import repr_rich
 from edgar.xbrl import XBRL, XBRLS, Statement
 from edgar.xbrl.presentation import ViewType
 from edgar.xbrl.statements import StitchedStatement
-from edgar.xbrl.xbrl import XBRLFilingWithNoXbrlData
+from edgar.xbrl.xbrl import no_xbrl_attachments
 
 # Columns produced by RenderedStatement.to_dataframe() that are metadata, not
 # period values.
@@ -121,13 +122,36 @@ class Financials:
 
     @classmethod
     def extract(cls, filing) -> Optional["Financials"]:
-        try:
-            xb = XBRL.from_filing(filing)
-            return Financials(xb)
-        except XBRLFilingWithNoXbrlData as e:
-            # Handle the case where the filing does not have XBRL data
-            log.warning(f"Filing {filing} does not contain XBRL data: {e}")
-            return None
+        """Build the financials for a filing.
+
+        A filing with no XBRL attachments still yields a `Financials` here —
+        one wrapping `xb=None`, whose every statement accessor answers `None`.
+        That object is why this was a silent failure: it is truthy, so the
+        documented `if financials is not None:` guard passes and the caller
+        then gets `None` from `income_statement()` with nothing explaining it.
+
+        The warning belongs here rather than in `XBRL.from_filing`, even though
+        that is the shared choke point. `filing.xbrl()` answering `None` for a
+        filing without XBRL is a documented true absence that stays quiet in
+        6.0 (docs/upgrade/6.0.md); warning at the choke point would have
+        reversed that. Asking for *financial statements* and silently getting an
+        object that has none is the actual failure, and this is where it happens.
+
+        The hollow object itself stays in 5.x: removing it is the behaviour
+        change, and the warning is the additive half that has to ship first
+        (edgartools-07lk.23). 6.0 raises and the object goes then.
+        """
+        xb = XBRL.from_filing(filing)
+        if xb is None:
+            # stacklevel=3: helper, this classmethod, the caller. The
+            # `get_financials()` chain sits two frames deeper, so the warning
+            # lands inside edgartools there rather than on the user's line —
+            # the message says what happened and does not depend on the line.
+            # There is deliberately no `except XBRLFilingWithNoXbrlData` around
+            # this: under strict, warn_will_raise raises and that error IS the
+            # 6.0 behaviour, so catching it would make strict a no-op here.
+            warn_will_raise(no_xbrl_attachments(filing), stacklevel=3)
+        return Financials(xb)
 
     def balance_sheet(self, include_dimensions: bool = None, view: ViewType = None):
         """

--- a/edgar/xbrl/xbrl.py
+++ b/edgar/xbrl/xbrl.py
@@ -49,6 +49,36 @@ class XBRLFilingWithNoXbrlData(NotFoundError):
         super().__init__(message)
 
 
+def no_xbrl_attachments(filing) -> XBRLFilingWithNoXbrlData:
+    """The error for a filing that carries no XBRL attachments at all.
+
+    Built as a value rather than raised, so `warn_will_raise` decides — and so
+    the frame between the warning and the user is not one of ours, which is
+    what keeps `stacklevel` pointing at the line the reader has to change. Same
+    shape as `_no_xml_to_parse` in `edgar/__init__.py`, for the same reasons.
+
+    Lives here, next to the class and the condition it describes, but is raised
+    from `Financials.extract` rather than from `from_filing`: `filing.xbrl()`
+    answering `None` is a documented true absence, while a truthy `Financials`
+    whose accessors all answer `None` is the failure worth naming.
+    """
+    error = XBRLFilingWithNoXbrlData(
+        f"Filing {filing.accession_no} ({filing.form}) has no XBRL attachments, "
+        f"so there are no financial statements to read from it. This is a "
+        f"property of the filing, not of the form — SEC phased XBRL in between "
+        f"2009 and 2011, and filings from before then carry none."
+    )
+    # Stable across filings so a walk through a company's whole filing history
+    # warns once, not once per pre-2009 filing — see warn_will_raise.
+    error.warning_summary = (
+        "This filing has no XBRL attachments, so there are no financial "
+        "statements to read from it. This is a property of the filing, not of "
+        "the form — SEC phased XBRL in between 2009 and 2011, and filings from "
+        "before then carry none."
+    )
+    return error
+
+
 class XBRLAttachments:
     """
     An adapter for the Attachments class that provides easy access to the XBRL documents.
@@ -594,7 +624,9 @@ class XBRL:
             filing: Filing object with attachments containing XBRL files
 
         Returns:
-            XBRL object with parsed data
+            XBRL object with parsed data, or `None` when the filing carries no
+            XBRL attachments at all — a property of the filing, not a failure to
+            read it, and one this keeps answering with a quiet `None` in 6.0.
         """
         if filing.form.endswith("/A"):
             log.debug(dedent(f"""
@@ -608,6 +640,12 @@ class XBRL:
         xbrl_attachments = XBRLAttachments(filing.attachments)
 
         if xbrl_attachments.empty:
+            # Silent on purpose. `filing.xbrl()` answering None for a filing
+            # with no XBRL is a true absence, not a failure, and docs/upgrade/
+            # 6.0.md commits to it staying that way. The silent-None bug this
+            # module was implicated in (edgartools-07lk.10.1) is one level up,
+            # where `Financials` wraps this None into a truthy object whose
+            # every accessor answers None — so that is where the warning went.
             log.debug(f"No XBRL attachments found in filing {filing}")
             return None
 

--- a/tests/issues/regression/test_07lk101_no_xbrl_hollow_financials.py
+++ b/tests/issues/regression/test_07lk101_no_xbrl_hollow_financials.py
@@ -1,0 +1,247 @@
+"""A filing with no XBRL used to hand back a hollow `Financials`, silently.
+
+Bead: edgartools-07lk.10.1, the first finding of 07lk.10's silent-None sweep.
+
+`Company(104599).get_financials()` returned a `Financials` object — truthy, so
+the documented `if financials is not None:` guard passed — whose every accessor
+then answered `None`, with no warning at any level. The only signal was a
+`log.debug`, which is off for every normal user.
+
+WHERE THE WARNING GOES, AND WHY NOT ONE LEVEL DOWN. `XBRL.from_filing` is the
+shared choke point and warning there would have caught every path in one edit.
+It is the wrong place: `filing.xbrl()` answering `None` for a filing without
+XBRL is a TRUE ABSENCE, and docs/upgrade/6.0.md commits in writing to it staying
+quiet in 6.0 — "those are answers, not failures, and that distinction is the
+point of the whole change". Asking for financial statements and silently getting
+an object that has none is the failure. So `Financials.extract` warns and
+`filing.xbrl()` does not, and the tests below pin BOTH halves — the second is
+the one a future choke-point refactor would quietly break.
+
+WHAT THESE TESTS PROTECT, in order of how quietly each could break:
+
+  1. **`filing.xbrl()` stays silent.** Nothing about it is asserted anywhere
+     else, so moving the warning down to `from_filing` would look like a tidy
+     simplification and pass every other test in this file.
+  2. **Strict mode actually raises.** `XBRLFilingWithNoXbrlData` was never
+     raised ANYWHERE before this change, so the two `except` clauses written
+     for it — in `Financials.extract` and in `Filing.xbrl` — were dead code
+     that looked like handling. Re-adding one would restore the silent `None`
+     under strict while every lenient test still passed, and it would read as
+     conscientious error handling to whoever added it.
+  3. **The warning dedups.** Its text must not carry the accession number.
+     Python's filter compares rendered text, so a per-filing message turns a
+     sweep over a company's history into one warning per pre-2009 filing, which
+     reads as a broken library. This is the trap `_no_xml_to_parse` already hit.
+  4. **Filings WITH XBRL stay silent.** A guard that warned on the healthy path
+     would be worse than the bug: it would train users to filter the warning.
+"""
+import warnings
+
+import pytest
+
+from edgar import Filing
+from edgar.financials import Financials
+from edgar.xbrl.xbrl import XBRLFilingWithNoXbrlData, no_xbrl_attachments
+
+# Circuit City stopped filing in 2009, so its LATEST 10-K predates SEC's
+# 2009-2011 XBRL phase-in. That makes it reachable through get_financials()
+# with no historical-filing gymnastics — the exact shape a user hits.
+CIRCUIT_CITY_10K = dict(
+    form="10-K",
+    filing_date="2008-04-28",
+    company="CIRCUIT CITY STORES INC",
+    cik=104599,
+    accession_no="0001193125-08-093063",
+)
+
+
+@pytest.fixture
+def strict(monkeypatch):
+    monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", "1")
+
+
+@pytest.fixture
+def lenient(monkeypatch):
+    monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS", raising=False)
+
+
+class _Filing:
+    """The smallest thing `no_xbrl_attachments` reads."""
+    form = "10-K"
+    accession_no = "0001193125-08-093063"
+
+
+# --------------------------------------------------------------------------
+# The error value itself — offline
+# --------------------------------------------------------------------------
+
+def test_error_is_built_not_raised():
+    """The helper returns the error as a value, so warn_will_raise can decide."""
+    assert isinstance(no_xbrl_attachments(_Filing()), XBRLFilingWithNoXbrlData)
+
+
+def test_error_message_names_the_filing():
+    """The copy a user debugs against identifies WHICH filing."""
+    error = no_xbrl_attachments(_Filing())
+    assert "0001193125-08-093063" in str(error)
+    assert "10-K" in str(error)
+
+
+def test_warning_summary_is_dedup_stable():
+    """The warning text must NOT vary per filing.
+
+    Python suppresses a repeat only on an exact text match, so an accession
+    number here turns a corpus loop into one warning per filing.
+    """
+    error = no_xbrl_attachments(_Filing())
+    assert error.warning_summary is not None
+    assert "0001193125-08-093063" not in error.warning_summary
+    # Still has to say what happened, not merely that something did.
+    assert "no XBRL" in error.warning_summary
+
+
+def test_warning_summary_explains_that_this_is_the_filing_not_the_form():
+    """A user seeing this on a 10-K must not conclude 10-Ks are unsupported."""
+    assert "property of the filing" in no_xbrl_attachments(_Filing()).warning_summary
+
+
+# --------------------------------------------------------------------------
+# The dead handlers — offline, via AST
+# --------------------------------------------------------------------------
+
+def _caught_exception_names(func) -> set:
+    """Names in this function's `except` clauses, via AST rather than text.
+
+    Grepping the source is what a first pass does and it is wrong here: both
+    functions carry a comment explaining why they do NOT catch this error, so a
+    text match reports the handler it is meant to prove absent.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            for sub in ast.walk(node.type):
+                if isinstance(sub, ast.Name):
+                    names.add(sub.id)
+                elif isinstance(sub, ast.Attribute):
+                    names.add(sub.attr)
+    return names
+
+
+def test_the_dead_handlers_stay_dead():
+    """Neither call site may catch XBRLFilingWithNoXbrlData again."""
+    from edgar import _filings
+
+    assert "XBRLFilingWithNoXbrlData" not in _caught_exception_names(_filings.Filing.xbrl)
+    assert "XBRLFilingWithNoXbrlData" not in _caught_exception_names(Financials.extract)
+
+
+def test_the_handler_probe_can_actually_see_a_handler():
+    """Mutation probe: the guard above must fail when a handler IS present.
+
+    Without this, `_caught_exception_names` returning an empty set for any
+    reason would make the guard vacuously pass forever.
+    """
+    def _with_handler():
+        try:
+            pass
+        except XBRLFilingWithNoXbrlData:
+            return None
+
+    assert "XBRLFilingWithNoXbrlData" in _caught_exception_names(_with_handler)
+
+
+# --------------------------------------------------------------------------
+# Behaviour against the real filing
+# --------------------------------------------------------------------------
+
+@pytest.mark.network
+def test_filing_xbrl_stays_silent(lenient):
+    """`filing.xbrl()` answering None is a true absence and must NOT warn.
+
+    docs/upgrade/6.0.md commits to this staying quiet in 6.0. Moving the
+    warning down to `XBRL.from_filing` would break this and nothing else.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = Filing(**CIRCUIT_CITY_10K).xbrl()
+    assert result is None
+    assert not [w for w in caught if issubclass(w.category, FutureWarning)]
+
+
+@pytest.mark.network
+def test_filing_xbrl_stays_silent_under_strict(strict):
+    """Not even strict mode makes `filing.xbrl()` raise — it is not a failure."""
+    assert Filing(**CIRCUIT_CITY_10K).xbrl() is None
+
+
+@pytest.mark.network
+def test_financials_extract_warns(lenient):
+    """The ground truth: asking for statements that cannot exist says so."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Financials.extract(Filing(**CIRCUIT_CITY_10K))
+    messages = [str(w.message) for w in caught if issubclass(w.category, FutureWarning)]
+    assert messages, "a filing with no XBRL must not go quiet"
+    # The warning names what to catch, so the reader does not have to go find out.
+    assert "XBRLFilingWithNoXbrlData" in messages[0]
+
+
+@pytest.mark.network
+def test_financials_still_returns_the_hollow_object_in_5x(lenient):
+    """5.x behaviour is UNCHANGED apart from the warning.
+
+    Removing the hollow object is the breaking half and lands in 6.0. Staging
+    the warning without the flip is the whole point of edgartools-07lk.23.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        financials = Financials.extract(Filing(**CIRCUIT_CITY_10K))
+    assert financials is not None
+    assert financials.income_statement() is None
+    assert financials.balance_sheet() is None
+    assert financials.cash_flow_statement() is None
+
+
+@pytest.mark.network
+def test_strict_mode_raises_through_financials_extract(strict):
+    """Under strict the error reaches the caller — the 6.0 behaviour."""
+    with pytest.raises(XBRLFilingWithNoXbrlData):
+        Financials.extract(Filing(**CIRCUIT_CITY_10K))
+
+
+@pytest.mark.network
+def test_strict_mode_raises_through_get_financials(strict):
+    """The whole point: the public entry point users actually call."""
+    from edgar import Company
+
+    with pytest.raises(XBRLFilingWithNoXbrlData):
+        Company(104599).get_financials()
+
+
+@pytest.mark.network
+def test_repeated_calls_warn_once(lenient):
+    """A sweep over many pre-2009 filings must not emit one warning per filing."""
+    filing = Filing(**CIRCUIT_CITY_10K)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("default")  # Python's real default filter
+        for _ in range(5):
+            Financials.extract(filing)
+    assert len([w for w in caught if issubclass(w.category, FutureWarning)]) == 1
+
+
+@pytest.mark.network
+def test_filing_with_xbrl_is_untouched_and_silent(lenient):
+    """The healthy path must not warn — a warning here would train users to filter it."""
+    from edgar import Company
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        financials = Company("AAPL").get_financials()
+        income = financials.income_statement()
+    assert income is not None
+    assert not [w for w in caught if issubclass(w.category, FutureWarning)]


### PR DESCRIPTION
The first finding of `07lk.10`'s silent-`None` sweep, and the staging half of it for `07lk.23`.

## The bug

```python
c = Company(104599)          # Circuit City, last 10-K filed 2008-04-28
fin = c.get_financials()

fin is None                  # False  — the object is truthy
fin.income_statement()       # None
fin.balance_sheet()          # None
fin.cash_flow_statement()    # None
# warnings emitted: []
```

A caller who does the documented thing — `if fin is not None:` — **passes the guard** and then gets `None` from every accessor with nothing explaining it. The docstring promises the opposite: *"None means exactly one thing: this company has filed no 10-K, 20-F or 40-F that we can see. It is never how a failure is reported."* Here the filing was found; it just predates SEC's 2009–2011 XBRL phase-in.

Any company that stopped filing before the phase-in reaches this through its **latest** annual report, so no historical-filing gymnastics are needed. Every pre-phase-in filing reaches it via `filing.obj().financials`.

## Three defects in sequence

1. `XBRL.from_filing` returns `None` when there are no XBRL attachments, behind a `log.debug` — not a warning, and debug is off for every normal user.
2. **`XBRLFilingWithNoXbrlData` was never raised anywhere.** `grep -rn "raise XBRLFilingWithNoXbrlData" edgar/` returned nothing. It is already a correct `NotFoundError` in the hierarchy — right error, fully wired, never thrown. Both handlers written for it were dead code that read as handling: `financials.py:127` and `_filings.py:1866`. The second also misled anyone reading `Filing.xbrl()`, whose documented "or None" actually came from the return value, not the `except` above it.
3. `Financials.extract` wrapped the `None` rather than propagating it. 13 methods guard `if self.xb is None: return None`, so the hollowness is systematic rather than one missed accessor.

## What changes

`Financials.extract` now warns via `warn_will_raise` and raises `XBRLFilingWithNoXbrlData` under `EDGARTOOLS_STRICT_ERRORS`. Both dead handlers are removed, so strict actually reaches the caller — leaving either in place would have made strict a no-op on this path.

**The hollow object is unchanged in 5.x.** Removing it is the breaking half; the warning is the additive half that has to ship first, and ship early enough that users get a real warning period. That is `07lk.23`'s whole discipline, and this row was the largest silent-`None` left in the library.

## Why the warning is *not* at the choke point

`XBRL.from_filing` is the shared choke point. Warning there is one edit, covers all eight callers, and cannot miss a path. **I implemented that first and reverted it**, because `docs/upgrade/6.0.md:448` already commits in writing to the opposite:

> `filing.obj()` on a form edgartools does not model still returns `None`, and so does **`filing.xbrl()` on a filing without XBRL**. Those are answers, not failures, and that distinction is the point of the whole change.

Warning at the choke point would have made `filing.xbrl()` warn and, under strict, raise — reversing a published 6.0 commitment as a side effect of fixing something else.

The line that matters: **`filing.xbrl()` is asking whether there is XBRL**, so "there is none" is an answer. **`get_financials()` asked for statements and did not answer** — it returned an object that passes `is not None` and then yields `None` from everything. Same underlying condition, opposite verdicts, and only the second is a silent failure.

Cost accepted: the other six `from_filing` callers (viewer, stitching, examples) stay silent. None is a documented financial-data entry point.

## Verification

14 tests in `tests/issues/regression/test_07lk101_no_xbrl_hollow_financials.py` — 6 offline, 8 network, green in both lanes.

Ground truth is Circuit City `0001193125-08-093063`, a real 2008 10-K, asserted through the public API rather than through internals.

They pin **both halves**, including that `filing.xbrl()` stays silent and stays silent *under strict*. That test is the one a future choke-point refactor would break while every other test in the file still passed — which is exactly how this fix nearly shipped the wrong way.

Two details worth flagging:

- **The dead-handler guard reads the AST, not the source text.** Both functions now carry a comment explaining why they do *not* catch that error, so `"except XBRLFilingWithNoXbrlData" not in getsource(...)` reports the handler it is meant to prove absent. It failed exactly that way on the first run.
- **A mutation probe asserts the AST helper can actually see a handler.** Without it, `_caught_exception_names` returning an empty set for any reason would make the guard pass vacuously forever.

The warning's `warning_summary` carries **no accession number**, so a sweep over a company's filing history warns once rather than once per pre-2009 filing — the trap `_no_xml_to_parse` already hit. `test_repeated_calls_warn_once` pins it under Python's real default filter.

Also green: full `hatch run test-fast` (6354 passed, 9 skipped). Ruff is back at its per-file baseline.

**No internal caller emits the new warning.** The only place in the whole suite that triggers it is `test_filing.py::test_10K_filing_with_no_financial_data` — the intended path. That was checked deliberately, because the `iirl` rename hit the opposite: internal callers turning a deprecation into noise the user could not act on.

## Not covered here

The hollow-object *pattern*. `Financials` is unlikely to be the only class that takes an `Optional` in its constructor and short-circuits all 13 of its accessors on it. That is a different search from "returns `None`" — look for constructors taking `Optional[X]` whose methods all guard on it — and it wants its own pass.

CHANGELOG and `docs/upgrade/6.0.md` entries land in this PR, per the `07lk.18` standard.

Refs edgartools-07lk.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
