### PR TITLE
fix(xbrl): three public Statement helpers had never returned a correct result (#1240, #1241, #1244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three public `Statement` helpers had never returned a correct result for any filing.** `analyze_trends()` read `period_views[0]['periods']`, a key the producer never emits — it emits `period_keys` — so the loop never ran and the method returned `{}` every time. `calculate_ratios()` looked up `us-gaap_CurrentAssets`, `us-gaap_CurrentLiabilities` and `us-gaap_Inventory`, none of which is a us-gaap concept (the words are reversed; the real names are `AssetsCurrent`, `LiabilitiesCurrent`, `InventoryNet`), leaving `current_ratio` and `quick_ratio` permanently absent and indistinguishable from "this filing lacks the data". `to_dataframe(matrix=True)` omitted `standard_concept` from its metadata columns, so that column became the first entry in `period_cols` and every matrix cell was read from it: Apple's FY2023 equity statement returned 33 null cells and now returns the filed values, beginning balances of $64,849M in paid-in capital against $-3,068M retained earnings. The ratio and trend lookups also now accept a candidate list, since Apple tags revenue as `RevenueFromContractWithCustomerExcludingAssessedTax` rather than `us-gaap:Revenues` and a single hardcoded name answered for only a fraction of filers. None of the three had a test asserting a real result — `analyze_trends` and `matrix=True` had zero references in the suite, and the four `calculate_ratios` hits either mocked the return value or never asserted on it. (GH #1240, #1241, #1244, bead edgartools-ysr8)
+
 
 ## [5.56.0] - 2026-09-02
 

--- a/edgar/xbrl/statements.py
+++ b/edgar/xbrl/statements.py
@@ -8,7 +8,7 @@ import re
 import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import pandas as pd
 from rich import box
@@ -18,6 +18,25 @@ from edgar.richtools import repr_rich
 from edgar.xbrl.dimensions import is_breakdown_dimension
 from edgar.exceptions import ParsingError, StatementNotFoundError
 from edgar.xbrl.presentation import StatementView, ViewType, normalize_view
+
+# Concept candidates for the ratio/trend helpers. Ordered: the first candidate
+# present in a statement wins. GH #1241 — the previous single-name lookups
+# ('us-gaap_CurrentAssets', 'us-gaap_CurrentLiabilities', 'us-gaap_Inventory')
+# had their words reversed and match no us-gaap concept at all, so
+# current_ratio and quick_ratio were never computed for any filing.
+CURRENT_ASSETS_CONCEPTS = ('us-gaap_AssetsCurrent',)
+CURRENT_LIABILITIES_CONCEPTS = ('us-gaap_LiabilitiesCurrent',)
+INVENTORY_CONCEPTS = ('us-gaap_InventoryNet', 'us-gaap_InventoryGross')
+# us-gaap:Revenues leads: where a filer reports both, it is the grand total and
+# the contract-revenue tag is one component of it (an insurer files contract
+# revenue beside investment income). Filers that report no Revenues total —
+# Apple, Microsoft — fall through to the ASC 606 tag, which is their top line.
+REVENUE_CONCEPTS = (
+    'us-gaap_Revenues',
+    'us-gaap_RevenueFromContractWithCustomerExcludingAssessedTax',
+    'us-gaap_RevenueFromContractWithCustomerIncludingAssessedTax',
+    'us-gaap_SalesRevenueNet',
+)
 
 # XBRL structural element patterns (Issue #03zg)
 # These are XBRL metadata, not financial data, and should be filtered from user-facing output
@@ -1736,7 +1755,11 @@ class Statement:
             'concept', 'label', 'level', 'abstract', 'dimension', 'is_breakdown',
             'dimension_axis', 'dimension_member', 'dimension_member_label',
             'dimension_label', 'balance', 'weight', 'preferred_sign',
-            'parent_concept', 'parent_abstract_concept', 'unit', 'point_in_time'
+            'parent_concept', 'parent_abstract_concept', 'unit', 'point_in_time',
+            # GH #1244: standard_concept is emitted by _build_dataframe_from_raw_data
+            # immediately after 'label', so omitting it here made it the first
+            # entry in period_cols and every matrix cell read from it -> all null.
+            'standard_concept'
         }
         period_cols = [col for col in df.columns if col not in metadata_cols]
 
@@ -1930,13 +1953,13 @@ class Statement:
         ratios = {}
 
         # Current ratio
-        current_assets = self._get_concept_value(data, 'us-gaap_CurrentAssets')
-        current_liabilities = self._get_concept_value(data, 'us-gaap_CurrentLiabilities')
+        current_assets = self._get_concept_value(data, CURRENT_ASSETS_CONCEPTS)
+        current_liabilities = self._get_concept_value(data, CURRENT_LIABILITIES_CONCEPTS)
         if current_assets and current_liabilities:
             ratios['current_ratio'] = current_assets / current_liabilities
 
         # Quick ratio
-        inventory = self._get_concept_value(data, 'us-gaap_Inventory')
+        inventory = self._get_concept_value(data, INVENTORY_CONCEPTS)
         if current_assets and current_liabilities and inventory:
             ratios['quick_ratio'] = (current_assets - inventory) / current_liabilities
 
@@ -1947,7 +1970,7 @@ class Statement:
         ratios = {}
 
         # Gross margin
-        revenue = self._get_concept_value(data, 'us-gaap_Revenues')
+        revenue = self._get_concept_value(data, REVENUE_CONCEPTS)
         gross_profit = self._get_concept_value(data, 'us-gaap_GrossProfit')
         if revenue and gross_profit:
             ratios['gross_margin'] = gross_profit / revenue
@@ -1959,13 +1982,24 @@ class Statement:
 
         return ratios
 
-    def _get_concept_value(self, data: List[Dict[str, Any]], concept: str) -> Optional[float]:
-        """Get the value for a specific concept from statement data."""
-        for item in data:
-            if concept in item.get('all_names', []):
-                values = item.get('values', {})
-                if values:
-                    return float(next(iter(values.values())))
+    def _get_concept_value(self, data: List[Dict[str, Any]],
+                           concept: Union[str, Sequence[str]]) -> Optional[float]:
+        """Get the value for a concept from statement data.
+
+        Accepts either a single concept name or an ordered sequence of
+        candidates; the first candidate present in the statement wins. Filers
+        tag the same economic line item with different us-gaap concepts (Apple
+        reports revenue as RevenueFromContractWithCustomerExcludingAssessedTax,
+        Coca-Cola as Revenues), so a single hardcoded name answers for only a
+        fraction of filings.
+        """
+        candidates = [concept] if isinstance(concept, str) else list(concept)
+        for candidate in candidates:
+            for item in data:
+                if candidate in item.get('all_names', []):
+                    values = item.get('values', {})
+                    if values:
+                        return float(next(iter(values.values())))
         return None
 
     def analyze_trends(self, periods: int = 4) -> Dict[str, List[float]]:
@@ -1980,7 +2014,11 @@ class Statement:
         if not period_views:
             return trends
 
-        periods_to_analyze = period_views[0].get('periods', [])[:periods]
+        # GH #1240: generate_period_view() (edgar/xbrl/periods.py) emits
+        # 'period_keys'. Reading 'periods' was a dead lookup, so the loop below
+        # never ran and analyze_trends() returned {} for every filing.
+        period_keys = period_views[0].get('period_keys') or period_views[0].get('periods', [])
+        periods_to_analyze = period_keys[:periods]
 
         for period in periods_to_analyze:
             data = self.get_raw_data(period)
@@ -2014,7 +2052,7 @@ class Statement:
                                         period: str) -> None:
         """Analyze income statement trends."""
         metrics = {
-            'revenue': 'us-gaap_Revenues',
+            'revenue': REVENUE_CONCEPTS,
             'gross_profit': 'us-gaap_GrossProfit',
             'net_income': 'us-gaap_NetIncomeLoss'
         }

--- a/tests/issues/regression/test_ysr8_statement_helpers.py
+++ b/tests/issues/regression/test_ysr8_statement_helpers.py
@@ -1,0 +1,172 @@
+"""
+Regression tests for edgartools-ysr8 (GH #1240, #1241, #1244): three public
+`Statement` helpers that had never returned a correct result for any filing.
+
+Each was a small, independent mistake, and the suite never caught any of them
+because no test asserted a real result — `analyze_trends`, `_pivot_to_matrix`
+and `matrix=True` had zero references in tests/, and the four `calculate_ratios`
+hits either mocked the return value or called it without asserting anything.
+That appearance of coverage is why these shipped.
+
+  GH #1240  analyze_trends() read period_views[0]['periods']; the producer
+            (edgar/xbrl/periods.py generate_period_view) only ever emits
+            'period_keys'. Dead lookup -> empty list -> `{}` for every filing.
+
+  GH #1241  The balance-sheet ratios looked up 'us-gaap_CurrentAssets',
+            'us-gaap_CurrentLiabilities' and 'us-gaap_Inventory'. The words are
+            reversed and none of those is a us-gaap concept, so current_ratio
+            and quick_ratio were never computed — indistinguishable from
+            "this filing lacks the data".
+
+  GH #1244  _pivot_to_matrix()'s metadata_cols omitted 'standard_concept', which
+            the DataFrame builder emits right after 'label'. It therefore became
+            period_cols[0], every cell was read from a metadata column, and the
+            equity matrix came back all null.
+
+Ground truth is Apple's FY2023 10-K (period ending 2023-09-30), read off the
+filed balance sheet, income statement and statement of equity.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from edgar.xbrl import XBRL
+
+FIXTURE = Path("tests/fixtures/xbrl/aapl/10k_2023")
+
+# Filed values, AAPL FY2023 10-K.
+CURRENT_ASSETS = 143_566_000_000.0
+CURRENT_LIABILITIES = 145_308_000_000.0
+INVENTORIES = 6_331_000_000.0
+REVENUE_FY2023 = 383_285_000_000.0
+REVENUE_FY2022 = 394_328_000_000.0
+GROSS_PROFIT_FY2023 = 169_148_000_000.0
+TOTAL_ASSETS_FY2023 = 352_583_000_000.0
+TOTAL_ASSETS_FY2022 = 352_755_000_000.0
+NET_INCOME_FY2023 = 96_995_000_000.0
+
+# Statement of equity, beginning balances for FY2023 (= FY2022 ending balances).
+APIC_BEGINNING = 64_849_000_000.0
+RETAINED_EARNINGS_BEGINNING = -3_068_000_000.0
+AOCI_BEGINNING = -11_109_000_000.0
+
+
+@pytest.fixture(scope="module")
+def xbrl():
+    return XBRL.from_directory(FIXTURE)
+
+
+# --- GH #1241: calculate_ratios ------------------------------------------
+
+
+def test_balance_sheet_ratios_are_computed_from_the_real_concepts(xbrl):
+    ratios = xbrl.statements.balance_sheet().calculate_ratios()
+
+    assert ratios["current_ratio"] == pytest.approx(
+        CURRENT_ASSETS / CURRENT_LIABILITIES
+    )
+    assert ratios["quick_ratio"] == pytest.approx(
+        (CURRENT_ASSETS - INVENTORIES) / CURRENT_LIABILITIES
+    )
+
+
+def test_income_statement_ratios_survive_the_revenue_concept_a_filer_chose(xbrl):
+    """Apple tags revenue as RevenueFromContractWithCustomerExcludingAssessedTax,
+    not us-gaap:Revenues, so a single hardcoded revenue name answers for only a
+    fraction of filings."""
+    ratios = xbrl.statements.income_statement().calculate_ratios()
+
+    assert ratios["gross_margin"] == pytest.approx(
+        GROSS_PROFIT_FY2023 / REVENUE_FY2023
+    )
+    assert ratios["net_margin"] == pytest.approx(NET_INCOME_FY2023 / REVENUE_FY2023)
+
+
+# --- GH #1240: analyze_trends --------------------------------------------
+
+
+def test_analyze_trends_returns_the_filed_series_not_an_empty_dict(xbrl):
+    trends = xbrl.statements.balance_sheet().analyze_trends()
+
+    assert trends, "analyze_trends() returned {} — the period-key lookup is dead again"
+    assert trends["total_assets"][:2] == [TOTAL_ASSETS_FY2023, TOTAL_ASSETS_FY2022]
+    assert set(trends) >= {"total_assets", "total_liabilities", "equity"}
+
+
+def test_analyze_trends_reads_a_distinct_value_per_period(xbrl):
+    """The failure mode after a naive fix is one value repeated, because the
+    per-period filter is not applied."""
+    trends = xbrl.statements.income_statement().analyze_trends()
+
+    assert trends["revenue"][:2] == [REVENUE_FY2023, REVENUE_FY2022]
+    assert len(set(trends["revenue"])) == len(trends["revenue"])
+
+
+# --- GH #1244: to_dataframe(matrix=True) ---------------------------------
+
+
+def test_equity_matrix_is_populated_and_carries_no_metadata_column(xbrl):
+    df = xbrl.statements.statement_of_equity().to_dataframe(matrix=True)
+
+    assert not df.empty
+    assert "standard_concept" not in df.columns, (
+        "standard_concept leaked into the matrix columns; it is metadata, and "
+        "as period_cols[0] it made every cell null"
+    )
+
+    component_cols = [c for c in df.columns
+                      if c not in ("concept", "label", "level", "abstract")]
+    assert component_cols, "no equity component columns produced"
+
+    values = df[component_cols]
+    assert values.notna().to_numpy().any(), "every matrix cell is null (GH #1244)"
+
+    beginning = df[df["label"] == "Beginning balances"].iloc[0]
+    assert beginning["Common stock and additional paid-in capital"] == pytest.approx(
+        APIC_BEGINNING
+    )
+    assert beginning["Retained earnings/(Accumulated deficit)"] == pytest.approx(
+        RETAINED_EARNINGS_BEGINNING
+    )
+    assert beginning["Accumulated other comprehensive income/(loss)"] == pytest.approx(
+        AOCI_BEGINNING
+    )
+
+
+# --- Breadth and silence checks ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture, gross_margin, current_ratio",
+    [
+        # Filed figures. Apple and Microsoft tag revenue as
+        # RevenueFromContractWithCustomerExcludingAssessedTax; Coca-Cola and IBM
+        # file a us-gaap:Revenues total.
+        ("tests/fixtures/xbrl/msft/10k_2024", 0.6976, 1.2750),
+        ("tests/fixtures/xbrl/ko/10k_2024", 0.5952, 1.1341),
+        ("tests/fixtures/xbrl/ibm/10k_2024", 0.5665, 1.0404),
+        ("tests/fixtures/xbrl/aapl/10k_2010", 0.3520, 2.0113),
+    ],
+)
+def test_ratios_across_filers_and_taxonomy_vintages(fixture, gross_margin, current_ratio):
+    x = XBRL.from_directory(Path(fixture))
+
+    assert x.statements.income_statement().calculate_ratios()["gross_margin"] == pytest.approx(
+        gross_margin, abs=1e-4
+    )
+    assert x.statements.balance_sheet().calculate_ratios()["current_ratio"] == pytest.approx(
+        current_ratio, abs=1e-4
+    )
+
+
+def test_an_unclassified_balance_sheet_yields_no_ratio_rather_than_a_wrong_one():
+    """JPMorgan files an unclassified balance sheet: there is no AssetsCurrent
+    and no LiabilitiesCurrent, so there is no current ratio to report. The
+    helper must return nothing rather than compute one from whatever it finds."""
+    x = XBRL.from_directory(Path("tests/fixtures/xbrl/jpm/10k_2024"))
+
+    ratios = x.statements.balance_sheet().calculate_ratios()
+
+    assert "current_ratio" not in ratios
+    assert "quick_ratio" not in ratios

--- a/tests/test_xbrl_statements.py
+++ b/tests/test_xbrl_statements.py
@@ -438,8 +438,13 @@ def test_canonical_type_preservation(tsla_xbrl):
     # It should have the canonical type set
     assert income_stmt.canonical_type == "IncomeStatement"
 
-    # Check that calculate_ratios uses the canonical type
+    # Check that calculate_ratios uses the canonical type.
+    # edgartools-ysr8: this call used to assert nothing, which let three broken
+    # helpers ship looking covered. Assert on the result, not just the call.
     ratios = income_stmt.calculate_ratios()
+    assert ratios, "calculate_ratios() returned nothing for a Tesla income statement"
+    assert 0 < ratios["gross_margin"] < 1
+    assert ratios["net_margin"] < ratios["gross_margin"]
 
     # Get the statement data and make sure it's retrievable
     statement_data = income_stmt.get_raw_data()


### PR DESCRIPTION
Three public `Statement` methods had never returned a correct result for any filing. Each is a small, independent mistake; together they are a coverage finding, which is why they are one PR.

## The three defects

**`analyze_trends()` returned `{}` for every filing (#1240).** It read `period_views[0].get('periods', [])`. The producer — `generate_period_view()` in `edgar/xbrl/periods.py` — only ever emits `period_keys`. A dead key lookup yields an empty list, so the loop body never executed.

**`calculate_ratios()` never computed `current_ratio` or `quick_ratio` (#1241).** The balance-sheet block looked up `us-gaap_CurrentAssets`, `us-gaap_CurrentLiabilities` and `us-gaap_Inventory`. The words are reversed and none of those is a us-gaap concept — the real names are `AssetsCurrent`, `LiabilitiesCurrent` and `InventoryNet`. Every lookup returned `None` for every filing, and the result was indistinguishable from "this filing lacks the data".

**`to_dataframe(matrix=True)` returned an all-null matrix (#1244).** `_pivot_to_matrix()`'s `metadata_cols` set omitted `standard_concept`, which the DataFrame builder emits immediately after `label`. It therefore survived into `period_cols` as its first entry, `primary_period = period_cols[0]` selected it instead of a real period, and every `member_row[primary_period]` read pulled from a metadata column.

## Measured

Apple's FY2023 10-K, offline from `tests/fixtures/xbrl/aapl/10k_2023`:

| | before | after |
|---|---|---|
| `balance_sheet().analyze_trends()` | `{}` | `total_assets: [352,583M, 352,755M]`, plus liabilities and equity |
| `balance_sheet().calculate_ratios()` | `{}` | `current_ratio 0.9880`, `quick_ratio 0.9444` |
| `statement_of_equity().to_dataframe(matrix=True)` | 33 null cells | filed values — beginning balances $64,849M paid-in capital, $-3,068M retained earnings, $-11,109M AOCI |

## One scope extension

The concept lookups now accept an ordered candidate list rather than a single name, because the same single-name mistake was killing the income-statement ratios for most modern filers: Apple and Microsoft tag revenue as `RevenueFromContractWithCustomerExcludingAssessedTax`, not `us-gaap:Revenues`, so `gross_margin` and `net_margin` were dead for them too. `Revenues` leads the candidate list, since a filer that reports both files it as the grand total with contract revenue as one component of it.

Checked across all 13 fixture filings — Apple FY2023 gross margin 44.13%, Microsoft FY2024 69.76%, IBM FY2024 56.65%, Coca-Cola FY2024 59.52%, all matching the filed figures. JPMorgan's unclassified balance sheet correctly yields no current ratio at all, and Netflix FY2024 correctly yields no gross margin, rather than either returning a number built from the wrong concepts.

## The coverage finding

Grepped `tests/` on main before the fix:

- `analyze_trends` — 0 references anywhere
- `_pivot_to_matrix` — 0 references
- `matrix=True` — 0 references
- `calculate_ratios` — 4 hits, all decorative: two mock the return value (testing delegation only), and `tests/test_xbrl_statements.py:442` calls it for real but never asserts on the result, not even `is not None`

All three shipped with no test that ever checked a non-empty result, and `calculate_ratios` had the *appearance* of coverage, which is worse than none. Fixing the three lines without adding value assertions would have left the situation unchanged, so:

- `tests/issues/regression/test_ysr8_statement_helpers.py` — 10 offline tests, ground-truth values read off the filed statements, breadth across four filers and two taxonomy vintages, plus a silence check that an unclassified balance sheet produces no ratio rather than a wrong one
- Each of the five core cases was confirmed to **fail against the unfixed code** and pass with it
- `tests/test_xbrl_statements.py:442` now asserts on what it calls

Closes #1240
Closes #1241
Closes #1244

Bead: `edgartools-ysr8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2NaNcXEuv5YvcKFntcaZ
