### PR TITLE
chore(release): 5.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [5.56.0] - 2026-09-02
+
+### Added
+
+- **Role-scoped access to the XBRL dimensional model.** `XBRL.axes_for_role(role_uri)` and `XBRL.domains_for_role(role_uri)` return the axes and domains a single extended link role declares, keyed on element ID. Prefer them over `xbrl.axes` / `xbrl.domains` wherever the role is known: the same domain routinely carries different members in different roles, so the flat views can only offer the union. `Axis` and `Domain` gain `role_uri`, and `XBRL.axes_by_role` / `XBRL.domains_by_role` expose the underlying store.
+- **`CalculationTree.all_arcs`, one entry per filed calculation relationship.** A concept may roll up into two totals with a different weight, and often a different sign, under each, which the one-node-per-concept `all_nodes` map cannot represent. `all_nodes` is unchanged and still the right thing for lookup and membership; `all_arcs` is the graph.
+- **`ElementCatalog.typed_domain_ref` and `ElementCatalog.substitution_group`**, read from the element declaration, which is what lets `Axis.is_typed_dimension` report a dimension the filer declared as typed.
+
 ### Fixed
 
 - **`get_revenue(unit=...)` answered a request for one unit with a figure in another.** When the unit filter correctly rejected every candidate fact, `_get_standardized_concept_value` fell through to its component calculation, and that calculation checked the two components against *each other* — which establishes only that they can be added — before normalising with no target unit at all. Apple's `GrossProfit` and `CostOfGoodsAndServicesSold` are both USD, so their sum was returned as the answer to `unit='EUR'` and to `unit='shares'` alike: 364,357,000,000 in both cases, and both now `None`. The default USD path is unchanged and still answers from the revenue fact itself. Strictness now reaches the fallbacks, and a derived figure has to answer the unit that was asked for — an exact match always does, a merely compatible one only where the caller did not pin the unit, which is the rule the direct path already used. `get_gross_profit()` was leaking the same way for a second reason — its own direct branch never asked for strict matching at all, so a compatible-but-different currency succeeded before the guard was even reached — and both fallbacks now answer by the same rule as the direct path. This was latent until bare concept names were indexed (GH #1202, same release): before that, `get_fact('GrossProfit')` returned `None`, the components were never found, and the fallback returned `None` for the wrong reason. (bead edgartools-885h)

--- a/edgar/__about__.py
+++ b/edgar/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Dwight Gunning <dgunning@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '5.55.0'
+__version__ = '5.56.0'


### PR DESCRIPTION
Version bump and changelog fold for **5.56.0**. No code changes.

## What ships

27 entries, from six PRs merged today plus the sweep work already sitting in `[Unreleased]`.

| PR | |
|---|---|
| #1260 | The XBRL dimensional model was not role-scoped — six reports as one rework |
| #1261 | Calculation edges are per relationship, not per concept |
| #1262 | Footnote arcs resolved to nothing; footnote text truncated and duplicated |
| #1263 | The namespace prefix was treated as a concept's identity; typed dimensions never read |
| #1264 | The last public routes off `edgar.files`, and two silently-broken APIs |
| #1265 | A derived figure has to answer the unit that was asked for |

## Why minor, not patch

Everything shipping is a fix, but several of the fixes added public surface: `XBRL.axes_for_role()` / `domains_for_role()`, `CalculationTree.all_arcs` with `CalculationArc`, `Axis.role_uri` / `Domain.role_uri`, and `ElementCatalog.typed_domain_ref` / `substitution_group`.

Those are recorded in a new `### Added` section. They were described only inside `Fixed` bullets, where a reader scanning for API changes would miss them — and `axes_for_role()` / `domains_for_role()` are now the recommended path over the flat `xbrl.axes` / `xbrl.domains`, which can only return a union across roles.

## Two entries worth reading before merging

**`get_revenue(unit=...)` answered in the wrong unit (#1265).** Latent until bare concept names were indexed (#1202) — which ships in *this same release*. Verified on `f115ea0^` that the components were unreachable before that fix, so users never see the exposed window. The two fixes have to go out together.

**`Report.get_dataframe()` and `Document.chunks()` (#1264)** were both broken for every filing — one returned an empty DataFrame, the other raised `ModuleNotFoundError` on every call.

## Verification

`test-fast` green: **6828 passed, 5 skipped, 1 xfailed.**

`[Unreleased]` is left empty above the new dated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2NaNcXEuv5YvcKFntcaZ
