### PR TITLE
fix(xbrl,find): four structural defects — dead stitching path, dropped query option, mutated fact cache, X-ticker routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`XBRLS.get_statement(use_optimal_periods=False)` crashed instead of returning a statement.** The non-optimal path appended the `(statements, role, statement_type)` tuple from `XBRL.find_statement()` to the list handed to `StatementStitcher`, which then called `.get()` on it and raised `AttributeError: 'tuple' object has no attribute 'get'`. It now calls `get_statement_by_type()`, the same accessor the optimal path uses, and skips filings that lack the statement type. (GH #1173)
+- **`XBRLS.query(standardize=False)` still standardized.** The option was stored under the keyword `standardize` and read back as `standard`, so it never reached `get_statement()` and every query came back with standard-concept mapping applied. Both spellings are now accepted. (GH #1172)
+- **`FactQuery.transform()` and `.scale()` mutated the shared fact cache.** Transformed values were written back into the row dictionaries returned by `get_facts()`, which come from the facts view's cache, so `.scale(1000)` scaled the cache itself and a second identical query returned values divided by a million. Rows are now copied before transformation. `StitchedFactQuery` had the same defect. (GH #1175)
+- **`find()` did not recognize tickers containing `X`.** The ordinary-ticker pattern was `^[A-WYZ]{1,5}([.-][A-Z])?$`, a character class excluding `X` in every position rather than only the trailing position that marks a mutual fund, so `find("XOM")` returned `CompanySearchResults` instead of the `Company` that `Company("XOM")` resolves. The `^[A-Z]{4}X$` fund pattern is now tested first and the ticker pattern admits the full alphabet. (GH #1178)
+
 ## [5.54.0] - 2026-08-30
 
 ### Deprecated

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -296,13 +296,16 @@ def find(search_id: Union[str, int]) -> Optional[Union[Filing, Entity, CompanySe
         return get_by_accession_number_enriched(accession_number)
     elif re.match(r"\d{4,10}$", search_id):
         return Entity(search_id)
-    elif re.match(r"^[A-WYZ]{1,5}([.-][A-Z])?$", search_id):  # Ticker (including dot or hyphenated)
+    elif re.match(r"^[A-Z]{4}X$", search_id):  # Mutual Fund Ticker
+        # Checked before the ordinary-ticker branch below.  The five-letter
+        # trailing X is the mutual fund convention, so it wins over the more
+        # general ticker shape it would otherwise also match.
+        return find_fund(search_id)
+    elif re.match(r"^[A-Z]{1,5}([.-][A-Z])?$", search_id):  # Ticker (including dot or hyphenated)
         try:
             return Entity(search_id)
         except CompanyNotFoundError:
             return find_company(search_id)
-    elif re.match(r"^[A-Z]{4}X$", search_id):  # Mutual Fund Ticker
-        return find_fund(search_id)
     elif re.match(r"^[CS]\d+$", search_id):
         return find_fund(search_id)
     elif re.match(r"^\d{6,}-", search_id):

--- a/edgar/xbrl/facts.py
+++ b/edgar/xbrl/facts.py
@@ -881,11 +881,18 @@ class FactQuery:
         for filter_func in self._filters:
             results = [f for f in results if filter_func(f)]
 
-        # Apply transformations
-        for transform_fn in self._transformations:
+        # Apply transformations.  Copy each row before writing to it: get_facts()
+        # hands back the rows from FactsView's shared cache, so transforming in
+        # place would scale the cache itself and compound on the next query.
+        if self._transformations:
+            transformed = []
             for fact in results:
                 if 'value' in fact and fact['value'] is not None:
-                    fact['value'] = transform_fn(fact['value'])
+                    fact = dict(fact)
+                    for transform_fn in self._transformations:
+                        fact['value'] = transform_fn(fact['value'])
+                transformed.append(fact)
+            results = transformed
 
         # Apply aggregations
         if self._aggregations:

--- a/edgar/xbrl/stitching/core.py
+++ b/edgar/xbrl/stitching/core.py
@@ -1071,8 +1071,18 @@ def stitch_statements(
     # Traditional approach without using entity info
     else:
         for xbrl in xbrl_list:
-            # Get statement data for the specified type
-            statement = xbrl.find_statement(statement_type)
+            # Get statement data for the specified type.  This must be
+            # get_statement_by_type() and not find_statement(): the latter
+            # returns a (statements, role, statement_type) tuple of index
+            # entries, which carries neither 'periods' nor 'data' and which
+            # StatementStitcher cannot read.  Skip filings that lack this
+            # statement type, matching the optimal-periods path above.
+            try:
+                statement = xbrl.get_statement_by_type(
+                    statement_type, include_dimensions=include_dimensions
+                )
+            except StatementNotFoundError:
+                continue
             if statement:
                 statements.append(statement)
 

--- a/edgar/xbrl/stitching/query.py
+++ b/edgar/xbrl/stitching/query.py
@@ -278,7 +278,10 @@ class StitchedFactQuery(FactQuery):
 
         # Store query-specific parameters for get_facts
         self._max_periods = kwargs.get('max_periods', 8)
-        self._standard = kwargs.get('standard', True)
+        # XBRLS.query() spells this option 'standardize'; the base FactQuery
+        # spells it 'standard'.  Accept both, or the caller's standardize=False
+        # is silently dropped and standardization stays on.
+        self._standard = kwargs.get('standardize', kwargs.get('standard', True))
         self._statement_types = kwargs.get('statement_types', None)
 
     def __str__(self):
@@ -410,11 +413,18 @@ class StitchedFactQuery(FactQuery):
         for filter_func in self._filters:
             results = [f for f in results if filter_func(f)]
 
-        # Apply transformations
-        for transform_fn in self._transformations:
+        # Apply transformations.  Copy each row before writing to it: get_facts()
+        # hands back the rows from the view's shared cache, so transforming in
+        # place would scale the cache itself and compound on the next query.
+        if self._transformations:
+            transformed = []
             for fact in results:
                 if 'value' in fact and fact['value'] is not None:
-                    fact['value'] = transform_fn(fact['value'])
+                    fact = dict(fact)
+                    for transform_fn in self._transformations:
+                        fact['value'] = transform_fn(fact['value'])
+                transformed.append(fact)
+            results = transformed
 
         # Apply aggregations
         if self._aggregations:

--- a/tests/issues/regression/test_issue_1172_1175_query_options.py
+++ b/tests/issues/regression/test_issue_1172_1175_query_options.py
@@ -1,5 +1,8 @@
 """Regression tests for issues #1172 and #1175.
 
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1172
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1175
+
 #1172 — `XBRLS.query()` stored its option under the keyword `standardize` while
 `StitchedFactQuery` read `standard`, so `standardize=False` was silently dropped
 and standardization stayed on.

--- a/tests/issues/regression/test_issue_1172_1175_query_options.py
+++ b/tests/issues/regression/test_issue_1172_1175_query_options.py
@@ -1,0 +1,123 @@
+"""Regression tests for issues #1172 and #1175.
+
+#1172 — `XBRLS.query()` stored its option under the keyword `standardize` while
+`StitchedFactQuery` read `standard`, so `standardize=False` was silently dropped
+and standardization stayed on.
+
+#1175 — `FactQuery.transform()` / `.scale()` wrote transformed values straight
+back into the fact dictionaries returned by `get_facts()`.  Those dictionaries
+come from the facts view's shared cache, so a transform mutated the cache and
+compounded on every later query.
+"""
+
+from types import MethodType
+
+from edgar.xbrl import XBRLS
+from edgar.xbrl.facts import FactQuery
+from edgar.xbrl.stitching.query import StitchedFactQuery, StitchedFactsView
+
+PERIOD = "duration_2025-01-01_2025-12-31"
+
+
+def _stub_statement(standard: bool):
+    return {
+        "periods": [(PERIOD, "2025")],
+        "statement_data": [
+            {
+                "concept": "example_Sales",
+                "label": "Company-specific sales",
+                "original_label": "Company-specific sales",
+                "standard_concept": "Revenue" if standard else None,
+                "values": {PERIOD: 100},
+            }
+        ],
+    }
+
+
+# --- #1172 ------------------------------------------------------------------
+
+def test_standardize_false_reaches_get_statement():
+    received = []
+    xbrls = XBRLS([])
+
+    def fake_get_statement(self, statement_type, max_periods=8, standard=True, **kwargs):
+        received.append(standard)
+        return _stub_statement(standard)
+
+    xbrls.get_statement = MethodType(fake_get_statement, xbrls)
+
+    result = xbrls.query(standardize=False, statement_types=["IncomeStatement"]).execute()
+
+    assert received == [False]
+    assert result[0]["standard_concept"] is None
+
+
+def test_standardize_defaults_to_true():
+    received = []
+    xbrls = XBRLS([])
+
+    def fake_get_statement(self, statement_type, max_periods=8, standard=True, **kwargs):
+        received.append(standard)
+        return _stub_statement(standard)
+
+    xbrls.get_statement = MethodType(fake_get_statement, xbrls)
+
+    result = xbrls.query(statement_types=["IncomeStatement"]).execute()
+
+    assert received == [True]
+    assert result[0]["standard_concept"] == "Revenue"
+
+
+def test_the_base_standard_keyword_still_works():
+    """StitchedFactQuery is also constructed directly with `standard`."""
+    view = StitchedFactsView(XBRLS([]))
+    assert StitchedFactQuery(view, standard=False)._standard is False
+    assert StitchedFactQuery(view, standardize=False)._standard is False
+    assert StitchedFactQuery(view)._standard is True
+
+
+# --- #1175 ------------------------------------------------------------------
+
+class _CachingFactsView:
+    """A facts view that hands back the same row objects on every call."""
+
+    def __init__(self):
+        self.cache = [{"concept": "us-gaap_Revenues", "value": 1000, "label": "Revenues"}]
+
+    def get_facts(self, **kwargs):
+        return self.cache
+
+
+def test_scale_does_not_mutate_the_shared_fact_cache():
+    view = _CachingFactsView()
+
+    first = FactQuery(view).scale(1000).execute()
+    assert first[0]["value"] == 1.0
+
+    # The cached row must be untouched, so a second identical query agrees.
+    assert view.cache[0]["value"] == 1000
+    second = FactQuery(view).scale(1000).execute()
+    assert second[0]["value"] == 1.0
+
+    # And an untransformed query still sees the original value.
+    assert FactQuery(view).execute()[0]["value"] == 1000
+
+
+def test_stitched_scale_does_not_mutate_the_shared_fact_cache():
+    view = _CachingFactsView()
+
+    first = StitchedFactQuery(view).scale(1000).execute()
+    assert first[0]["value"] == 1.0
+
+    assert view.cache[0]["value"] == 1000
+    second = StitchedFactQuery(view).scale(1000).execute()
+    assert second[0]["value"] == 1.0
+
+
+def test_chained_transforms_still_compose_in_order():
+    view = _CachingFactsView()
+
+    result = FactQuery(view).transform(lambda v: v + 1).transform(lambda v: v * 2).execute()
+
+    assert result[0]["value"] == 2002
+    assert view.cache[0]["value"] == 1000

--- a/tests/issues/regression/test_issue_1173_stitch_non_optimal_periods.py
+++ b/tests/issues/regression/test_issue_1173_stitch_non_optimal_periods.py
@@ -1,5 +1,7 @@
 """Regression test for issue #1173.
 
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1173
+
 `XBRLS.get_statement(use_optimal_periods=False)` appended the three-item tuple
 returned by `XBRL.find_statement()` to the list of statements handed to
 `StatementStitcher`, which then called `.get()` on it.  The non-optimal path

--- a/tests/issues/regression/test_issue_1173_stitch_non_optimal_periods.py
+++ b/tests/issues/regression/test_issue_1173_stitch_non_optimal_periods.py
@@ -1,0 +1,79 @@
+"""Regression test for issue #1173.
+
+`XBRLS.get_statement(use_optimal_periods=False)` appended the three-item tuple
+returned by `XBRL.find_statement()` to the list of statements handed to
+`StatementStitcher`, which then called `.get()` on it.  The non-optimal path
+raised `AttributeError: 'tuple' object has no attribute 'get'` and could never
+return a statement.
+"""
+
+from edgar.xbrl import XBRLS
+
+PERIOD = "duration_2024-01-01_2024-12-31"
+
+STATEMENT = {
+    "role": "role://income",
+    "definition": "Income statement",
+    "statement_type": "IncomeStatement",
+    "periods": {PERIOD: {"label": "2024"}},
+    "data": [
+        {
+            "concept": "us-gaap_Revenues",
+            "label": "Revenues",
+            "values": {PERIOD: 350018000000},
+            "decimals": {PERIOD: -6},
+        }
+    ],
+}
+
+
+class StubXBRL:
+    """The two calls stitch_statements() makes on an XBRL object."""
+
+    entity_info = {
+        "fiscal_period": "FY",
+        "fiscal_year": 2024,
+        "document_period_end_date": "2024-12-31",
+    }
+    reporting_periods = [
+        {
+            "key": PERIOD,
+            "label": "Year Ended December 31, 2024",
+            "type": "duration",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+            "duration_days": 365,
+        }
+    ]
+
+    def find_statement(self, statement_type, is_parenthetical=False):
+        # The real signature: (matching statements, role, actual type).
+        return ([STATEMENT], STATEMENT["role"], statement_type)
+
+    def get_statement_by_type(self, statement_type, include_dimensions=False):
+        return STATEMENT
+
+
+def test_non_optimal_path_returns_a_stitched_statement():
+    xbrls = XBRLS.from_xbrl_objects([StubXBRL()])
+
+    result = xbrls.get_statement(
+        "IncomeStatement", max_periods=1, use_optimal_periods=False
+    )
+
+    assert isinstance(result, dict)
+    assert result["periods"] == [(PERIOD, "2024")]
+    assert result["statement_data"][0]["values"][PERIOD] == 350018000000
+
+
+def test_non_optimal_path_agrees_with_the_optimal_path():
+    xbrls = XBRLS.from_xbrl_objects([StubXBRL()])
+
+    optimal = xbrls.get_statement("IncomeStatement", max_periods=1)
+    non_optimal = xbrls.get_statement(
+        "IncomeStatement", max_periods=1, use_optimal_periods=False
+    )
+
+    assert [row["values"] for row in non_optimal["statement_data"]] == [
+        row["values"] for row in optimal["statement_data"]
+    ]

--- a/tests/issues/regression/test_issue_1178_find_ticker_with_x.py
+++ b/tests/issues/regression/test_issue_1178_find_ticker_with_x.py
@@ -1,5 +1,7 @@
 """Regression test for issue #1178.
 
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1178
+
 `find()` matched ordinary tickers with `^[A-WYZ]{1,5}...`, a character class that
 excludes `X` in every position — not just the trailing position that marks a
 mutual fund.  XOM, AXP and FIX therefore fell through to ranked company-name

--- a/tests/issues/regression/test_issue_1178_find_ticker_with_x.py
+++ b/tests/issues/regression/test_issue_1178_find_ticker_with_x.py
@@ -1,0 +1,61 @@
+"""Regression test for issue #1178.
+
+`find()` matched ordinary tickers with `^[A-WYZ]{1,5}...`, a character class that
+excludes `X` in every position — not just the trailing position that marks a
+mutual fund.  XOM, AXP and FIX therefore fell through to ranked company-name
+search and came back as `CompanySearchResults` instead of a `Company`.
+
+The fix orders the `^[A-Z]{4}X$` fund pattern ahead of the ticker pattern, so
+fund routing is preserved without excluding `X` from ordinary symbols.
+"""
+
+import re
+
+import pytest
+
+import edgar
+
+# The two patterns from find(), in dispatch order.
+FUND_TICKER = re.compile(r"^[A-Z]{4}X$")
+ORDINARY_TICKER = re.compile(r"^[A-Z]{1,5}([.-][A-Z])?$")
+
+
+def route(search_id: str) -> str:
+    """Which of the two ticker branches claims this identifier."""
+    if FUND_TICKER.match(search_id):
+        return "fund"
+    if ORDINARY_TICKER.match(search_id):
+        return "ticker"
+    return "name-search"
+
+
+@pytest.mark.parametrize("ticker", ["XOM", "AXP", "FIX", "X", "NFLX", "XYZ", "BRK-B"])
+def test_ordinary_tickers_containing_x_route_to_the_ticker_branch(ticker):
+    assert route(ticker) == "ticker"
+
+
+@pytest.mark.parametrize("ticker", ["VFIAX", "SPHIX", "FXAIX"])
+def test_five_letter_trailing_x_still_routes_to_the_fund_branch(ticker):
+    assert route(ticker) == "fund"
+
+
+@pytest.mark.parametrize("ticker", ["AAPL", "MSFT", "BRK.B"])
+def test_tickers_without_x_are_unaffected(ticker):
+    assert route(ticker) == "ticker"
+
+
+def test_find_source_uses_the_inclusive_ticker_class():
+    """The dispatch chain in edgar/__init__.py must not exclude X."""
+    source = (edgar.__file__)
+    with open(source) as fh:
+        text = fh.read()
+    assert "[A-WYZ]" not in text
+    assert 'r"^[A-Z]{1,5}([.-][A-Z])?$"' in text
+
+
+@pytest.mark.network
+@pytest.mark.parametrize("ticker,cik", [("XOM", 34088), ("AXP", 4962), ("FIX", 1035983)])
+def test_find_resolves_x_tickers_to_companies(ticker, cik):
+    result = edgar.find(ticker)
+    assert isinstance(result, edgar.Entity)
+    assert result.cik == cik


### PR DESCRIPTION
Fixes #1173, #1172, #1175 and #1178 — four reproducible defects, each verified against the source before fixing and each gated by a regression test confirmed to fail without its fix.

## The fixes

**#1173 — `XBRLS.get_statement(use_optimal_periods=False)` crashed.** The non-optimal branch appended the `(statements, role, statement_type)` tuple from `XBRL.find_statement()` to the list handed to `StatementStitcher`, which then called `.get()` on it. Those tuple entries are index records carrying neither `periods` nor `data`, so the branch was dead code that raised `AttributeError: 'tuple' object has no attribute 'get'` before stitching a single period. It now calls `get_statement_by_type()` — the accessor the optimal branch already uses, which itself wraps `find_statement()` — with the `StatementNotFoundError` skip added for #683.

**#1172 — `XBRLS.query(standardize=False)` still standardized.** `XBRLS.query()` stored the option as `standardize`; `StitchedFactQuery.__init__` read `standard`. The value never reached `get_statement()`, so standardization stayed on regardless. Both spellings are accepted now, keeping the base-class `standard=` callers working.

**#1175 — `.transform()` / `.scale()` mutated the shared fact cache.** Both `FactQuery` and `StitchedFactQuery` wrote transformed values back into the row dictionaries returned by `get_facts()`, which come from the facts view's cache. `.scale(1000)` therefore scaled the cache itself: a second identical query returned values divided by a million, and an unrelated *untransformed* query on the same view saw the scaled numbers. Rows are copied before transformation.

**#1178 — `find()` did not recognize tickers containing `X`.** The ordinary-ticker pattern `^[A-WYZ]{1,5}([.-][A-Z])?$` excluded `X` in every position, but the thing it was standing in for is the mutual-fund convention of a *trailing* X. `find("XOM")`, `find("AXP")` and `find("FIX")` fell through to `find_company()` and returned `CompanySearchResults` instead of the `Company` that `Company(ticker)` resolves. The `^[A-Z]{4}X$` fund pattern is now tested first and the ticker class admits the full alphabet.

## Verification

- Three new regression tests under `tests/issues/regression/`. Each was confirmed to be a real gate by reverting the source and watching it fail — including reproducing the reporter's exact `AttributeError` for #1173.
- Full fast suite: 4204 passed, 9 skipped. `tests/issues`: 2230 passed, 1 xfailed. No new failures.

## Notes for review

- Fund routing under #1178 is provably unchanged: under the old ordering no X-containing string could reach the ticker branch at all, so everything that previously matched `^[A-Z]{4}X$` still does. The tests pin `VFIAX`/`SPHIX`/`FXAIX` to the fund branch.
- #1178 is a **behavior change** in `find()`'s return type for X-containing tickers. It matches the documented contract, but anyone handling `CompanySearchResults` back from `find("XOM")` now gets an `Entity`.
- The new tests are stub-based and offline. The `@pytest.mark.network` case in `test_issue_1178_find_ticker_with_x.py` (asserting `find("XOM").cik == 34088`) has not been run.
- All four issues were reported by @synfonia-llc in a single automated batch. The four fixed here are the ones I verified against the source line by line; the remaining reports from that batch (#1174, #1176, #1177, #1179, #1180, #1181) are untouched and the data-correctness ones still need ground-truth checking against real filings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
