### PR TITLE
deprecate(files): the two page-break functions warn before 6.0 removes them (07lk.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - **`detect_page_breaks()` and `mark_page_breaks()` now warn before 6.0 removes them.** Both are re-exported at the top level, so `from edgar import detect_page_breaks` works — and they were the last names in `edgar.files` a user could reach through the documented import root and get no notice about before the package disappears. They emit a `DeprecationWarning` naming 6.0. There is no replacement, and the warning says so: the `edgar.documents` parser treats page-break `<hr>`s and page-number containers as print chrome and discards them, so page-break positions are not part of the supported document model. Internal callers stay silent as before, so a downstream suite running `-W error` is unaffected unless it calls these itself.
+
 ### Changed
 
 - **`get_financials()` no longer goes quiet on a filing that has no XBRL.** A company whose latest annual report predates SEC's 2009-2011 XBRL phase-in got a `Financials` object back — a truthy one, so the documented `if financials is not None:` guard passed — whose `income_statement()`, `balance_sheet()` and `cash_flow_statement()` then all returned `None` with nothing said at any level. `Company(104599).get_financials()`, Circuit City's 2008 10-K, is the case. That path now emits a `FutureWarning` naming the filing and raises `XBRLFilingWithNoXbrlData` in 6.0; set `EDGARTOOLS_STRICT_ERRORS=1` for the 6.0 behaviour today. The object itself is unchanged in 5.x, so nothing you branch on today moves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`detect_page_breaks()` and `mark_page_breaks()` now warn before 6.0 removes them.** Both are re-exported at the top level, so `from edgar import detect_page_breaks` works — and they were the last names in `edgar.files` a user could reach through the documented import root and get no notice about before the package disappears. They emit a `DeprecationWarning` naming 6.0. There is no replacement, and the warning says so: the `edgar.documents` parser treats page-break `<hr>`s and page-number containers as print chrome and discards them, so page-break positions are not part of the supported document model. Internal callers stay silent as before, so a downstream suite running `-W error` is unaffected unless it calls these itself.
+
 ## [5.53.0] - 2026-08-25
 
 ### Changed

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -500,6 +500,7 @@ against these; each will get a section above when it lands.
 | Change | What to expect |
 |---|---|
 | `edgar.files` removal | The legacy parser package and `chunked_document` go. Use `edgar.documents`. |
+| `detect_page_breaks()`, `mark_page_breaks()` | Already deprecated in 5.x, and importable from the top level (`from edgar import detect_page_breaks`), which is why they warn on their own rather than only going out with the package. No replacement — see the row below for why page breaks are not part of the new document model. |
 | `include_page_breaks` on `markdown()` | Already deprecated in 5.x: `Filing.markdown()` and `Attachment.markdown()` render through `edgar.documents`, but `include_page_breaks=True` still falls back to the legacy renderer — which drops images. Both it and `start_page_number` go with `edgar.files`. There is no replacement: the new builder treats page-break `<hr>`s and page-number containers as print chrome and discards them. |
 | `httpx` → `httpx2` | Under consideration, not committed. It is no longer a breaking change for you either way: `TransportError` now owns the exception types at the network boundary, so the HTTP client underneath is ours to change. |
 | Public API **enforcement** | `__all__` is already declared (see below) — 6.0 makes the names outside it private, and some currently-importable names will move. |

--- a/edgar/files/_deprecation.py
+++ b/edgar/files/_deprecation.py
@@ -35,11 +35,22 @@ PAGE_BREAK_DEPRECATION = (
 # the standard library's dataclasses module. The dataclass machinery
 # emits an __init__ that runs in the *defining* module's namespace, so
 # we also skip the deprecated modules when walking up.
+#
+# EVERY MODULE THAT CALLS THIS HELPER MUST BE LISTED. The walk below starts at
+# the caller's own frame, so a deprecated function whose module is absent here
+# is read as an edgartools-internal call and silenced — the warning becomes a
+# no-op that looks correct at the call site and survives any test that only
+# asserts the call exists. `edgar.files.page_breaks` was added when
+# `detect_page_breaks`/`mark_page_breaks` got their warnings and hit exactly
+# that: they fired for nobody until the module was named here.
+# `test_07lk3_page_break_deprecation.py` derives the caller list by scanning
+# the package, so a new call site is covered the day it lands.
 _TRANSPARENT_MODULES = frozenset({
     'edgar.files._deprecation',
     'edgar.files.html',
     'edgar.files.html_documents',
     'edgar.files.htmltools',
+    'edgar.files.page_breaks',
     'dataclasses',
 })
 

--- a/edgar/files/page_breaks.py
+++ b/edgar/files/page_breaks.py
@@ -10,6 +10,22 @@ from typing import Any, Dict, List
 
 from bs4 import Tag
 
+from edgar.files._deprecation import warn_legacy_html_usage
+
+#: `detect_page_breaks` and `mark_page_breaks` are re-exported from the top
+#: level, so `from edgar import detect_page_breaks` works and is the only way a
+#: user is likely to have reached this module. They go with `edgar.files` in
+#: 6.0 and there is no replacement: the `edgar.documents` builder treats page-
+#: break `<hr>`s and page-number containers as print chrome and discards them,
+#: which is why the whole `include_page_breaks` renderer is going rather than
+#: being ported (see `PAGE_BREAK_DEPRECATION` in `_deprecation`).
+_PAGE_BREAKS_DEPRECATION_MSG = (
+    "{name} is deprecated and will be removed in v6.0 along with the "
+    "edgar.files package. There is no replacement: the edgar.documents parser "
+    "treats page breaks as print chrome and discards them, so page-break "
+    "positions are not part of the supported document model."
+)
+
 
 class PageBreakDetector:
     """Detects page breaks in SEC HTML documents."""
@@ -161,7 +177,13 @@ def detect_page_breaks(html_content: str) -> List[Dict[str, Any]]:
 
     Returns:
         List of dictionaries containing page break information
+
+    .. deprecated:: 5.54
+        Removed in 6.0 with the rest of ``edgar.files``. No replacement — the
+        ``edgar.documents`` parser discards page breaks as print chrome.
     """
+    warn_legacy_html_usage(_PAGE_BREAKS_DEPRECATION_MSG.format(name="detect_page_breaks()"))
+
     from bs4 import BeautifulSoup
 
     soup = BeautifulSoup(html_content, 'html.parser')
@@ -234,10 +256,17 @@ def mark_page_breaks(html_content: str) -> str:
 
     Returns:
         Modified HTML string with page break markers added
+
+    .. deprecated:: 5.54
+        Removed in 6.0 with the rest of ``edgar.files``. No replacement — the
+        ``edgar.documents`` parser discards page breaks as print chrome.
     """
+    warn_legacy_html_usage(_PAGE_BREAKS_DEPRECATION_MSG.format(name="mark_page_breaks()"))
+
     from bs4 import BeautifulSoup
 
     soup = BeautifulSoup(html_content, 'html.parser')
+    # The staticmethod, not this function — no second warning for our own hop.
     PageBreakDetector.mark_page_breaks(soup)
     return str(soup)
 

--- a/tests/issues/regression/test_07lk3_page_break_deprecation.py
+++ b/tests/issues/regression/test_07lk3_page_break_deprecation.py
@@ -1,0 +1,166 @@
+"""The last un-warned public names in `edgar.files`.
+
+Bead: edgartools-07lk.3, staging row for edgartools-07lk.23.
+
+`edgar.files` is deleted in 6.0. Most of its public surface already warned —
+`Document`, `ChunkedDocument`, `HtmlDocument` — but `detect_page_breaks` and
+`mark_page_breaks` did not, and those two are RE-EXPORTED AT THE TOP LEVEL:
+`from edgar import detect_page_breaks` works today. They were the only names a
+user could hold, reach through the documented import root, and receive nothing
+about before the package disappeared.
+
+THE BUG THIS FILE EXISTS TO PREVENT IS IN THE GATE, NOT THE WARNING.
+`warn_legacy_html_usage` is frame-gated: it walks up from its own frame and
+stays quiet if the first non-transparent frame belongs to `edgar.*`. The walk
+starts at the CALLER'S OWN FRAME, so a deprecated function whose module is
+missing from `_TRANSPARENT_MODULES` is read as an internal call and silenced.
+
+Adding the two `warn_legacy_html_usage(...)` calls therefore did nothing at all
+until `edgar.files.page_breaks` was added to that set. A test that only asserted
+"the call site exists" would have passed against the broken version, and so
+would any review reading the diff. These tests call the functions as a user does
+and assert a warning actually arrives.
+
+WHAT THESE TESTS PROTECT, in order of how quietly each could break:
+
+  1. **The warnings actually reach a user.** Removing `edgar.files.page_breaks`
+     from `_TRANSPARENT_MODULES` — an easy tidy, since it looks like a list of
+     legacy HTML modules and page_breaks is not one — silently re-suppresses
+     both.
+  2. **Internal callers stay quiet.** The whole reason the gate exists: the
+     `include_page_breaks=True` renderer reaches page-break code on every call,
+     and a naive module-level warning turns `import edgar` into a failure for
+     any downstream suite running `-W error`.
+  3. **The message names the removal and the absence of a replacement.** There
+     is no migration target here — `edgar.documents` discards page breaks as
+     print chrome — and a deprecation that does not say so sends the reader
+     looking for a replacement that was never written.
+"""
+import warnings
+
+import pytest
+
+HTML = (
+    "<html><body>"
+    "<p>One</p>"
+    '<div style="page-break-before: always"></div>'
+    "<p>Two</p>"
+    "</body></html>"
+)
+
+
+def _deprecations(fn, *args):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn(*args)
+    return [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+# --------------------------------------------------------------------------
+# The warnings reach a user
+# --------------------------------------------------------------------------
+
+def test_detect_page_breaks_warns_from_the_top_level_import():
+    """`from edgar import detect_page_breaks` is the path a user actually has."""
+    from edgar import detect_page_breaks
+
+    assert _deprecations(detect_page_breaks, HTML)
+
+
+def test_mark_page_breaks_warns_from_the_top_level_import():
+    from edgar import mark_page_breaks
+
+    assert _deprecations(mark_page_breaks, HTML)
+
+
+@pytest.mark.parametrize("name", ["detect_page_breaks", "mark_page_breaks"])
+def test_message_names_the_release_and_the_missing_replacement(name):
+    """No migration target exists; the warning has to say so."""
+    import edgar
+
+    message = _deprecations(getattr(edgar, name), HTML)[0]
+    assert "6.0" in message
+    assert "no replacement" in message.lower()
+    # Name the function, so a user with several deprecations knows which fired.
+    assert name in message
+
+
+# --------------------------------------------------------------------------
+# The frame gate — the part that silently breaks
+# --------------------------------------------------------------------------
+
+def test_page_breaks_module_is_transparent_to_the_frame_gate():
+    """Without this entry both warnings above are suppressed as 'internal'.
+
+    Asserted directly as well as behaviourally: the behavioural tests say
+    something broke, this one says what.
+    """
+    from edgar.files._deprecation import _TRANSPARENT_MODULES
+
+    assert "edgar.files.page_breaks" in _TRANSPARENT_MODULES
+
+
+def test_every_module_calling_the_helper_is_transparent():
+    """The general form of the bug, so the next call site cannot repeat it.
+
+    Any module that calls `warn_legacy_html_usage` and is not listed as
+    transparent silences itself. Derived by scanning the package rather than
+    hardcoded, so a new call site is covered the day it lands.
+    """
+    import ast
+    from pathlib import Path
+
+    from edgar.files._deprecation import _TRANSPARENT_MODULES
+
+    files_pkg = Path(__file__).parents[3] / "edgar" / "files"
+    callers = set()
+    for path in files_pkg.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "warn_legacy_html_usage"):
+                callers.add(f"edgar.files.{path.stem}")
+
+    missing = callers - _TRANSPARENT_MODULES
+    assert not missing, (
+        f"these modules call warn_legacy_html_usage but are not transparent, "
+        f"so their warnings are silenced: {sorted(missing)}"
+    )
+
+
+def test_the_scan_finds_the_known_callers():
+    """Mutation probe: the scan above must not pass by finding nothing."""
+    import ast
+    from pathlib import Path
+
+    files_pkg = Path(__file__).parents[3] / "edgar" / "files"
+    callers = set()
+    for path in files_pkg.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "warn_legacy_html_usage"):
+                callers.add(f"edgar.files.{path.stem}")
+
+    assert "edgar.files.page_breaks" in callers
+    assert "edgar.files.html" in callers
+
+
+# --------------------------------------------------------------------------
+# Internal callers stay quiet
+# --------------------------------------------------------------------------
+
+def test_internal_page_break_marking_stays_quiet():
+    """`Document.parse` marks page breaks internally and must not warn twice.
+
+    It emits its own `edgar.files.html` deprecation; adding a second one for
+    the page-break hop would make the legacy path noisier than the thing it is
+    steering people away from.
+    """
+    from edgar.files.html import Document
+
+    messages = _deprecations(Document.parse, HTML)
+    page_break_warnings = [m for m in messages if "page_breaks()" in m]
+    assert not page_break_warnings, messages


### PR DESCRIPTION
Staging row for `07lk.23`: the last un-warned public names in `edgar.files`.

## What was missing

`edgar.files` is deleted in 6.0. Most of its public surface already warned — `Document`, `ChunkedDocument`, `HtmlDocument`. Two names did not, and they are the two that are **re-exported at the top level**:

```python
from edgar import detect_page_breaks, mark_page_breaks   # works today, warned about nothing
```

Those were the only names a user could hold, reach through the documented import root, and get no notice about before the package disappears.

Both now emit a `DeprecationWarning` naming 6.0. The message also says **there is no replacement**, which matters more than usual here: the `edgar.documents` builder treats page-break `<hr>`s and page-number containers as print chrome and discards them, so page-break positions are not part of the supported document model. A deprecation that omits that sends the reader hunting for a migration target nobody wrote.

## The part worth reviewing is the frame gate, not the warnings

`warn_legacy_html_usage` is frame-gated — it walks up from its own frame and stays quiet if the first non-transparent frame belongs to `edgar.*`. That gate exists for a good reason: the legacy renderer reaches this code on every call, and a naive module-level warning turns `import edgar` into a failure for any downstream suite running `-W error`.

The walk starts at the **caller's own frame**. So a deprecated function whose module is absent from `_TRANSPARENT_MODULES` is read as an internal call and silenced.

**Adding the two `warn_legacy_html_usage(...)` calls therefore did nothing at all** until `edgar.files.page_breaks` joined that set. Measured with a probe before and after, not inferred from reading:

```
                                      before        after
edgar.detect_page_breaks(html)        SILENT   ->   WARNS
edgar.mark_page_breaks(html)          SILENT   ->   WARNS
edgar.Document(...)                   WARNS         WARNS     (control)
ChunkedDocument(html)                 WARNS         WARNS     (control)
```

A test asserting only "the call site exists" would have passed against the broken version, and so would a review reading the diff. `_deprecation.py` now carries a comment saying this, because the set reads as a list of legacy *HTML* modules and `page_breaks` is not one — which makes deleting the entry look like a tidy.

## What is deliberately left alone

`PageBreakDetector` stays silent. It is staticmethod-only, not exported at the top level, undocumented, and its one real caller is `edgar.files.html` — which already emits its own deprecation. Warning on the staticmethod would double-warn the same user for a single call.

## Verification

8 tests in `tests/issues/regression/test_07lk3_page_break_deprecation.py`, all offline, so they gate this PR rather than only running post-merge.

They pin the behaviour *and* the gate. `test_every_module_calling_the_helper_is_transparent` derives the caller list by scanning the package with the AST rather than hardcoding it, so the next call site is covered the day it lands instead of repeating this bug. A companion probe asserts that scan actually finds the known callers, so it cannot pass by finding nothing.

**Mutation-probed:** removing `edgar.files.page_breaks` from `_TRANSPARENT_MODULES` fails 6 of the 8.

Also green: full `hatch run test-fast` (6356 passed, 9 skipped). Ruff unchanged — 0 errors on both touched files, before and after.

**No library code emits the new warning.** The only place in the whole suite that triggers it is `tests/test_page_breaks.py`, which calls the functions directly — user-shaped code, correctly warned. So a downstream suite on `-W error` is unaffected unless it calls these itself.

## Found while measuring, not fixed here

`edgar/files/html_documents_id_parser.py` — 687 lines, three classes (`AssembleText`, `ParsedHtml10K`, `ParsedHtml10Q`) — is **entirely unreachable**. Nothing in `edgar/`, `tests/` or `scripts/` imports the module; the only mentions anywhere are two historical comments in `edgar/documents/` describing a bug that *used* to route there. It is also one of the six remaining `bs4` importers.

I deliberately did not fold a 687-line deletion into a deprecation PR. There is a precedent for handling it in 5.x rather than holding it for the window — `edgar/xbrl/analysis/` was deleted outright on the grounds that a subtree which cannot be constructed has no behaviour to break — and the same argument applies here, more strongly, since these classes have no callers at all. Worth its own PR under `07lk.3` or `07lk.4`.

CHANGELOG and `docs/upgrade/6.0.md` entries land in this PR, per the `07lk.18` standard.

Refs edgartools-07lk.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
