### PR TITLE
test(filing): the no-XBRL 10-K test says which lane each claim belongs to

### DIFF
--- a/tests/test_filing.py
+++ b/tests/test_filing.py
@@ -749,15 +749,40 @@ def test_as_company_filing(carbo_10k_filing):
 
 @pytest.mark.fast
 @pytest.mark.vcr
-def test_10K_filing_with_no_financial_data():
+def test_10K_filing_with_no_financial_data(monkeypatch):
+    """An ABS trust's 10-K carries no XBRL, and both lanes of that are pinned here.
+
+    This test asserted the hollow `Financials` alone until edgartools-07lk.10.1
+    gave that path a voice, at which point it failed in the strict lane — which
+    is the lane doing its job: it exists to find OUR code still relying on the
+    pre-6.0 behaviour. The repair is to say which lane each claim belongs to,
+    not to drop the claim.
+
+    The env var is set explicitly in both directions rather than inherited, so
+    the two halves assert the same things wherever the suite runs, and the flag
+    itself is what the test shows to be the switch.
+    """
+    from edgar.financials import Financials
+    from edgar.xbrl.xbrl import XBRLFilingWithNoXbrlData
+
     filing = Filing(form='10-K', filing_date='2023-05-26', company='CarMax Auto Owner Trust 2019-3', cik=1779026,
                     accession_no='0001779026-23-000027')
     tenk: TenK = filing.obj()
-    assert tenk.financials
+
+    # 5.x: the hollow object stays, and now says so once, on first access.
+    monkeypatch.delenv("EDGARTOOLS_STRICT_ERRORS", raising=False)
+    with pytest.warns(FutureWarning, match="no XBRL"):
+        assert tenk.financials
     assert not tenk.balance_sheet
     assert not tenk.income_statement
     assert not tenk.cash_flow_statement
     print(tenk)
+
+    # 6.0, today, under the flag. Reuses the same filing: `Financials.extract`
+    # is the line that changes, and `tenk.financials` has cached its answer.
+    monkeypatch.setenv("EDGARTOOLS_STRICT_ERRORS", "1")
+    with pytest.raises(XBRLFilingWithNoXbrlData):
+        Financials.extract(filing)
 
 @pytest.mark.fast
 def test_text_url_for_filing(carbo_10k_filing):


### PR DESCRIPTION
Main has been red since #1155 merged. One failure, in the `test-strict-errors` lane:

```
FAILED tests/test_filing.py::test_10K_filing_with_no_financial_data
  edgar.xbrl.xbrl.XBRLFilingWithNoXbrlData: Filing 0001779026-23-000027 (10-K) has no XBRL attachments...
```

`test_10K_filing_with_no_financial_data` asserted `tenk.financials` truthy — the pre-6.0 hollow object — and 07lk.10.1 gave that path a voice, so the assertion raises under `EDGARTOOLS_STRICT_ERRORS=1`.

That is the strict lane doing exactly what it was built for: finding our own code that still relies on the old behaviour while there is a 5.x release left to fix it in. So this names the lane each claim belongs to rather than dropping the claim.

- **5.x half** — env unset, `pytest.warns(FutureWarning, match="no XBRL")` around the first `.financials` access; the hollow-object assertions are unchanged.
- **6.0 half** — env set, `pytest.raises(XBRLFilingWithNoXbrlData)` on `Financials.extract(filing)`, the line that actually changes in 6.0.

Both halves set the variable explicitly rather than inheriting it, so the test asserts the same two things wherever the suite runs and shows the flag to be the switch between them. It reuses the same `filing` object and the already-cached `tenk.financials`, so it stays on the one existing cassette — nothing new is recorded.

## Verification

- lenient lane: passes
- strict lane: passes
- whole offline suite under the flag: **6354 passed, 9 skipped, 1 xfailed** — this was the only test relying on the old behaviour

## Note on what CI can show here

`test-strict-errors` carries `if: github.event_name != 'pull_request'` by design, so the lane this fixes will not run on this PR — it runs on the push to main. That gap is what let the failure land in the first place; worth recording on edgartools-07lk.24 as a silent-pass class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)