### PR TITLE
fix(xbrl): a Disclosure role about notes payable is not a Notes section (#1207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A disclosure whose subject is notes payable was routed to `notes()`.** `get_all_statements()` falls back to keyword matching when a role carries no `FilingSummary` menu category, and that fallback tested the bare substring `"note"` before it tested `"disclosure"`. "Note" names a financial-statement section and a debt instrument, so Oracle's four `Disclosure - NOTES PAYABLE AND OTHER BORROWINGS` roles (10-Q `0000950170-23-047713`) reported `type="Notes"` / `category="note"`, came back from `xbrl.notes()`, and were absent from `xbrl.disclosures()`. The ambiguous word no longer outranks a role that states what it is - by its `Disclosure` category marker, or by the concept it hangs from (`us-gaap_DebtDisclosureAbstract`) - unless the definition names the notes section itself, so `Notes to Consolidated Financial Statements` and `Note 1 - Organization` still classify as notes. Roles whose definition does not contain "note" are classified exactly as before. (GH #1207)
+
 ## [5.55.0] - 2026-08-31
 
 ### Changed

--- a/edgar/xbrl/xbrl.py
+++ b/edgar/xbrl/xbrl.py
@@ -1072,6 +1072,18 @@ class XBRL:
                     # notes payable, so a role that declares itself a disclosure
                     # is taken at its word unless the definition names the notes
                     # section itself (issue #1207).
+                    #
+                    # Known limitation (issue #1218): this decides one role at a
+                    # time, and in a filing that falls back to role names the
+                    # members of one family do not all carry the same evidence.
+                    # gahc's `ConvertiblePromissoryNotesPayable` hangs from
+                    # us-gaap_DebtDisclosureAbstract and moves; its `Tables` and
+                    # `ScheduleOf...` children hang from a debt-balance abstract
+                    # and their names do not lead with the marker, so they stay
+                    # notes and the family splits across the two accessors. A
+                    # role with a real schema definition - the case in #1207 -
+                    # carries ` - Disclosure - ` on every member, so those move
+                    # together.
                     if _names_notes_section(role_def) or not _declares_disclosure(role_def, primary_concept):
                         statement_type = "Notes"
                         statement_category = "note"

--- a/edgar/xbrl/xbrl.py
+++ b/edgar/xbrl/xbrl.py
@@ -12,6 +12,7 @@ organizing facts according to presentation hierarchies, validating calculations,
 and handling dimensional qualifiers.
 """
 import datetime
+import re
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
@@ -38,6 +39,58 @@ from edgar.xbrl.rendering import RenderedStatement, generate_rich_representation
 from edgar.exceptions import NotFoundError
 from edgar.xbrl.statement_resolver import StatementResolver
 from edgar.xbrl.statements import statement_to_concepts
+
+
+# The word "note" carries two unrelated meanings in a role definition: the
+# financial-statement section, and the debt instrument ("notes payable",
+# "convertible notes").  A role that declares itself a disclosure is one even
+# when notes are its subject, which is what these two helpers separate
+# (issue #1207).
+
+# EDGAR role definitions carry an explicit category segment:
+# "0011 - Disclosure - Promissory Notes Payable".  When the schema definition is
+# missing, the role name stands in for it and the same marker leads it:
+# "DisclosurePromissoryNotesPayable".
+_ROLE_CATEGORY_MARKER = 'disclosure'
+
+# The concept a disclosure role hangs from, e.g. us-gaap_DebtDisclosureAbstract.
+# Matches the Disclosures concept patterns in statement_resolver.py.
+_DISCLOSURE_CONCEPT_RE = re.compile(r"disclosures?abstract$", re.IGNORECASE)
+
+# The section sense of the word, kept deliberately generous: a definition that
+# matches here keeps the classification it already had, so a false positive
+# costs nothing while a false negative would move a real note.
+_NOTES_SECTION_RE = re.compile(
+    r"notes?\s*to\s*[\w\s',&-]*financial\s*statements?"  # Notes to Consolidated Financial Statements
+    r"|notes?\s*\d"                                      # Note 7 - Income Taxes
+    r"|footnotes?"                                       # Footnotes
+    r"|(?:^|\s-\s)notes?$"                               # a role titled only "Notes"
+)
+
+
+def _declares_disclosure(role_def: str, primary_concept: str) -> bool:
+    """Whether a role states that it is a disclosure, rather than merely
+    mentioning the word.
+
+    Args:
+        role_def: Role definition, lowercased.
+        primary_concept: The role's first presentation node.
+    """
+    if _DISCLOSURE_CONCEPT_RE.search(primary_concept or ''):
+        return True
+    if any(part.strip() == _ROLE_CATEGORY_MARKER for part in role_def.split(' - ')):
+        return True
+    return role_def.startswith(_ROLE_CATEGORY_MARKER)
+
+
+def _names_notes_section(role_def: str) -> bool:
+    """Whether a role definition names the notes to the financial statements,
+    as opposed to using "note" as the subject of a disclosure.
+
+    Args:
+        role_def: Role definition, lowercased.
+    """
+    return bool(_NOTES_SECTION_RE.search(role_def))
 
 
 def _capture_sgml_period_of_report(xbrl: "XBRL", filing) -> None:
@@ -1010,9 +1063,21 @@ class XBRL:
 
             # Fall back to keyword-based patterns for notes and disclosures
             if not statement_type:
-                if 'us-gaap_NotesToFinancialStatementsAbstract' in primary_concept or 'note' in role_def:
+                if 'us-gaap_NotesToFinancialStatementsAbstract' in primary_concept:
                     statement_type = "Notes"
                     statement_category = "note"
+                elif 'note' in role_def:
+                    # The bare keyword cannot tell the notes to the financial
+                    # statements from a disclosure whose subject happens to be
+                    # notes payable, so a role that declares itself a disclosure
+                    # is taken at its word unless the definition names the notes
+                    # section itself (issue #1207).
+                    if _names_notes_section(role_def) or not _declares_disclosure(role_def, primary_concept):
+                        statement_type = "Notes"
+                        statement_category = "note"
+                    else:
+                        statement_type = "Disclosures"
+                        statement_category = "disclosure"
                 elif 'us-gaap_DisclosuresAbstract' in primary_concept or 'disclosure' in role_def:
                     statement_type = "Disclosures"
                     statement_category = "disclosure"

--- a/tests/issues/regression/test_issue_1207_disclosure_notes_payable.py
+++ b/tests/issues/regression/test_issue_1207_disclosure_notes_payable.py
@@ -1,0 +1,134 @@
+"""Regression test for issue #1207.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1207
+
+`get_all_statements()` falls back to keyword matching when a role carries no
+`FilingSummary` menu category, and that fallback tested the bare substring
+`"note"` before it tested `"disclosure"`.  "Note" names a financial-statement
+section and a debt instrument, so every role like
+`"0021 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS"` was claimed by the
+first branch: reported as `type="Notes"` / `category="note"`, returned by
+`xbrl.notes()`, and absent from `xbrl.disclosures()`.
+
+The fix keeps the keyword order but stops the ambiguous word from outranking a
+role that states what it is - by its `Disclosure` category marker, or by the
+concept it hangs from (`us-gaap_DebtDisclosureAbstract`) - unless the
+definition names the notes section itself.
+
+Roles whose definition does not contain "note" are classified exactly as
+before.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from edgar.xbrl.xbrl import XBRL, _declares_disclosure, _names_notes_section
+
+DATA = Path(__file__).resolve().parents[3] / "data" / "xbrl" / "datafiles"
+
+
+# --- the bug: "notes payable" is a disclosure subject, not a notes section ---
+
+# The four Oracle 10-Q roles from the report (accession 0000950170-23-047713).
+ORACLE_ROLES = [
+    ("0000021 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS",
+     "us-gaap_DebtDisclosureAbstract"),
+    ("0000022 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS (Tables)",
+     "us-gaap_DebtInstrumentsAbstract"),
+    ("0000023 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS (Details)",
+     "us-gaap_DebtInstrumentsAbstract"),
+    ("0000024 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS (Narrative) (Details)",
+     "us-gaap_DebtDisclosureAbstract"),
+]
+
+
+@pytest.mark.parametrize("definition,concept", ORACLE_ROLES)
+def test_notes_payable_disclosure_roles_declare_themselves_disclosures(definition, concept):
+    role_def = definition.lower()
+    assert _declares_disclosure(role_def, concept)
+    assert not _names_notes_section(role_def)
+
+
+@pytest.mark.parametrize("definition", [
+    "0011 - Disclosure - PROMISSORY NOTES PAYABLE",
+    "0012 - Disclosure - CONVERTIBLE PROMISSORY NOTES PAYABLE (Tables)",
+    "Disclosure - Notes Receivable, Net",
+    "Disclosure - Senior Notes",
+    "DisclosureConvertibleNotesPayable",
+])
+def test_note_bearing_disclosure_titles_are_not_notes_sections(definition):
+    assert not _names_notes_section(definition.lower())
+
+
+# --- what must keep working: real notes to the financial statements ----------
+
+@pytest.mark.parametrize("definition", [
+    "0007 - Disclosure - Notes to Consolidated Financial Statements",
+    "0007 - Disclosure - Notes to the Unaudited Condensed Consolidated Financial Statements",
+    "NotesToFinancialStatements",
+    "0008 - Disclosure - Note 1 - Organization and Basis of Presentation",
+    "DisclosureNote1OrganizationAndBasisOfPresentation",
+    "0009 - Disclosure - Notes",
+    "0010 - Disclosure - Footnotes",
+])
+def test_notes_sections_are_still_recognised(definition):
+    assert _names_notes_section(definition.lower())
+
+
+@pytest.mark.parametrize("definition,concept", [
+    # No category marker and no disclosure concept: nothing states otherwise,
+    # so the legacy keyword result stands.
+    ("PromissoryNotesPayable", "us-gaap_OtherLiabilitiesCurrentAbstract"),
+    ("0011 - Statement - NOTES PAYABLE", "us-gaap_DebtInstrumentsAbstract"),
+])
+def test_roles_that_do_not_declare_a_disclosure_are_left_alone(definition, concept):
+    assert not _declares_disclosure(definition.lower(), concept)
+
+
+# --- end to end, on filings committed to the repository ---------------------
+
+def test_gahc_notes_payable_roles_are_disclosures():
+    """Great American Holding 10-Q: the debt roles hang from
+    us-gaap_DebtDisclosureAbstract and were reported as Notes."""
+    directory = DATA / "gahc"
+    assert directory.exists(), f"missing fixture: {directory}"
+    xbrl = XBRL.from_directory(directory)
+
+    by_definition = {s["definition"]: s for s in xbrl.get_all_statements()}
+    for definition in ("PromissoryNotesPayable",
+                       "PromissoryNotesPayableNarrativeDetails",
+                       "ConvertiblePromissoryNotesPayable"):
+        statement = by_definition[definition]
+        assert statement["primary_concept"] == "us-gaap_DebtDisclosureAbstract"
+        assert statement["category"] == "disclosure"
+        assert statement["type"] == "Disclosures"
+
+    note_roles = {s.role_or_type for s in xbrl.notes()}
+    disclosure_roles = {s.role_or_type for s in xbrl.disclosures()}
+    target = {by_definition["PromissoryNotesPayable"]["role"]}
+    assert target <= disclosure_roles
+    assert not target & note_roles
+
+
+def test_aeon_convertible_note_roles_are_disclosures():
+    """AEON Biopharma 10-Q: the role names lead with the Disclosure marker."""
+    directory = DATA / "aeon"
+    assert directory.exists(), f"missing fixture: {directory}"
+    xbrl = XBRL.from_directory(directory)
+
+    convertible = [s for s in xbrl.get_all_statements()
+                   if "ConvertibleNote" in s["definition"]]
+    assert convertible, "fixture no longer contains convertible-note roles"
+    assert {s["category"] for s in convertible} == {"disclosure"}
+
+
+def test_aapl_classification_is_unchanged():
+    """No Apple role definition contains "note", so none of them may move."""
+    directory = DATA / "aapl"
+    assert directory.exists(), f"missing fixture: {directory}"
+    xbrl = XBRL.from_directory(directory)
+
+    statements = xbrl.get_all_statements()
+    assert not [s for s in statements if "note" in s["definition"].lower()]
+    assert {s["definition"] for s in statements if s["category"] == "note"} == set()

--- a/tests/issues/regression/test_issue_1207_disclosure_notes_payable.py
+++ b/tests/issues/regression/test_issue_1207_disclosure_notes_payable.py
@@ -23,9 +23,15 @@ from pathlib import Path
 
 import pytest
 
-from edgar.xbrl.xbrl import XBRL, _declares_disclosure, _names_notes_section
+from edgar.xbrl.xbrl import XBRL
 
 DATA = Path(__file__).resolve().parents[3] / "data" / "xbrl" / "datafiles"
+
+# `_declares_disclosure` and `_names_notes_section` are imported inside the
+# tests that use them, not here. They only exist on a tree carrying the fix, and
+# a module-level import would turn this file into a collection error when it is
+# run against an unfixed tree - which is exactly when someone wants to watch it
+# fail. Kept lazy so that run reports test failures instead.
 
 
 # --- the bug: "notes payable" is a disclosure subject, not a notes section ---
@@ -45,6 +51,8 @@ ORACLE_ROLES = [
 
 @pytest.mark.parametrize("definition,concept", ORACLE_ROLES)
 def test_notes_payable_disclosure_roles_declare_themselves_disclosures(definition, concept):
+    from edgar.xbrl.xbrl import _declares_disclosure, _names_notes_section
+
     role_def = definition.lower()
     assert _declares_disclosure(role_def, concept)
     assert not _names_notes_section(role_def)
@@ -58,6 +66,8 @@ def test_notes_payable_disclosure_roles_declare_themselves_disclosures(definitio
     "DisclosureConvertibleNotesPayable",
 ])
 def test_note_bearing_disclosure_titles_are_not_notes_sections(definition):
+    from edgar.xbrl.xbrl import _names_notes_section
+
     assert not _names_notes_section(definition.lower())
 
 
@@ -73,6 +83,8 @@ def test_note_bearing_disclosure_titles_are_not_notes_sections(definition):
     "0010 - Disclosure - Footnotes",
 ])
 def test_notes_sections_are_still_recognised(definition):
+    from edgar.xbrl.xbrl import _names_notes_section
+
     assert _names_notes_section(definition.lower())
 
 
@@ -83,13 +95,15 @@ def test_notes_sections_are_still_recognised(definition):
     ("0011 - Statement - NOTES PAYABLE", "us-gaap_DebtInstrumentsAbstract"),
 ])
 def test_roles_that_do_not_declare_a_disclosure_are_left_alone(definition, concept):
+    from edgar.xbrl.xbrl import _declares_disclosure
+
     assert not _declares_disclosure(definition.lower(), concept)
 
 
 # --- end to end, on filings committed to the repository ---------------------
 
 def test_gahc_notes_payable_roles_are_disclosures():
-    """Great American Holding 10-Q: the debt roles hang from
+    """Global Arena Holding 10-Q: the debt roles hang from
     us-gaap_DebtDisclosureAbstract and were reported as Notes."""
     directory = DATA / "gahc"
     assert directory.exists(), f"missing fixture: {directory}"


### PR DESCRIPTION
Fixes #1207.

## The defect

`get_all_statements()` falls back to keyword matching when a role carries no `FilingSummary` menu category, and that fallback tested the bare substring `"note"` before it tested `"disclosure"`:

```python
if 'us-gaap_NotesToFinancialStatementsAbstract' in primary_concept or 'note' in role_def:
    statement_type = "Notes"
elif 'us-gaap_DisclosuresAbstract' in primary_concept or 'disclosure' in role_def:
    statement_type = "Disclosures"
```

"Note" names a financial-statement section and a debt instrument, and both keywords are present in a definition like `0000021 - Disclosure - NOTES PAYABLE AND OTHER BORROWINGS`. The first branch won, so Oracle's four notes-payable roles (10-Q `0000950170-23-047713`) reported `type="Notes"` / `category="note"`, came back from `xbrl.notes()`, and were absent from `xbrl.disclosures()`.

## The change

The keyword order is unchanged. What changed is that the ambiguous word no longer outranks a role that states what it is:

- its `Disclosure` category marker - either the `" - "` segment of an EDGAR role definition, or the marker leading the role name when the schema definition is missing (`DisclosurePromissoryNotesPayable`); or
- the concept it hangs from, `us-gaap_DebtDisclosureAbstract`. `Statements.classify_statement` (tier 2) and the `Disclosures` concept patterns in `statement_resolver.py` already read a `*DisclosureAbstract` concept as a disclosure; this fallback tested only the literal `us-gaap_DisclosuresAbstract`, which these roles never carry.

unless the definition names the notes section itself - `Notes to Consolidated Financial Statements`, `Note 1 - Organization`, `Footnotes`, a role titled only `Notes`. That test is deliberately generous: a definition matching it keeps the classification it already had, so a false positive costs nothing while a false negative would move a real note.

**A role whose definition does not contain "note" takes exactly the branch it took before.** The change is confined to the disputed branch.

## Verification

`tests/issues/regression/test_issue_1207_disclosure_notes_payable.py`. Two of the fixtures already committed to the repository carry the defect, so the end-to-end assertions run offline with no cassette:

| fixture | role | before | after |
|---|---|---|---|
| `datafiles/gahc` | `PromissoryNotesPayable` (`us-gaap_DebtDisclosureAbstract`) | `note` / `Notes` | `disclosure` / `Disclosures` |
| `datafiles/gahc` | `ConvertiblePromissoryNotesPayable` | `note` / `Notes` | `disclosure` / `Disclosures` |
| `datafiles/aeon` | `DisclosureDaewoongConvertibleNotesPredecessor` | `note` / `Notes` | `disclosure` / `Disclosures` |
| `datafiles/aapl` | no definition contains "note" | unchanged | unchanged |

On `main` those assertions fail 6 ways; with the fix they pass. The unit-level cases cover the four Oracle definitions from the report verbatim, plus the notes sections that must not move.

Also run, on Windows / Python 3.14: the 864 non-network tests matching `xbrl or statement or notes or disclosure or categor` (848 pass; the 16 failures in `test_notes_characterization.py` are a `cp1252` decode of the baseline files and fail identically on `main`), and `scripts/check_regression_provenance.py` / `scripts/check_regression_skips.py`, both OK. `ruff check edgar/xbrl/xbrl.py` reports the same 15 pre-existing findings before and after.

## Behaviour note

For a filing with no `FilingSummary`, a notes-payable role now leaves `xbrl.notes()` and appears in `xbrl.disclosures()`, which is what the issue asks for. It is still reachable by role and by name - `xbrl.get_table("...")` and `xbrl.get_disclosure(role)` are not category-filtered. Filings that do have a `FilingSummary` never reach this fallback and are unaffected.
