### PR TITLE
fix(tests): resolve the contradicting unaccumulation contract, and put its tests in the lane that gates it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,24 @@ def pytest_collection_modifyitems(config, items):
         # MA-I municipal advisor parse; tests/test_muni_advisors.py matches the
         # 'test_muni' network pattern. Verified with outbound sockets blocked.
         'test_ma_i_form_contract',
+        # Re-classified 2026-08-31. Was in NETWORK_PATTERNS (whole-file, from the
+        # 2026-08-04 pass) because ONE of its 18 tests fetches AAPL from SEC — and
+        # that one already carries its own @pytest.mark.network, which wins over
+        # this list. The whole-file entry bought nothing and cost the 17 synthetic
+        # unit tests of StatementStitcher._unaccumulate_cashflow_ytd, which build
+        # their stitcher in memory and touch no fetch path.
+        #
+        # That is not hypothetical: PR #1204 changed _subtract_periods to drop
+        # un-derivable cells (GH #1179) and left this file's contradicting test
+        # un-updated. It could not fail the pull request, because test-network is
+        # skipped on PRs, so main went red after the merge and the break shipped
+        # in 5.55.0. A test of a function has to run in the lane that gates
+        # changes to that function.
+        #
+        # MEASURED, not guessed: under `pytest -p tests._offline_harness` the file
+        # is 17 passed / 1 failed, the failure being exactly the AAPL test, which
+        # passes on the network.
+        'test_cashflow_unaccumulation',
     ]
 
     # Files that need network (fetch from SEC)
@@ -365,7 +383,7 @@ def pytest_collection_modifyitems(config, items):
         # Classified 2026-08-04 (see the note in FAST_PATTERNS). These fail with
         # outbound sockets blocked, so they are network by measurement.
         'test_registration_s1', 'test_registration_s4', 'test_prospectus497k',
-        'test_cashflow_unaccumulation', 'test_drs', 'test_to_context',
+        'test_drs', 'test_to_context',
         'test_twentyfourf',
         # Reproduction scripts under tests/issues/reproductions/ whose names
         # matched nothing. All fetch from SEC (Company(), get_filings()).

--- a/tests/test_cashflow_unaccumulation.py
+++ b/tests/test_cashflow_unaccumulation.py
@@ -153,8 +153,32 @@ class TestUnaccumulateCashflowYTD:
         assert stitcher.data['us-gaap_OperatingCashFlow'][ytd9_pid]['value'] == 250  # 600-350
         assert stitcher.data['us-gaap_OperatingCashFlow'][fy_pid]['value'] == 400    # 1000-600
 
-    def test_concept_missing_in_shorter_period_kept_as_is(self):
-        """If a concept has no value in the shorter period, the longer value is kept unchanged."""
+    def test_concept_missing_in_shorter_period_is_dropped(self):
+        """A concept with no value in the shorter period is dropped, not kept.
+
+        This test asserted the opposite until GH #1179 (bead edgartools-51xd,
+        shipped 5.55.0). Keeping the longer value looks conservative but is not:
+        `_subtract_periods` relabels the period to a discrete quarter for EVERY
+        concept in it, whether or not that concept could be converted, so a kept
+        value is a CUMULATIVE figure sitting under a Q2/Q3/Q4 label. Meta's FY2024
+        "Deferred income taxes" is the filed case — the 10-K and the Q3 10-Q tag
+        the identically-labelled line differently, so the 12-month $(4.738)B had
+        no operand and was presented as Q4.
+
+        The cost is real and worth stating: a concept genuinely absent from the
+        shorter period because the event had not yet occurred (a one-off
+        impairment first reported in Q2) has a 6-month value that IS its discrete
+        quarter, and that true value is dropped too. XBRL absence does not mean
+        zero, so the two cases are indistinguishable here. For a caller who has
+        explicitly asked for `discrete_quarters=True`, an empty cell is the
+        answerable failure and a mislabelled cumulative figure is not.
+
+        The paired assertion lives in
+        tests/issues/regression/test_51xd_period_identity.py
+        ::test_a_quarter_that_cannot_be_derived_is_dropped_not_left_cumulative.
+        If you are here because this test failed, change the code, not the test:
+        the two encode one contract and must not drift apart again.
+        """
         q1_pid = 'duration_2024-01-01_2024-03-31'
         ytd6_pid = 'duration_2024-01-01_2024-06-30'
 
@@ -165,13 +189,22 @@ class TestUnaccumulateCashflowYTD:
                 {'key': 'us-gaap_SpecialItem', 'values': {
                     ytd6_pid: 42,
                 }},
+                # Control: present in both, so Q2 is derivable and must survive.
+                {'key': 'us-gaap_OperatingCashFlow', 'values': {
+                    q1_pid: 100,
+                    ytd6_pid: 350,
+                }},
             ],
         )
 
         stitcher._unaccumulate_cashflow_ytd()
 
-        # Should be kept as-is since there's nothing to subtract
-        assert stitcher.data['us-gaap_SpecialItem'][ytd6_pid]['value'] == 42
+        assert ytd6_pid not in stitcher.data['us-gaap_SpecialItem'], (
+            "the un-derivable cumulative value survived under a discrete-quarter "
+            f"label: {stitcher.data['us-gaap_SpecialItem'].get(ytd6_pid)}")
+        # Dropping the un-derivable cell must not cost the derivable neighbour,
+        # or the fix would empty the column instead of correcting it.
+        assert stitcher.data['us-gaap_OperatingCashFlow'][ytd6_pid]['value'] == 250
 
     def test_different_fiscal_year_starts_handled_independently(self):
         """Periods from different fiscal years don't interfere with each other."""


### PR DESCRIPTION
`main` is red. One test fails, and it is not flake — it reproduces locally in 8s:

```
tests/test_cashflow_unaccumulation.py::TestUnaccumulateCashflowYTD
  ::test_concept_missing_in_shorter_period_kept_as_is
KeyError: 'duration_2024-01-01_2024-06-30'
```

## Two tests, one contract, opposite assertions

PR #1204 changed `_subtract_periods` to **drop** a cell it cannot derive (GH #1179). This test asserted the opposite — that the longer value is **kept**. They cannot both be right, and the project already chose: `_subtract_periods` relabels the period to a discrete quarter for *every* concept in it, whether or not that concept was converted, so a kept value is a cumulative figure sitting under a `Q2`/`Q3`/`Q4` label. Meta's FY2024 "Deferred income taxes" is the filed case — the 10-K and the Q3 10-Q tag the identically-labelled line differently, so the 12-month $(4.738)B had no operand and was presented as Q4.

The test is updated to the shipped contract and gains a control asserting the *derivable* neighbour on the same period still converts, so a future "fix" cannot empty the column instead of correcting it. Both halves now name each other by node id.

The docstring states the cost rather than hiding it: a concept genuinely absent from the shorter period — a one-off impairment first reported in Q2 — has a 6-month value that *is* its discrete quarter, and that true value is dropped too. XBRL absence does not mean zero, so the two cases are indistinguishable at this layer. For a caller who explicitly passed `discrete_quarters=True`, an empty cell is the answerable failure and a mislabelled cumulative figure is not.

**No library code changes.** The shipped behaviour is correct; only the stale test moves.

## Why it escaped, which matters more

`test_cashflow_unaccumulation` sat in conftest's `NETWORK_PATTERNS` as a **whole file**, from the 2026-08-04 classification, because 1 of its 18 tests fetches AAPL from SEC. That one test already carries its own `@pytest.mark.network`, and an explicit marker wins over the pattern list — so the whole-file entry bought nothing and cost the 17 synthetic unit tests of `StatementStitcher._unaccumulate_cashflow_ytd`, which build their stitcher in memory and touch no fetch path.

`test-network` is skipped on pull requests. So #1204 — which changed exactly that function — could not fail on these tests, merged green, and the break shipped in 5.55.0.

A test of a function has to run in the lane that gates changes to that function.

## Measured, not guessed

Per the procedure in `tests/_offline_harness.py`:

```
pytest -p tests._offline_harness tests/test_cashflow_unaccumulation.py
→ 17 passed, 1 failed
```

The single failure is the AAPL test, and it passes on the network. Lanes now split **17 fast / 1 network**, confirmed by collection.

## Verification

- `hatch run test-fast`: **6596 passed**, 9 skipped, 1 xfailed. Was 6579 before this branch; the +17 are these tests entering the lane.
- `-m network` on the file: 1 passed, 17 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2NaNcXEuv5YvcKFntcaZ