### PR TITLE
chore(release): 5.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.55.0] - 2026-08-31
+
 ### Changed
 
 - **`edgar.muniadvisors` is a package rather than a single module.** The MA-I parser moved to `edgar/muniadvisors/core.py`, matching `edgar/ownership/` and `edgar/entity/`. Nothing changes for callers: a module converting to a package of the same name keeps the import path identical, and all 19 of its public names still resolve to the same objects — `__all__` named only `MunicipalAdvisorForm`, so a naive re-export would have dropped the other 18. (bead edgartools-07lk.12.1)
@@ -40,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`XBRLS.query(standardize=False)` still standardized.** The option was stored under the keyword `standardize` and read back as `standard`, so it never reached `get_statement()` and every query came back with standard-concept mapping applied. Both spellings are now accepted. (GH #1172)
 - **`FactQuery.transform()` and `.scale()` mutated the shared fact cache.** Transformed values were written back into the row dictionaries returned by `get_facts()`, which come from the facts view's cache, so `.scale(1000)` scaled the cache itself and a second identical query returned values divided by a million. Rows are now copied before transformation. `StitchedFactQuery` had the same defect. (GH #1175)
 - **`find()` did not recognize tickers containing `X`.** The ordinary-ticker pattern was `^[A-WYZ]{1,5}([.-][A-Z])?$`, a character class excluding `X` in every position rather than only the trailing position that marks a mutual fund, so `find("XOM")` returned `CompanySearchResults` instead of the `Company` that `Company("XOM")` resolves. The `^[A-Z]{4}X$` fund pattern is now tested first and the ticker pattern admits the full alphabet. (GH #1178)
+
 ## [5.54.0] - 2026-08-30
 
 ### Deprecated

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.54.0'
+__version__ = '5.55.0'


### PR DESCRIPTION
Cuts 5.55.0: bumps `edgar/__about__.py` to `5.55.0` and folds the accumulated `[Unreleased]` section into `## [5.55.0] - 2026-08-31`. No code changes — every entry below is already merged on `main`.

## Why now

Two of the entries are staging rows that do nothing until they are on PyPI. The `edgar.effect` → `edgar.offerings.effect` and `edgar.form144` → `edgar.ownership.form144` moves, and the `edgar.files.markdown` / `.tables` / `.text` deprecation warnings, exist so that users meet the warning in a released 5.x before 6.0 removes the old path. Held back until the freeze window, they would ship as an unannounced `ImportError`.

## What ships

**Fixed (13)** — the period-identity cluster from #1204 (a 273-day YTD appearing in a quarterly column, `quarterize()` returning non-quarters, `latest_periods(1)` returning three years, an unchanged annual value presented as Q4), the typed-field cluster from #1203 (`FormD.is_new` inverted, Form D recipient ZIPs always `None`, `Form144.nothing_to_report` truthy `"N"`), the XBRL/find structural defects from #1183, `period_length` accepted and never read, and the multi-warning legacy render.

**Changed** — `edgar.muniadvisors` is a package; the wheel stops shipping ~8,900 lines of development tooling; three silently-disabled signals now report their failure; a malformed 13F primary document names the missing element.

**Deprecated** — the three `edgar.files` modules, the `edgar.effect` / `edgar.form144` old paths, and `period_length`.

**Removed** — `html_documents_id_parser.py` and four dead modules, none with callers.

## Behaviour changes worth reading before merging

- `Form144.nothing_to_report` is `Optional[bool]` now, not `bool`. Callers comparing it against the string `"N"` need updating.
- `period_length` is honoured rather than ignored, so callers who passed it were reading annual figures under a quarterly label and will see different numbers.
- The period-identity fix widens what reaches every `EntityFacts` consumer: the old admission gate was rejecting 4,099 of 8,163 SNOW facts, of which only 6 were the forward-looking schedules it was written for.

## Verification

`hatch run test-fast`: 6579 passed, 9 skipped, 1 xfailed, 3359 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2NaNcXEuv5YvcKFntcaZ