### PR TITLE
chore(changelog): PRs write changelog.d/ fragments instead of editing CHANGELOG.md

### DIFF
--- a/.github/workflows/python-hatch-workflow.yml
+++ b/.github/workflows/python-hatch-workflow.yml
@@ -4,7 +4,7 @@
 #   - Pull requests:  fast tests only, single Python version  (cheap, quick gate)
 #   - Push to main:   fast (full matrix) + network + slow      (real integration gate)
 #   - Nightly (cron): full suite                               (freshness vs SEC API)
-#   - concurrency:    cancel superseded runs on the same ref
+#   - concurrency:    cancel superseded PR runs; main runs always complete
 #   - pip cache:      avoid reinstalling deps from scratch in every job
 #
 # There is deliberately NO paths-ignore. A docs-only change would then report no
@@ -53,10 +53,13 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
-# Cancel an in-progress run when a newer commit lands on the same branch/PR.
+# Cancel an in-progress run when a newer commit lands on the same PR. Pushes to
+# main are never cancelled: PRs merge without being up to date with main, so the
+# post-merge run is the only check that the combination works, and back-to-back
+# merges used to cancel it before it finished.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   # Must pass before any job that runs pytest. vcrpy loads cassettes with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,13 @@ Only parallelize fast tests to avoid SEC rate limits.
 - **Test error paths**: Verify that failures produce useful messages, not silent `None`
 - **Place regression tests** in `tests/issues/regression/test_issue_NNN.py`
 
+## Changelog
+
+**Never edit `CHANGELOG.md` in a PR** — concurrent PRs conflict on it. Add a fragment
+`changelog.d/<bead-or-issue-id>.<section>.md` (section: added/changed/fixed/...) with the
+bullet text; see `changelog.d/README.md`. Fragments are folded into `[Unreleased]` at release
+by `scripts/release/assemble_changelog.py`.
+
 ## Version
 
 Check `edgar/__about__.py`

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,21 @@
+# Changelog fragments
+
+Do not edit `CHANGELOG.md` in a pull request. Add one file here instead:
+
+```
+changelog.d/<id>.<section>.md
+```
+
+- `<id>`: the bead ID (`xn1u`), issue number (`1244`), or a short slug.
+- `<section>`: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`, or `performance`.
+- Body: the bullet text exactly as it should appear in the changelog, e.g.
+  `**A statement whose columns are not dates lost every column.** A column was kept only if ...`
+  The leading `- ` is optional.
+
+At release time `python scripts/release/assemble_changelog.py` folds every fragment into
+`[Unreleased]` and deletes it. `--check` validates and previews without changing anything.
+
+Why: every PR used to insert a bullet at the same line of `CHANGELOG.md`, so any two open
+PRs conflicted and each merge forced a conflict fix plus another CI run on every other PR.
+A new file per PR never conflicts, and a fragment can only ever land in the *next* release,
+which also removes the stale-branch trap where a bullet merged into an already-shipped section.

--- a/scripts/release/assemble_changelog.py
+++ b/scripts/release/assemble_changelog.py
@@ -1,0 +1,146 @@
+# ruff: noqa: T201, S603, S607  -- a CLI script: it prints, and it shells out to git
+"""Fold changelog fragments from changelog.d/ into CHANGELOG.md's [Unreleased] section.
+
+Each PR adds one file to changelog.d/ instead of editing CHANGELOG.md, so
+concurrent PRs never conflict on the changelog. At release time this script
+moves every fragment into [Unreleased] and deletes it.
+
+Fragment naming: ``<id>.<section>.md`` where ``<id>`` is the bead ID, issue
+number, or a short slug, and ``<section>`` is one of the Keep a Changelog
+headings (added, changed, deprecated, removed, fixed, security, performance).
+
+Fragment body: the bullet text, written exactly as it should appear. A leading
+``- `` is optional; multi-line bodies are kept as one bullet.
+
+Usage:
+    python scripts/release/assemble_changelog.py           # write CHANGELOG.md, delete fragments
+    python scripts/release/assemble_changelog.py --check   # print what would be added, change nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHANGELOG = ROOT / "CHANGELOG.md"
+FRAGMENT_DIR = ROOT / "changelog.d"
+
+# Order the sections appear in under [Unreleased].
+SECTIONS = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security", "Performance"]
+FRAGMENT_NAME = re.compile(r"^(?P<id>[^.]+)\.(?P<section>[a-z]+)\.md$")
+
+
+def _commit_time(path: Path) -> int:
+    """Unix time the fragment was last committed; 0 for an uncommitted file."""
+    out = subprocess.run(
+        ["git", "log", "-1", "--format=%ct", "--", str(path)],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    ).stdout.strip()
+    return int(out) if out else 0
+
+
+def load_fragments() -> dict[str, list[tuple[Path, str]]]:
+    """Return {section heading: [(path, bullet), ...]} newest fragment first."""
+    by_section: dict[str, list[tuple[Path, str]]] = {s: [] for s in SECTIONS}
+    bad: list[str] = []
+    for path in sorted(FRAGMENT_DIR.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        m = FRAGMENT_NAME.match(path.name)
+        section = m.group("section").capitalize() if m else None
+        if section not in by_section:
+            bad.append(path.name)
+            continue
+        body = path.read_text(encoding="utf-8").strip()
+        if not body:
+            bad.append(f"{path.name} (empty)")
+            continue
+        if body.startswith("- "):
+            body = body[2:]
+        by_section[section].append((path, "- " + body))
+    if bad:
+        sys.exit(
+            "Bad changelog fragments (expected <id>.<section>.md with a non-empty body, "
+            f"section in {[s.lower() for s in SECTIONS]}): {', '.join(bad)}"
+        )
+    # Newest at the top of each section, matching the hand-written convention.
+    # Uncommitted fragments (time 0) sort last, which is fine for --check.
+    for entries in by_section.values():
+        entries.sort(key=lambda e: _commit_time(e[0]), reverse=True)
+    return {s: e for s, e in by_section.items() if e}
+
+
+def merge_into_unreleased(text: str, fragments: dict[str, list[tuple[Path, str]]]) -> str:
+    """Insert fragment bullets at the top of their section under [Unreleased].
+
+    Creates missing section headings in SECTIONS order. Never touches a dated
+    section, so a fragment can only ever land in the next release.
+    """
+    lines = text.split("\n")
+    try:
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("## [Unreleased]"))
+    except StopIteration:
+        sys.exit("CHANGELOG.md has no '## [Unreleased]' heading")
+    end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+
+    block = lines[start + 1:end]
+    for section in SECTIONS:
+        entries = fragments.get(section)
+        if not entries:
+            continue
+        bullets = [b for _, b in entries]
+        heading = f"### {section}"
+        if heading in block:
+            at = block.index(heading) + 1
+            while at < len(block) and block[at].strip() == "":
+                at += 1
+            block[at:at] = bullets
+        else:
+            # Keep headings in canonical order: insert before the first later section.
+            later = [f"### {s}" for s in SECTIONS[SECTIONS.index(section) + 1:]]
+            at = next((i for i, ln in enumerate(block) if ln in later), None)
+            new = [heading, ""] + bullets + [""]
+            if at is None:
+                while block and block[-1].strip() == "":
+                    block.pop()
+                block += ["", *new]
+            else:
+                block[at:at] = new
+    # Exactly one blank line before the next dated heading.
+    while block and block[-1].strip() == "":
+        block.pop()
+    block.append("")
+    return "\n".join(lines[: start + 1] + block + lines[end:])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--check", action="store_true", help="validate and print fragments; change nothing")
+    args = parser.parse_args()
+
+    fragments = load_fragments()
+    count = sum(len(v) for v in fragments.values())
+    if not count:
+        print("No changelog fragments in changelog.d/")
+        return
+    if args.check:
+        for section, entries in fragments.items():
+            print(f"### {section}")
+            for path, bullet in entries:
+                print(f"  [{path.name}] {bullet[:100]}")
+        print(f"{count} fragment(s) ready to assemble")
+        return
+
+    CHANGELOG.write_text(merge_into_unreleased(CHANGELOG.read_text(encoding="utf-8"), fragments), encoding="utf-8")
+    for entries in fragments.values():
+        for path, _ in entries:
+            path.unlink()
+    print(f"Assembled {count} fragment(s) into CHANGELOG.md [Unreleased]; fragments deleted")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_assemble_changelog.py
+++ b/tests/test_assemble_changelog.py
@@ -1,0 +1,82 @@
+"""The release-time changelog assembler: fragments land in [Unreleased] and nowhere else."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "release" / "assemble_changelog.py"
+spec = importlib.util.spec_from_file_location("assemble_changelog", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- **Existing unreleased fix.** Detail.
+
+## [5.56.0] - 2026-09-02
+
+### Fixed
+
+- **Shipped fix.** Must not move.
+"""
+
+
+def frag(section, *bullets):
+    return {section: [(Path(f"{i}.{section.lower()}.md"), f"- {b}") for i, b in enumerate(bullets)]}
+
+
+def unreleased(text):
+    start = text.index("## [Unreleased]")
+    return text[start:text.index("## [5.56.0]")]
+
+
+def test_fragment_goes_to_top_of_existing_section():
+    out = mod.merge_into_unreleased(CHANGELOG, frag("Fixed", "**New fix.** Detail."))
+    block = unreleased(out)
+    assert block.index("**New fix.**") < block.index("**Existing unreleased fix.**")
+    # The dated section is byte-identical.
+    assert out[out.index("## [5.56.0]"):] == CHANGELOG[CHANGELOG.index("## [5.56.0]"):]
+
+
+def test_missing_section_is_created_in_canonical_order():
+    fragments = {**frag("Added", "**A feature.**"), **frag("Performance", "**Faster.**")}
+    block = unreleased(mod.merge_into_unreleased(CHANGELOG, fragments))
+    assert block.index("### Added") < block.index("### Fixed") < block.index("### Performance")
+    assert block.count("### Fixed") == 1
+
+
+def test_empty_unreleased_section_gets_heading_and_single_trailing_blank():
+    text = CHANGELOG.replace("### Fixed\n\n- **Existing unreleased fix.** Detail.\n\n## [5.56.0]", "## [5.56.0]")
+    out = mod.merge_into_unreleased(text, frag("Fixed", "**Only fix.**"))
+    assert "## [Unreleased]\n\n### Fixed\n\n- **Only fix.**\n\n## [5.56.0]" in out
+
+
+def test_load_fragments_rejects_bad_names_and_empty_bodies(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "FRAGMENT_DIR", tmp_path)
+    monkeypatch.setattr(mod, "ROOT", tmp_path)
+    (tmp_path / "abcd.fixed.md").write_text("**Good.** Body.\n")
+    (tmp_path / "wxyz.md").write_text("no section")
+    with pytest.raises(SystemExit, match="wxyz.md"):
+        mod.load_fragments()
+    (tmp_path / "wxyz.md").unlink()
+    (tmp_path / "efgh.fixed.md").write_text("   \n")
+    with pytest.raises(SystemExit, match="efgh.fixed.md \\(empty\\)"):
+        mod.load_fragments()
+
+
+def test_load_fragments_strips_optional_dash_and_ignores_readme(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "FRAGMENT_DIR", tmp_path)
+    monkeypatch.setattr(mod, "ROOT", tmp_path)
+    (tmp_path / "README.md").write_text("# how to")
+    (tmp_path / "abcd.fixed.md").write_text("- **Dashed.** Body.\n")
+    (tmp_path / "efgh.added.md").write_text("**Plain.** Body.\n")
+    got = mod.load_fragments()
+    assert [b for _, b in got["Fixed"]] == ["- **Dashed.** Body."]
+    assert [b for _, b in got["Added"]] == ["- **Plain.** Body."]


### PR DESCRIPTION
## Why

Every PR inserted its bullet at the same line of `CHANGELOG.md`, so any two open PRs conflicted regardless of what their code touched. Of the last ten merged PRs, all ten changed `CHANGELOG.md` and almost none overlapped elsewhere; of the two open PRs currently marked CONFLICTING, #1303 conflicts on nothing else. Each merge forced a conflict fix plus a second CI run on every other open PR, serially.

## What

- **`changelog.d/<id>.<section>.md` fragments.** A PR adds one file and never touches `CHANGELOG.md`. Convention in `changelog.d/README.md` and `CLAUDE.md`.
- **`scripts/release/assemble_changelog.py`** folds fragments into `[Unreleased]` at release time and deletes them; `--check` previews. It only ever writes into `[Unreleased]`, which also closes the stale-branch trap where a bullet merged into an already-shipped section (5.46.0, 5.49.0).
- **Runs on `main` are no longer cancelled** by the workflow's concurrency group. PRs merge without being up to date with `main`, so the post-merge run is the only check of the combination — and today both of `main`'s runs were cancelled by the next merge before finishing. PR runs are still superseded as before.

## Verification

- `tests/test_assemble_changelog.py` (5 fast tests): fragment goes to the top of an existing section; missing sections are created in canonical order; dated sections are byte-identical; bad names / empty bodies are rejected with the filename.
- End-to-end on the real `CHANGELOG.md`: a test fragment assembled into `[Unreleased] > Fixed` as a one-line diff and was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2NaNcXEuv5YvcKFntcaZ