### PR TITLE
fix: distinguish 497K fee tables from footnotes

### DIFF
--- a/edgar/funds/_497k_tables.py
+++ b/edgar/funds/_497k_tables.py
@@ -177,9 +177,9 @@ def _label_matches(text: str, *patterns: str) -> bool:
 # Table classification
 # ---------------------------------------------------------------------------
 
-_FEE_TABLE_LABELS = (
-    'management fee',
-    'management fees',
+_MANAGEMENT_FEE_LABEL_RE = re.compile(r'\bmanagement fees?\b')
+_FLATTENED_FEE_VALUES_RE = re.compile(
+    r'^(?:\([^)]*\)\s*)?(?:[-+]?\(?\d*\.?\d+\)?\s*%\s*){2}'
 )
 
 _EXPENSE_EXAMPLE_LABELS = (
@@ -211,6 +211,29 @@ _BAR_CHART_LABELS = (
 )
 
 
+def _is_management_fee_row(row: List[str]) -> bool:
+    """Return whether a row has management-fee label/value structure."""
+    if not row:
+        return False
+
+    label = _normalize(row[0])
+    match = _MANAGEMENT_FEE_LABEL_RE.search(label)
+    if match is None:
+        return False
+    if len(row) > 1:
+        return any(
+            _normalize(cell) in {'none', 'n/a', 'na', 'not applicable', '-', '--', '–', '—'}
+            or '%' in cell
+            or (_parse_percentage(cell) is not None and '.' in cell)
+            for cell in row[1:]
+        )
+
+    # Some malformed nested tables flatten all fee rows into one cell. Keep
+    # those only when the label is immediately followed by two percentage values.
+    trailing = label[match.end():].lstrip()
+    return match.start() == 0 and _FLATTENED_FEE_VALUES_RE.match(trailing) is not None
+
+
 def _classify_table(rows: List[List[str]]) -> Optional[str]:
     """Classify a table by its content. Returns a type string or None."""
     all_text = ' '.join(' '.join(row) for row in rows)
@@ -225,8 +248,9 @@ def _classify_table(rows: List[List[str]]) -> Optional[str]:
             ('quarter' in norm or 'return' in norm)):
         return 'quarter'
 
-    # Check for operating expenses table (has "management fee")
-    if any(p in norm for p in _FEE_TABLE_LABELS):
+    # Match the same label/value structure consumed by the fee extractor so
+    # prose-only footnote tables do not change the extraction strategy.
+    if any(_is_management_fee_row(row) for row in rows):
         return 'operating_expenses'
 
     # Tables with year-period columns (1 year, 3 years, etc.)

--- a/edgar/funds/_497k_tables.py
+++ b/edgar/funds/_497k_tables.py
@@ -178,9 +178,27 @@ def _label_matches(text: str, *patterns: str) -> bool:
 # ---------------------------------------------------------------------------
 
 _MANAGEMENT_FEE_LABEL_RE = re.compile(r'\bmanagement fees?\b')
+_ONE_YEAR_CELL_RE = re.compile(r'^(?:past\s+)?1\s*years?$')
 _FLATTENED_FEE_VALUES_RE = re.compile(
     r'^(?:\([^)]*\)\s*)?(?:[-+]?\(?\d*\.?\d+\)?\s*%\s*){2}'
 )
+_FEE_VALUE_FOOTNOTE_RE = re.compile(r'(?:\s*\(\s*[\d*†‡§]+\s*\)|\s*[*†‡§]+)\s*$')
+_PERCENT_VALUE_SHAPE_RE = re.compile(
+    r'''
+    ^\s*\(?\s*[-+]?\s*
+    (?:\d+(?:\.\s*\d*)?|\.\s*\d+)
+    \s*\)?\s*%\s*\)?\s*
+    (?:
+        [\d*†‡§\s]+
+        | \(\s*[\d*†‡§\s]+\s*\)
+        | [A-Za-z](?:\s*,\s*[A-Za-z])*
+        | \(\s*[A-Za-z](?:\s*,\s*[A-Za-z])*\s*\)
+    )?
+    \s*$
+    ''',
+    re.VERBOSE,
+)
+_MISSING_FEE_VALUES = {'none', 'n/a', 'na', 'not applicable', '-', '--', '–', '—'}
 
 _EXPENSE_EXAMPLE_LABELS = (
     '1 year',
@@ -211,27 +229,78 @@ _BAR_CHART_LABELS = (
 )
 
 
+def _align_indented_fee_row(row: List[str]) -> List[str]:
+    """Remove empty indentation cells before a fee label, preserving headers."""
+    for index, cell in enumerate(row):
+        if cell.strip():
+            return row[index:] if index and _is_fee_label(cell) else row
+    return row
+
+
+def _align_indented_fee_table(rows: List[List[str]]) -> List[List[str]]:
+    """Remove the shared indentation offset without shifting class columns."""
+    label_columns = [
+        index
+        for row in rows
+        for index, cell in enumerate(row)
+        if _is_fee_label(cell)
+    ]
+    offset = min(label_columns, default=0)
+    return [row[offset:] for row in rows] if offset else rows
+
+
+def _is_fee_value(cell: str) -> bool:
+    """Return whether a cell has a fee value or a marked missing value."""
+    normalized = _FEE_VALUE_FOOTNOTE_RE.sub('', _normalize(cell))
+    if normalized in _MISSING_FEE_VALUES:
+        return True
+    if '%' in normalized:
+        return _PERCENT_VALUE_SHAPE_RE.fullmatch(cell.replace('\xa0', ' ')) is not None
+    return _parse_percentage(cell) is not None
+
+
 def _is_management_fee_row(row: List[str]) -> bool:
     """Return whether a row has management-fee label/value structure."""
     if not row:
         return False
 
+    row = _align_indented_fee_row(row)
     label = _normalize(row[0])
     match = _MANAGEMENT_FEE_LABEL_RE.search(label)
     if match is None:
         return False
-    if len(row) > 1:
-        return any(
-            _normalize(cell) in {'none', 'n/a', 'na', 'not applicable', '-', '--', '–', '—'}
-            or '%' in cell
-            or (_parse_percentage(cell) is not None and '.' in cell)
-            for cell in row[1:]
-        )
+    if len(row) > 1 and any(cell.strip() for cell in row[1:]):
+        return any(_is_fee_value(cell) for cell in row[1:])
 
     # Some malformed nested tables flatten all fee rows into one cell. Keep
     # those only when the label is immediately followed by two percentage values.
     trailing = label[match.end():].lstrip()
     return match.start() == 0 and _FLATTENED_FEE_VALUES_RE.match(trailing) is not None
+
+
+def _is_shareholder_fee_row(row: List[str]) -> bool:
+    """Return whether a row has a shareholder-fee label and a separate value."""
+    row = next((row[index:] for index, cell in enumerate(row) if cell.strip()), row)
+    return (
+        len(row) > 1
+        and any(label in _normalize(row[0]) for label in _SHAREHOLDER_FEE_LABELS)
+        and any(_is_fee_value(cell) for cell in row[1:])
+    )
+
+
+def _has_one_year_column(rows: List[List[str]]) -> bool:
+    """Return whether a table has a standalone one-year column label."""
+    return any(
+        _ONE_YEAR_CELL_RE.fullmatch(_normalize(cell)) is not None
+        for row in rows
+        for cell in row
+    )
+
+
+def _has_bar_chart_columns(rows: List[List[str]]) -> bool:
+    """Return whether a table has at least three standalone annual labels."""
+    cells = {_normalize(cell) for row in rows for cell in row}
+    return sum(year in cells for year in _BAR_CHART_LABELS) >= 3
 
 
 def _classify_table(rows: List[List[str]]) -> Optional[str]:
@@ -252,6 +321,17 @@ def _classify_table(rows: List[List[str]]) -> Optional[str]:
     # prose-only footnote tables do not change the extraction strategy.
     if any(_is_management_fee_row(row) for row in rows):
         return 'operating_expenses'
+
+    # Management-fee prose belongs to footnotes, not another table class. Stop
+    # here so words such as "1 Year" or "sales charge" cannot displace the real
+    # expense-example or shareholder-fee table selected later.
+    if (
+        _MANAGEMENT_FEE_LABEL_RE.search(norm)
+        and not any(_is_shareholder_fee_row(row) for row in rows)
+        and not (_has_one_year_column(rows) and ('$' in all_text or '%' in all_text))
+        and not _has_bar_chart_columns(rows)
+    ):
+        return None
 
     # Tables with year-period columns (1 year, 3 years, etc.)
     # Distinguish expense example ($) from performance (%)
@@ -301,6 +381,8 @@ def _extract_operating_expenses(rows: List[List[str]]) -> List[Dict]:
     """
     if not rows:
         return []
+
+    rows = _align_indented_fee_table(rows)
 
     # Detect if first row is a header (class names) or data (fee labels)
     first_row = rows[0]
@@ -383,10 +465,24 @@ def _is_shareholder_fee_label(text: str) -> bool:
     return any(kw in norm for kw in keywords)
 
 
+def _align_indented_shareholder_fee_table(rows: List[List[str]]) -> List[List[str]]:
+    """Remove the shared indentation offset before shareholder-fee labels."""
+    label_columns = [
+        index
+        for row in rows
+        for index, cell in enumerate(row)
+        if _is_shareholder_fee_label(cell)
+    ]
+    offset = min(label_columns, default=0)
+    return [row[offset:] for row in rows] if offset else rows
+
+
 def _extract_shareholder_fees(rows: List[List[str]]) -> List[Dict]:
     """Extract shareholder fees (sales loads, redemption fees)."""
     if not rows:
         return []
+
+    rows = _align_indented_shareholder_fee_table(rows)
 
     # Detect if first row is a header or data
     first_row = rows[0]

--- a/tests/fixtures/prospectus_497k_baseline.json
+++ b/tests/fixtures/prospectus_497k_baseline.json
@@ -37,13 +37,6 @@
         "other_expenses": null,
         "total_annual_expenses": null,
         "twelve_b1_fee": null
-      },
-      {
-        "class_name": "The Investment Adviser has agreed to waive a portion of the management fee through March\u00a031, 2013. In addition, the Investment Adviser has agreed to reimburse the\nFund for certain Fund operating expenses such that total annual Fund operating expenses (exclusive of any front-end load, deferred sales charge, 12b-1 fees, taxes, income tax expense, brokerage commissions, expenses incurred in connection with any\nmerger or reorganization, acquired fund fees and expenses, or extraordinary expenses such as litigation) will not exceed 1.40% for each of Class\u00a0A Shares, Class C Shares and Class I Shares, subject to possible recoupment from the Fund in future\nyears on a rolling three year basis (within the three years after the fees have been waived and expenses reimbursed) if such recoupment can be achieved within the foregoing expense limits. Such waiver or reimbursement may not be terminated without\nthe consent of the Board of Trustees prior to March 31, 2013 and may be modified or terminated by the Investment Adviser at any time after March 31, 2013.",
-        "expense_10yr": 2119,
-        "expense_1yr": null,
-        "expense_3yr": null,
-        "expense_5yr": null
       }
     ],
     "metadata": {
@@ -185,10 +178,7 @@
     "fee_tables": [
       {
         "class_name": "",
-        "expense_10yr": null,
         "expense_1yr": null,
-        "expense_3yr": null,
-        "expense_5yr": null,
         "fee_waiver": null,
         "management_fee": null,
         "max_deferred_sales_load": null,
@@ -197,13 +187,6 @@
         "other_expenses": null,
         "total_annual_expenses": null,
         "twelve_b1_fee": null
-      },
-      {
-        "class_name": "The Adviser has contractually agreed to waive its management fees and/or to bear expenses of the Fund through January\u00a031, 2018 to the extent necessary to prevent total Fund\noperating expenses (excluding acquired fund fees and expenses other than the advisory fees of any AB Mutual Funds in which the Fund may invest, interest expense, taxes, extraordinary expenses, and brokerage commissions and other transaction costs),\non an annualized basis, from exceeding .95%, 1.70%, .70%, 1.20%, .95%, .70% and .70% of average daily net assets, respectively, for Class\u00a0A, Class C, Advisor Class, Class R, Class K, Class I and Class Z shares (\u201cexpense limitations\u201d).\nAny fees waived and expenses borne by the Adviser prior to July\u00a015, 2015 may be reimbursed by the Fund until the end of the third fiscal year after the fiscal period in which the fee was waived or the expense was borne, provided that no\nreimbursement payment will be made that would cause the Fund\u2019s Total Annual Fund Operating Expenses to exceed the expense limitations.",
-        "expense_10yr": null,
-        "expense_1yr": null,
-        "expense_3yr": null,
-        "expense_5yr": null
       }
     ],
     "metadata": {
@@ -360,13 +343,6 @@
         "other_expenses": null,
         "total_annual_expenses": null,
         "twelve_b1_fee": null
-      },
-      {
-        "class_name": "\u201cManagement Fees\u201d and \u201cOther Expenses\u201d have been restated to reflect current fees.",
-        "expense_10yr": null,
-        "expense_1yr": null,
-        "expense_3yr": 593,
-        "expense_5yr": null
       }
     ],
     "metadata": {

--- a/tests/issues/regression/test_issue_912_497k_fee_waiver.py
+++ b/tests/issues/regression/test_issue_912_497k_fee_waiver.py
@@ -30,7 +30,12 @@ from decimal import Decimal
 import pytest
 
 from edgar import find
-from edgar.funds._497k_tables import _extract_operating_expenses, _parse_percentage, extract_fee_tables
+from edgar.funds._497k_tables import (
+    _classify_table,
+    _extract_operating_expenses,
+    _parse_percentage,
+    extract_fee_tables,
+)
 from edgar.funds.prospectus497k import Prospectus497K
 from tests._offline_filings import offline_filing
 
@@ -125,6 +130,197 @@ class TestFeeWaiverFootnoteIsNotAFeeTable:
     )
     def test_prose_management_fee_text_is_not_a_fee_table(self, prose_footnote):
         assert extract_fee_tables(prose_footnote) == []
+
+    @pytest.mark.parametrize(
+        "rows",
+        [
+            [["Management fees are waived for 1 Year at a cost of $25."]],
+            [["The sales charge does not affect waived management fees."]],
+            [
+                ["Management fees are waived for 1 Year."],
+                ["(2)", "0.50%"],
+            ],
+        ],
+    )
+    def test_prose_management_fee_tables_are_terminally_unclassified(self, rows):
+        assert _classify_table(rows) is None
+
+    def test_split_cell_sales_charge_prose_is_terminally_unclassified(self):
+        rows = [
+            [
+                "The sales charge does not affect waived management fees.",
+                "See footnote (2).",
+            ]
+        ]
+
+        assert _classify_table(rows) is None
+
+    def test_percent_bearing_management_fee_prose_is_not_a_fee_table(self):
+        prose_footnote = """
+        <table>
+          <tr>
+            <td>Management Fees</td>
+            <td>may be waived up to 0.50% through 2027</td>
+          </tr>
+        </table>
+        """
+
+        assert extract_fee_tables(prose_footnote) == []
+
+    def test_percent_leading_management_fee_prose_is_not_a_fee_table(self):
+        prose_footnote = """
+        <table>
+          <tr>
+            <td>Management Fees</td>
+            <td>0.50% may be waived through 2027</td>
+          </tr>
+        </table>
+        """
+
+        assert extract_fee_tables(prose_footnote) == []
+
+    @pytest.mark.parametrize(
+        ("management_fee", "expected"),
+        [
+            ("None (1)", None),
+            ("— (1)", None),
+            ("N/A*", None),
+            ("1", Decimal("1")),
+        ],
+    )
+    def test_marked_missing_and_integer_values_keep_fee_table_classified(
+        self, management_fee, expected
+    ):
+        fee_table = f"""
+        <table>
+          <tr><td>Management Fees</td><td>{management_fee}</td></tr>
+          <tr><td>Total Annual Fund Operating Expenses</td><td>0.60%</td></tr>
+        </table>
+        """
+
+        assert extract_fee_tables(fee_table) == [
+            {
+                "class_name": "",
+                "management_fee": expected,
+                "total_annual_expenses": Decimal("0.60"),
+            }
+        ]
+
+    def test_leading_spacer_cells_do_not_hide_fee_labels(self):
+        fee_table = """
+        <table>
+          <tr><td></td><td>Management Fees</td><td>0.65%</td></tr>
+          <tr><td></td><td>Total Annual Fund Operating Expenses</td><td>0.75%</td></tr>
+        </table>
+        """
+
+        assert extract_fee_tables(fee_table) == [
+            {
+                "class_name": "",
+                "management_fee": Decimal("0.65"),
+                "total_annual_expenses": Decimal("0.75"),
+            }
+        ]
+
+    def test_leading_spacer_preserves_multi_class_value_alignment(self):
+        fee_table = """
+        <table>
+          <tr><th></th><th></th><th>Class A</th><th>Class C</th></tr>
+          <tr><td></td><td>Management Fees</td><td>0.50%</td><td>0.60%</td></tr>
+          <tr>
+            <td></td><td>Total Annual Fund Operating Expenses</td>
+            <td>0.75%</td><td>0.85%</td>
+          </tr>
+        </table>
+        """
+
+        assert extract_fee_tables(fee_table) == [
+            {
+                "class_name": "Class A",
+                "management_fee": Decimal("0.50"),
+                "total_annual_expenses": Decimal("0.75"),
+            },
+            {
+                "class_name": "Class C",
+                "management_fee": Decimal("0.60"),
+                "total_annual_expenses": Decimal("0.85"),
+            },
+        ]
+
+    def test_empty_trailing_cell_preserves_flattened_fee_row(self):
+        rows = [["Management Fees 0.65% 0.70%", ""]]
+
+        assert _classify_table(rows) == "operating_expenses"
+
+    def test_management_fee_footnote_does_not_hide_shareholder_fee_table(self):
+        rows = [
+            ["Maximum Sales Charge (Load) Imposed on Purchases", "5.75%"],
+            ["The adviser may waive management fees for some shareholders."],
+        ]
+
+        assert _classify_table(rows) == "shareholder_fees"
+
+    def test_indented_shareholder_row_stays_visible_with_management_fee_footnote(self):
+        rows = [
+            ["", "Maximum Sales Charge (Load) Imposed on Purchases", "5.75%"],
+            ["The adviser may waive management fees for some shareholders."],
+        ]
+
+        assert _classify_table(rows) == "shareholder_fees"
+
+    def test_indented_shareholder_row_preserves_extracted_fee(self):
+        filing_tables = """
+        <table>
+          <tr><td>Management Fees</td><td>0.50%</td></tr>
+          <tr><td>Total Annual Fund Operating Expenses</td><td>0.75%</td></tr>
+        </table>
+        <table>
+          <tr>
+            <td></td>
+            <td>Maximum Sales Charge (Load) Imposed on Purchases</td>
+            <td>5.75%</td>
+          </tr>
+          <tr>
+            <td>The adviser may waive management fees for some shareholders.</td>
+          </tr>
+        </table>
+        """
+
+        assert extract_fee_tables(filing_tables) == [
+            {
+                "class_name": "",
+                "management_fee": Decimal("0.50"),
+                "total_annual_expenses": Decimal("0.75"),
+                "max_sales_load": Decimal("5.75"),
+            }
+        ]
+
+    def test_management_fee_footnote_does_not_hide_expense_example(self):
+        rows = [
+            ["", "1 Year", "3 Years"],
+            ["Class A", "$109", "$381"],
+            ["Management fees may be waived under the expense limitation agreement."],
+        ]
+
+        assert _classify_table(rows) == "expense_example"
+
+    def test_management_fee_footnote_does_not_hide_performance_table(self):
+        rows = [
+            ["", "1 Year", "5 Years"],
+            ["Return", "7.50%", "8.25%"],
+            ["Management fees may be waived under the expense limitation agreement."],
+        ]
+
+        assert _classify_table(rows) == "performance"
+
+    def test_management_fee_footnote_does_not_hide_bar_chart(self):
+        rows = [
+            ["2020", "2021", "2022", "2023"],
+            ["4.25%", "6.10%", "-3.50%", "8.75%"],
+            ["Management fees may be waived under the expense limitation agreement."],
+        ]
+
+        assert _classify_table(rows) == "bar_chart"
 
 
 class TestFeeWaiverIsNotTheNetRatio:

--- a/tests/issues/regression/test_issue_912_497k_fee_waiver.py
+++ b/tests/issues/regression/test_issue_912_497k_fee_waiver.py
@@ -9,6 +9,11 @@ Reimbursement". The elif chain in `_extract_operating_expenses` tested
 matched the waiver branch, overwrote the real waiver value, and made the
 net_expenses branch unreachable.
 
+The same filing also rendered its fee-waiver footnote as a one-row table.
+Because the prose mentions "management fees", `_classify_table` counted it as
+a second operating-expenses table. That invented a phantom share class and
+changed the expense-example parser, producing $3 instead of $109 and $381.
+
 Ground truth is hand-verified from the fee table of the filing named in the
 issue: https://www.sec.gov/Archives/edgar/data/1314414/000158064224004234/
 
@@ -25,12 +30,32 @@ from decimal import Decimal
 import pytest
 
 from edgar import find
-from edgar.funds._497k_tables import _extract_operating_expenses, _parse_percentage
+from edgar.funds._497k_tables import _extract_operating_expenses, _parse_percentage, extract_fee_tables
 from edgar.funds.prospectus497k import Prospectus497K
 from tests._offline_filings import offline_filing
 
 # The 497K named in GH #912: Ocean Park High Income ETF, series S000085658.
 OCEAN_PARK_ACCESSION = "0001580642-24-004234"
+
+OCEAN_PARK_FEE_EXCERPT = """
+<table>
+  <tr><td>Annual Fund Operating Expenses</td><td></td></tr>
+  <tr><td>Management Fees</td><td>0.65%</td></tr>
+  <tr><td>Distribution and Service (12b-1) Fees</td><td>0.00%</td></tr>
+  <tr><td>Other Expenses (1)</td><td>0.32%</td></tr>
+  <tr><td>Acquired Fund Fees and Expenses (1)(2)</td><td>0.29%</td></tr>
+  <tr><td>Total Annual Fund Operating Expenses</td><td>1.26%</td></tr>
+  <tr><td>Fee Waiver and Reimbursement (3)</td><td>(0.19)%</td></tr>
+  <tr><td>Total Annual Fund Operating Expenses after Fee Waiver and Reimbursement</td><td>1.07%</td></tr>
+</table>
+<table>
+  <tr><td></td><td>(3)</td><td>The Adviser has contractually agreed to waive its management fees.</td></tr>
+</table>
+<table>
+  <tr><td>1 Year</td><td>3 Years</td></tr>
+  <tr><td>$109</td><td>$381</td></tr>
+</table>
+"""
 
 
 def _ocean_park_class(prospectus: Prospectus497K):
@@ -39,6 +64,67 @@ def _ocean_park_class(prospectus: Prospectus497K):
         if share_class.total_annual_expenses is not None:
             return share_class
     raise AssertionError("no share class carried operating-expense data")
+
+
+class TestFeeWaiverFootnoteIsNotAFeeTable:
+    def test_footnote_does_not_change_fee_table_layout(self):
+        assert extract_fee_tables(OCEAN_PARK_FEE_EXCERPT) == [
+            {
+                "class_name": "",
+                "management_fee": Decimal("0.65"),
+                "twelve_b1_fee": Decimal("0.00"),
+                "other_expenses": Decimal("0.32"),
+                "acquired_fund_fees": Decimal("0.29"),
+                "total_annual_expenses": Decimal("1.26"),
+                "fee_waiver": Decimal("-0.19"),
+                "net_expenses": Decimal("1.07"),
+                "expense_1yr": 109,
+                "expense_3yr": 381,
+            }
+        ]
+
+    def test_structured_management_fee_row_controls_classification(self):
+        fee_table = """
+        <table>
+          <tr><td>Annual Management Fees (1)</td><td>0.65%</td></tr>
+          <tr><td>Total Annual Fund Operating Expenses</td><td>0.65%</td></tr>
+        </table>
+        """
+
+        assert extract_fee_tables(fee_table) == [
+            {
+                "class_name": "",
+                "management_fee": Decimal("0.65"),
+                "total_annual_expenses": Decimal("0.65"),
+            }
+        ]
+
+    def test_en_dash_preserves_a_missing_management_fee(self):
+        fee_table = """
+        <table>
+          <tr><td>Management Fees</td><td>–</td></tr>
+          <tr><td>Total Annual Fund Operating Expenses</td><td>0.50%</td></tr>
+        </table>
+        """
+
+        assert extract_fee_tables(fee_table) == [
+            {
+                "class_name": "",
+                "management_fee": None,
+                "total_annual_expenses": Decimal("0.50"),
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "prose_footnote",
+        [
+            "<table><tr><td>Management fees have been restated.</td></tr></table>",
+            "<table><tr><td>Management fees have been restated.</td><td></td></tr></table>",
+            "<table><tr><td>Management fees 0.65% may be waived until expenses reach 1.00%.</td></tr></table>",
+        ],
+    )
+    def test_prose_management_fee_text_is_not_a_fee_table(self, prose_footnote):
+        assert extract_fee_tables(prose_footnote) == []
 
 
 class TestFeeWaiverIsNotTheNetRatio:


### PR DESCRIPTION
## Problem

A 497K fee-waiver footnote can be rendered as its own one-row table. The Ocean Park filing in #912 includes the phrase "management fees" in that prose, so `_classify_table` treated the footnote as a second operating-expenses table.

That false positive changed `extract_fee_tables` to the repeated-section path. The single-column expense parser then read `3 Years` as `$3`, returned no three-year value, and emitted the footnote as a phantom share class. The reduced filing excerpt returned two records with `expense_1yr == 3` instead of one record with expenses of $109 and $381.

## Approach

- Require fee-label/value structure before classifying a table as operating expenses. Missing values with conventional footnote markers and integer values remain valid, while percent-bearing narrative must match the complete SEC value shape.
- Stop prose-only management-fee tables before they fall through into expense-example, shareholder-fee, performance, or bar-chart classifiers. Mixed tables retain those classifications only when they contain the corresponding structural signal.
- Normalize a shared leading spacer offset across the whole operating-expense or shareholder-fee table so multi-class headers and values remain aligned.
- Preserve malformed nested tables that flatten into one cell only when the label is immediately followed by multiple percentage values, including the existing trailing-empty-cell shape.
- Add a reduced regression fixture preserving the three relevant Ocean Park tables, plus end-to-end cases for marked missing values, percent-bearing prose, single- and multi-class spacer layouts, flattened rows, and indented shareholder fees.
- Update the existing 497K corpus baseline to remove the three phantom records created from one-row prose footnotes.

I rejected filtering malformed classes after extraction because the false table count has already selected the wrong expense-example parser by then. I also rejected a literal prefix check because valid labels can be prefixed or footnote-marked, while prose can itself begin with "management fees."

A corpus-wide classifier comparison changed exactly three tables, all one-row prose footnotes. Existing management-fee label rows remained classified as operating expenses.

## Review follow-up

The maintainer-reported fall-through, marked-value, spacer-column, and flattened-row cases are covered directly. Follow-up review also added end-to-end protection for percent-leading narrative, multi-class value alignment, and shareholder-fee extraction after indentation normalization.

## Compatibility

This does not change the public API. It narrows an internal classifier false positive and preserves existing SEC value forms, including leading-decimal percentages, split-text percentages, parenthesized values, numeric or symbol markers, and single-letter marker lists.

This intentionally leaves the cover-page ticker fallback from #912 out of scope because it is a separate extraction path with different fallback rules.

## Testing

- Every reported and review-discovered behavior was reproduced as an isolated failing test before its source fix.
- `uvx hatch run pytest tests/issues/regression/test_issue_912_497k_fee_waiver.py tests/test_prospectus497k.py -q --tb=short`: 98 passed.
- Focused 497K characterization command: 50 passed with the same three environment-dependent metadata-only baseline cases excluded; the untouched branch fails those same three cases.
- Fast xdist and coverage gate: 6,433 passed; its 23 failures exactly match the untouched branch.
- Full regression gate: 2,950 passed; its 10 failures exactly match the untouched branch.
- Cassette safety, regression no-skip, regression provenance, Ruff, Pyright, added-line security, and whitespace checks introduced no new findings.
- The exact final diff and its current-base integration passed a fresh fail-closed review with no logic, security, scope, or test-gap findings.

Related to #912
