### PR TITLE
fix(entity): period_length was accepted, documented, and never read (#1177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`period_length` on `EntityFacts.income_statement()` and `.cash_flow_statement()` warns before 6.0 removes it.** `period=` is the supported spelling and the only one that can also ask for `'ttm'`. The parameter is honoured now rather than ignored — see Fixed below. (GH #1177)
+
 ### Fixed
 
+- **`period_length` was accepted, documented, and never read.** `EntityFacts.income_statement(period_length=3)` and `.cash_flow_statement(period_length=3)` returned the *annual* statement with no warning — the parameter appeared nowhere in either method body and had not since the Facts API landed. It now selects the period it names, and a value contradicting `period=` or `annual=` raises `ValidationError` instead of being silently resolved. Numbers can change for callers who were passing it: they were reading annual figures under a quarterly label. (GH #1177)
 - **`XBRLS.get_statement(use_optimal_periods=False)` crashed instead of returning a statement.** The non-optimal path appended the `(statements, role, statement_type)` tuple from `XBRL.find_statement()` to the list handed to `StatementStitcher`, which then called `.get()` on it and raised `AttributeError: 'tuple' object has no attribute 'get'`. It now calls `get_statement_by_type()`, the same accessor the optimal path uses, and skips filings that lack the statement type. (GH #1173)
 - **`XBRLS.query(standardize=False)` still standardized.** The option was stored under the keyword `standardize` and read back as `standard`, so it never reached `get_statement()` and every query came back with standard-concept mapping applied. Both spellings are now accepted. (GH #1172)
 - **`FactQuery.transform()` and `.scale()` mutated the shared fact cache.** Transformed values were written back into the row dictionaries returned by `get_facts()`, which come from the facts view's cache, so `.scale(1000)` scaled the cache itself and a second identical query returned values divided by a million. Rows are now copied before transformation. `StitchedFactQuery` had the same defect. (GH #1175)

--- a/docs/upgrade/6.0.md
+++ b/docs/upgrade/6.0.md
@@ -71,6 +71,55 @@ python -W "default::DeprecationWarning" your_script.py
 
 ---
 
+## `period_length` on the EntityFacts statements
+
+**What changed.** `EntityFacts.income_statement()` and
+`.cash_flow_statement()` took a `period_length` argument documented as
+"3=quarterly, 12=annual". It was never read — it appeared nowhere in either
+method body, and had not since the Facts API landed. Asking for
+`period_length=3` returned the **annual** statement, with no warning.
+
+It is honoured now, and deprecated in the same release: `period=` is the
+supported spelling and the only one that can also say `'ttm'`. **6.0 removes
+`period_length`.**
+
+```python
+# Before — silently annual, whatever you passed
+facts.cash_flow_statement(period_length=3)
+
+# Now — quarterly, with a DeprecationWarning naming the replacement
+facts.cash_flow_statement(period_length=3)
+
+# The spelling to move to
+facts.cash_flow_statement(period='quarterly')
+```
+
+**This one is a fix, not a break.** Nobody can have depended on the old
+behaviour deliberately: there was no way to pass `period_length` and get what
+the docstring promised. If a script of yours passes `period_length=3` and its
+numbers change, they were wrong before — it was reading annual figures under a
+quarterly label.
+
+**Contradictions now raise.** Saying two different things at once used to be
+resolved silently in favour of whichever the code happened to read:
+
+```python
+facts.income_statement(period='annual', period_length=3)   # ValidationError
+facts.income_statement(period='quarterly', period_length=3)  # fine, they agree
+```
+
+`period_length` values other than 3 or 12 raise `ValidationError` as well,
+rather than being ignored.
+
+**The mechanical rewrite:**
+
+```bash
+sed -i '' -e "s/period_length=3/period='quarterly'/g" \
+          -e "s/period_length=12/period='annual'/g" your_script.py
+```
+
+---
+
 ## `edgar` now declares `__all__`
 
 **What changed.** The top-level package declares its public API in `__all__`.

--- a/edgar/entity/entity_facts.py
+++ b/edgar/entity/entity_facts.py
@@ -47,7 +47,7 @@ from edgar.storage import get_edgar_data_directory, is_using_local_storage
 # never reached a traceback or a log. The canonical class builds the message
 # and passes it up. Old name kept as a deprecated alias below.
 from edgar._compat import deprecated_alias
-from edgar.exceptions import CompanyFactsNotFoundError, TransportError, http_status
+from edgar.exceptions import CompanyFactsNotFoundError, TransportError, ValidationError, http_status
 
 __getattr__ = deprecated_alias(NoCompanyFactsFound=CompanyFactsNotFoundError)
 
@@ -1784,6 +1784,85 @@ class EntityFacts:
             ticker=self._ticker,
         )
 
+    # ------------------------------------------------------------------
+    # Period resolution
+    # ------------------------------------------------------------------
+    #
+    # Three parameters name the same thing. `period` is the supported spelling;
+    # `annual` and `period_length` are legacy and both go in 6.0.
+    #
+    # `period_length` was accepted, documented as "3=quarterly, 12=annual", and
+    # never read — it appeared nowhere in the body of either statement method
+    # (#1177). Honouring it is therefore a fix and not a behaviour change: a
+    # caller passing period_length=3 was already getting the annual statement
+    # they did not ask for, silently, which is the failure class 6.0 is closing.
+
+    _PERIOD_LENGTH_TO_PERIOD = {3: "quarterly", 12: "annual"}
+    _VALID_PERIODS = {"annual", "quarterly", "ttm"}
+
+    @classmethod
+    def _resolve_period(cls,
+                        period: Optional[str],
+                        annual: Optional[bool],
+                        period_length: Optional[int]) -> str:
+        """Collapse period/annual/period_length into one period name.
+
+        `period=None` means the caller did not say, which is what lets a
+        contradiction be told apart from the default. Raises ValidationError
+        when the caller asks for two different things at once.
+        """
+        if annual is not None:
+            explicit = "annual" if annual else "quarterly"
+        elif period is not None:
+            explicit = period.lower()
+        else:
+            explicit = None
+
+        if period_length is None:
+            resolved = explicit or "annual"
+        else:
+            implied = cls._PERIOD_LENGTH_TO_PERIOD.get(period_length)
+            if implied is None:
+                raise ValidationError(
+                    f"period_length={period_length!r} is not a period this statement can be "
+                    "built for.",
+                    parameter="period_length",
+                    invalid_value=period_length,
+                    suggestions=[
+                        "period_length=3 for quarterly, or period_length=12 for annual",
+                        "better, use period='quarterly' or period='annual' — "
+                        "period_length is removed in 6.0",
+                    ],
+                )
+            if explicit is not None and explicit != implied:
+                raise ValidationError(
+                    f"period_length={period_length!r} means {implied!r}, which contradicts "
+                    f"the {explicit!r} period also requested.",
+                    parameter="period_length",
+                    invalid_value=period_length,
+                    suggestions=[
+                        f"drop period_length and pass period={implied!r}",
+                        f"or drop the {explicit!r} request if you meant {implied!r}",
+                    ],
+                )
+            warnings.warn(
+                "period_length is deprecated and will be removed in v6.0. "
+                "Use period='quarterly' instead of period_length=3, and "
+                "period='annual' instead of period_length=12.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            resolved = implied
+
+        if resolved not in cls._VALID_PERIODS:
+            # ValidationError IS-A ValueError, so this stays catchable as one.
+            raise ValidationError(
+                "period must be one of: 'annual', 'quarterly', 'ttm'",
+                parameter="period",
+                invalid_value=resolved,
+            )
+        return resolved
+
     def _build_enhanced_statement(self,
                                   facts: List[FinancialFact],
                                   statement_type: str,
@@ -1818,17 +1897,19 @@ class EntityFacts:
                          as_dataframe: bool = False,
                          annual: Optional[bool] = None,
                          concise_format: bool = False,
-                         period: str = 'annual') -> Union[pd.DataFrame, MultiPeriodStatement, 'TTMStatement']:
+                         period: Optional[str] = None) -> Union[pd.DataFrame, MultiPeriodStatement, 'TTMStatement']:
         """
         Get income statement facts for recent periods.
 
         Args:
             periods: Number of periods to retrieve
-            period_length: Optional filter for period length in months (3=quarterly, 12=annual)
+            period_length: Deprecated, removed in 6.0. Period length in months
+                (3=quarterly, 12=annual); prefer period='quarterly'/'annual'.
+                Raises ValidationError if it contradicts period or annual.
             as_dataframe: If True, return DataFrame; if False, return MultiPeriodStatement
             annual: Legacy parameter - if provided, overrides period (True='annual', False='quarterly')
             concise_format: If True, display values as $1.0B, if False display as $1,000,000,000
-            period: 'annual', 'quarterly', or 'ttm' (trailing twelve months)
+            period: 'annual' (the default), 'quarterly', or 'ttm' (trailing twelve months)
 
         Returns:
             MultiPeriodStatement or DataFrame with income statement data
@@ -1848,12 +1929,7 @@ class EntityFacts:
             stmt = facts.income_statement(periods=4)
             df = stmt.to_dataframe()
         """
-        if annual is not None:
-            period = 'annual' if annual else 'quarterly'
-
-        period = period.lower()
-        if period not in {'annual', 'quarterly', 'ttm'}:
-            raise ValueError("period must be one of: 'annual', 'quarterly', 'ttm'")
+        period = self._resolve_period(period, annual, period_length)
 
         if period == 'ttm':
             from edgar.ttm.statement import TTMStatementBuilder
@@ -1999,17 +2075,19 @@ class EntityFacts:
                            as_dataframe: bool = False,
                            annual: Optional[bool] = None,
                            concise_format: bool = False,
-                           period: str = 'annual') -> Union[pd.DataFrame, MultiPeriodStatement, 'TTMStatement']:
+                           period: Optional[str] = None) -> Union[pd.DataFrame, MultiPeriodStatement, 'TTMStatement']:
         """
         Get cash flow statement facts.
 
         Args:
             periods: Number of periods to retrieve
-            period_length: Optional filter for period length in months (3=quarterly, 12=annual)
+            period_length: Deprecated, removed in 6.0. Period length in months
+                (3=quarterly, 12=annual); prefer period='quarterly'/'annual'.
+                Raises ValidationError if it contradicts period or annual.
             as_dataframe: If True, return DataFrame; if False, return MultiPeriodStatement
             annual: Legacy parameter - if provided, overrides period
             concise_format: If True, display values as $1.0B, if False display as $1,000,000,000
-            period: 'annual', 'quarterly', or 'ttm' (trailing twelve months)
+            period: 'annual' (the default), 'quarterly', or 'ttm' (trailing twelve months)
 
         Returns:
             MultiPeriodStatement or DataFrame with cash flow data
@@ -2026,12 +2104,7 @@ class EntityFacts:
             stmt = facts.cash_flow_statement(periods=4)
             df = stmt.to_dataframe()
         """
-        if annual is not None:
-            period = 'annual' if annual else 'quarterly'
-
-        period = period.lower()
-        if period not in {'annual', 'quarterly', 'ttm'}:
-            raise ValueError("period must be one of: 'annual', 'quarterly', 'ttm'")
+        period = self._resolve_period(period, annual, period_length)
 
         if period == 'ttm':
             from edgar.ttm.statement import TTMStatementBuilder
@@ -2053,7 +2126,7 @@ class EntityFacts:
         )
 
     def cash_flow(self, periods: int = 4, period_length: Optional[int] = None, as_dataframe: bool = False,
-                  annual: bool = True, concise_format: bool = False) -> Union[DataFrame, MultiPeriodStatement]:
+                  annual: Optional[bool] = None, concise_format: bool = False) -> Union[DataFrame, MultiPeriodStatement]:
         """Deprecated: Use cash_flow_statement() instead."""
         warnings.warn(
             "cash_flow() is deprecated and will be removed in v6.0. "

--- a/tests/issues/regression/test_issue_1177_period_length.py
+++ b/tests/issues/regression/test_issue_1177_period_length.py
@@ -1,0 +1,140 @@
+"""Regression test for issue #1177.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1177
+Bead: edgartools-07lk.10
+
+`EntityFacts.income_statement()` and `.cash_flow_statement()` accepted a
+`period_length` argument and documented it as "3=quarterly, 12=annual", but
+never read it — it appeared nowhere in either method body.  A caller asking for
+quarterly data with `period_length=3` silently received the annual statement.
+
+This is the silent-failure class 6.0 closes (bead edgartools-07lk.10, GH #933):
+the parameter is now honoured, and deprecated in favour of `period=`.
+"""
+
+import warnings
+
+import pytest
+
+from edgar.entity.entity_facts import EntityFacts
+from edgar.exceptions import ValidationError
+
+def resolve(period, annual, period_length):
+    """Call the resolver at test time, not import time, so this module still
+    collects against a build that lacks it."""
+    return EntityFacts._resolve_period(period, annual, period_length)
+
+
+# --- the bug: period_length was ignored ------------------------------------
+
+def test_period_length_3_selects_quarterly():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert resolve(None, None, 3) == "quarterly"
+
+
+def test_period_length_12_selects_annual():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert resolve(None, None, 12) == "annual"
+
+
+# --- deprecation ------------------------------------------------------------
+
+def test_period_length_warns_and_names_its_replacement():
+    with pytest.warns(DeprecationWarning, match=r"period='quarterly'"):
+        resolve(None, None, 3)
+
+
+def test_no_warning_when_period_length_is_unused():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert resolve(None, None, None) == "annual"
+        assert resolve("quarterly", None, None) == "quarterly"
+
+
+# --- contradictions raise rather than silently picking one ------------------
+
+@pytest.mark.parametrize("period,length", [("annual", 3), ("quarterly", 12), ("ttm", 3), ("ttm", 12)])
+def test_contradicting_period_and_period_length_raises(period, length):
+    with pytest.raises(ValidationError) as exc:
+        resolve(period, None, length)
+    assert exc.value.parameter == "period_length"
+
+
+def test_contradicting_annual_and_period_length_raises():
+    with pytest.raises(ValidationError):
+        resolve(None, True, 3)      # annual=True vs period_length=3
+    with pytest.raises(ValidationError):
+        resolve(None, False, 12)    # annual=False vs period_length=12
+
+
+def test_agreeing_period_and_period_length_is_accepted():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert resolve("quarterly", None, 3) == "quarterly"
+        assert resolve(None, True, 12) == "annual"
+
+
+@pytest.mark.parametrize("length", [0, 1, 6, 9, 24, -3])
+def test_unsupported_period_length_raises(length):
+    with pytest.raises(ValidationError) as exc:
+        resolve(None, None, length)
+    assert exc.value.invalid_value == length
+
+
+# --- existing behaviour is preserved ----------------------------------------
+
+def test_period_defaults_to_annual():
+    assert resolve(None, None, None) == "annual"
+
+
+def test_annual_flag_still_overrides_period():
+    assert resolve("quarterly", True, None) == "annual"
+    assert resolve("annual", False, None) == "quarterly"
+
+
+def test_invalid_period_still_raises_a_valueerror():
+    """ValidationError IS-A ValueError, so existing handlers keep working."""
+    with pytest.raises(ValueError, match="period must be one of"):
+        resolve("monthly", None, None)
+
+
+def test_period_is_case_insensitive():
+    assert resolve("QUARTERLY", None, None) == "quarterly"
+
+
+# --- the public methods actually route through the resolver -----------------
+
+@pytest.mark.parametrize("method_name", ["income_statement", "cash_flow_statement"])
+@pytest.mark.parametrize("period_length,expected_annual", [(3, False), (12, True)])
+def test_period_length_reaches_the_statement_builder(monkeypatch, method_name, period_length, expected_annual):
+    """The original defect: period_length never reached the builder at all.
+
+    Before the fix both values produced annual=True, so period_length=3
+    silently returned the annual statement.
+    """
+    seen = {}
+
+    def fake_build(self, facts, statement_type, periods, annual, as_dataframe, concise_format):
+        seen["annual"] = annual
+        return "statement"
+
+    monkeypatch.setattr(EntityFacts, "_build_enhanced_statement", fake_build)
+    monkeypatch.setattr(EntityFacts, "_ttm_ready_facts", property(lambda self: self), raising=False)
+
+    facts = EntityFacts.__new__(EntityFacts)
+    facts._facts = []
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        getattr(EntityFacts, method_name)(facts, period_length=period_length)
+
+    assert seen["annual"] is expected_annual
+
+
+def test_statement_methods_reject_a_contradiction(monkeypatch):
+    facts = EntityFacts.__new__(EntityFacts)
+    for method in (EntityFacts.income_statement, EntityFacts.cash_flow_statement):
+        with pytest.raises(ValidationError):
+            method(facts, period="annual", period_length=3)


### PR DESCRIPTION
Fixes #1177. Bead `edgartools-07lk.10.2`, under `edgartools-07lk.10` — the 6.0 unified-error-policy work (GH #933).

## The defect

`EntityFacts.income_statement(period_length=3)` and `.cash_flow_statement(period_length=3)` returned the **annual** statement. The parameter sat in both signatures and both docstrings — *"Optional filter for period length in months (3=quarterly, 12=annual)"* — and was referenced **zero times** in either body (`entity_facts.py:1851-1876` and `2029-2054` before this change). `_build_enhanced_statement()` has no such parameter to receive it. Per `git log -S`, it has never been wired since the Facts API landed in `3b44ade1`.

This is the silent-failure class 6.0 is closing, in its purest form: a documented input accepted and discarded, wrong data returned, no warning. Same shape as `07lk.10.1` (the hollow `Financials`), which shipped in 5.54.0.

## The fix — honour it, and deprecate it

Staged additively per the `07lk.23` rule. `EntityFacts._resolve_period()` collapses the three spellings for one concept into a single value:

| input | result |
|---|---|
| `period_length=3` | `'quarterly'` + `DeprecationWarning` naming `period='quarterly'` |
| `period_length=12` | `'annual'` + same |
| contradicts `period=` or `annual=` | `ValidationError(parameter='period_length')` |
| any other value (0, 6, 9, 24, −3) | `ValidationError` |
| invalid `period=` | `ValidationError` — IS-A `ValueError`, message unchanged |

**6.0 removes `period_length`.** `period=` is the supported spelling and the only one that can also express `'ttm'`.

Two default changes make contradiction detection possible, both behaviour-preserving:
- `period` defaults to `None` rather than `'annual'`, so an explicit request is distinguishable from the default. `None` still resolves to `'annual'`.
- `cash_flow()` had `annual=True` as a default *and* forwards `period_length`, so it would have contradicted itself on every call. Its default is `None` now, which resolves identically.

## Why this is a fix and not a break

There was no way to pass `period_length` and get what the docstring promised, so no caller can have depended on the old behaviour deliberately. Numbers may change for callers who passed it — those numbers were annual figures under a quarterly label.

## Verification

- `tests/issues/regression/test_issue_1177_period_length.py`, 25 tests.
- **Behavioural gate verified**: reverting `entity_facts.py` makes `period_length=3` fail for *both* methods (the builder receives `annual=True`), and passes after. `period_length=12` passes either way — correct, since ignoring it coincidentally gave annual.
- Full fast suite 4204 passed / 9 skipped; `tests/issues` 2255 passed / 1 xfailed.
- `docs/upgrade/6.0.md` section added at landing time, per the `07lk.18` standard.

## Note

`balance_sheet()` never accepted `period_length` and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
