### PR TITLE
fix(bdc,entity): the BDC register loses companies each January; the credit band had no category

### DIFF
--- a/changelog.d/1120.fixed.md
+++ b/changelog.d/1120.fixed.md
@@ -1,0 +1,1 @@
+**Government-sponsored mortgage enterprises were labelled Operating Company.** No SIC set covered the non-depository credit band, so Fannie Mae, Freddie Mac and Farmer Mac (all SIC 6111) fell through to the default. Ten codes now map to a new `Credit Agency` category that `is_financial_institution()` counts; 6120 joins the bank codes as a depository. (GH #1120)

--- a/changelog.d/1146.fixed.md
+++ b/changelog.d/1146.fixed.md
@@ -1,0 +1,1 @@
+**The BDC register lost companies that the newest yearly report omitted.** `get_bdc_list()` read one year's CSV, and the 2026 report dropped 15 registrants the 2025 one carried — Ares Capital among them — so `is_bdc_cik(1287750)` answered False. The last three reports are now combined, restoring 22 registrants (212 to 234) with the most recent row per CIK. (GH #1146)

--- a/edgar/bdc/reference.py
+++ b/edgar/bdc/reference.py
@@ -625,26 +625,81 @@ def fetch_bdc_report(year: Optional[int] = None) -> pd.DataFrame:
     return df
 
 
+#: How many report years get_bdc_list() combines when no year is given.
+#: See _combined_bdc_report for why one year is not enough.
+BDC_REPORT_UNION_YEARS = 3
+
+
+def _combined_bdc_report(union_years: int = BDC_REPORT_UNION_YEARS) -> pd.DataFrame:
+    """Combine the most recent BDC reports into one registrant list.
+
+    Each yearly CSV is a snapshot taken while that year is still running, not a
+    complete register, and a registrant can be absent from it while remaining a
+    BDC. The 2026 report dropped 15 registrants that the 2025 one carried,
+    Ares Capital -- the largest publicly traded BDC -- among them, so reading
+    the newest year alone made ``is_bdc_cik(1287750)`` answer False and
+    ``find_bdc("ARCC")`` return nothing (GH #1146).
+
+    Note that a completeness check on the newest year would not have caught it:
+    the 2026 report has *more* rows than 2025 (212 against 196), because it
+    added 31 registrants while dropping those 15. Presence in any recent report
+    is the signal that survives, so the years are unioned and the most recent
+    row for a CIK wins.
+    """
+    latest = get_latest_bdc_report_year()
+
+    frames = []
+    for year in range(latest, latest - union_years, -1):
+        try:
+            frame = fetch_bdc_report(year).copy()
+        except Exception as e:
+            # A year the SEC has not published is a 404 and an ordinary miss;
+            # anything else is worth a line, but neither is fatal while some
+            # other year answered.
+            log.debug("No BDC report for %s (%s: %s)", year, type(e).__name__, e)
+            continue
+        frame['report_year'] = year
+        frames.append(frame)
+
+    if not frames:
+        # Every year failed. Let the newest year's failure speak rather than
+        # returning an empty register as though the SEC listed no BDCs.
+        return fetch_bdc_report(latest)
+
+    combined = pd.concat(frames, ignore_index=True)
+
+    # Keep one row per registrant, from the most recent report that carries it,
+    # so names and addresses stay current.
+    combined = combined.sort_values('report_year', ascending=False, kind='stable')
+    if 'cik' in combined.columns:
+        combined = combined[combined['cik'].notna()].drop_duplicates(subset='cik', keep='first')
+
+    return combined.drop(columns='report_year')
+
+
 def get_bdc_list(year: Optional[int] = None) -> BDCEntities:
     """
     Get all BDCs from the SEC BDC Report.
 
     Args:
-        year: The report year. If None, uses the latest available year.
+        year: A specific report year, returned exactly as the SEC published it.
+              If None, the most recent BDC_REPORT_UNION_YEARS reports are
+              combined, because a single year's snapshot can omit registrants
+              that are still BDCs (GH #1146).
 
     Returns:
         BDCEntities collection of all BDCs in the report.
 
     Example:
         >>> bdcs = get_bdc_list()
-        >>> len(bdcs)
-        196
+        >>> len(bdcs) > 200
+        True
         >>> bdcs[0]
         BDCEntity(...)
         >>> bdcs.filter(state='NY')
         BDCEntities with NY-based BDCs
     """
-    df = fetch_bdc_report(year)
+    df = fetch_bdc_report(year) if year is not None else _combined_bdc_report()
 
     bdcs = []
     for _, row in df.iterrows():

--- a/edgar/entity/categorization.py
+++ b/edgar/entity/categorization.py
@@ -30,6 +30,7 @@ __all__ = [
     'SIC_CODES_REIT',
     'SIC_CODES_SPAC',
     'SIC_CODES_BANK',
+    'SIC_CODES_CREDIT_AGENCY',
     'SIC_CODES_INSURANCE',
     'SIC_CODES_INVESTMENT_MANAGER',
     'SIC_CODES_HOLDING_COMPANY',
@@ -56,6 +57,7 @@ class BusinessCategory(str, Enum):
     REIT = "REIT"
     INVESTMENT_MANAGER = "Investment Manager"
     BANK = "Bank"
+    CREDIT_AGENCY = "Credit Agency"
     INSURANCE_COMPANY = "Insurance Company"
     SPAC = "SPAC"
     HOLDING_COMPANY = "Holding Company"
@@ -79,6 +81,27 @@ SIC_CODES_BANK: Set[int] = {
     6029,  # Commercial Banks NEC
     6035,  # Savings Institutions, Federally Chartered
     6036,  # Savings Institutions, Not Federally Chartered
+    6120,  # Savings & Loan Associations — a depository, like 6035/6036
+}
+
+# Non-depository credit institutions: they lend, guarantee or securitize
+# without taking deposits, so no bank SIC covers them and they used to fall
+# through every branch to "Operating Company" -- Fannie Mae, Freddie Mac and
+# Farmer Mac among them (GH #1120).
+#
+# 6189 (Asset-Backed Securities) is deliberately absent: those filers are
+# securitization trusts holding a static pool, not credit institutions, and the
+# code is used by thousands of them.
+SIC_CODES_CREDIT_AGENCY: Set[int] = {
+    6099,  # Functions Related to Depository Banking, NEC
+    6111,  # Federal & Federally-Sponsored Credit Agencies
+    6141,  # Personal Credit Institutions
+    6153,  # Short-Term Business Credit Institutions
+    6159,  # Federal & Federally-Sponsored Credit Agencies
+    6162,  # Mortgage Bankers & Loan Correspondents
+    6163,  # Loan Brokers
+    6172,  # Finance Lessors
+    6199,  # Finance Services
 }
 
 # Insurance Companies
@@ -275,7 +298,14 @@ def classify_business_category(
         if ('TRUST' in name_upper or 'FUND' in name_upper) and 'ROYALTY' not in name_upper:
             return BusinessCategory.ETF.value
 
-    # Step 9: Default to operating company
+    # Step 9: Non-depository credit institutions.
+    # Placed last among the positive branches on purpose: it only catches what
+    # would otherwise be called an Operating Company, so no entity that already
+    # matched a category above can change (GH #1120).
+    if sic_int is not None and sic_int in SIC_CODES_CREDIT_AGENCY:
+        return BusinessCategory.CREDIT_AGENCY.value
+
+    # Step 10: Default to operating company
     # If we have a SIC code and nothing above matched, the entity is an
     # operating company regardless of entity_type. This handles foreign/Canadian
     # filers (entity_type='other') that have clear SIC codes.
@@ -286,7 +316,7 @@ def classify_business_category(
     if entity_type in ('operating', '', None):
         return BusinessCategory.OPERATING_COMPANY.value
 
-    # Step 10: Unknown (no SIC and non-operating entity_type)
+    # Step 11: Unknown (no SIC and non-operating entity_type)
     return BusinessCategory.UNKNOWN.value
 
 

--- a/edgar/entity/core.py
+++ b/edgar/entity/core.py
@@ -902,7 +902,8 @@ class Company(Entity):
         """
         Check if company is a financial institution.
 
-        Includes Banks, Insurance Companies, Investment Managers, and BDCs.
+        Includes Banks, Credit Agencies, Insurance Companies, Investment
+        Managers, and BDCs.
 
         Returns:
             True if classified as a financial institution
@@ -914,7 +915,7 @@ class Company(Entity):
             False
         """
         return self.business_category in [
-            'Bank', 'Insurance Company', 'Investment Manager', 'BDC'
+            'Bank', 'Credit Agency', 'Insurance Company', 'Investment Manager', 'BDC'
         ]
 
     def is_operating_company(self) -> bool:

--- a/tests/issues/regression/test_issue_1120_credit_agency_category.py
+++ b/tests/issues/regression/test_issue_1120_credit_agency_category.py
@@ -1,0 +1,90 @@
+"""Regression test for issue #1120.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1120
+
+`business_category` returned "Operating Company" for the government-sponsored
+mortgage enterprises -- Fannie Mae (CIK 310522), Freddie Mac (1026214) and
+Farmer Mac (845877), all SIC 6111.
+
+Nothing in the 6100 range appeared in any SIC set in `categorization.py`, so the
+whole non-depository credit band missed every definitive branch and fell to the
+default. `SIC_CODES_CREDIT_AGENCY` now covers it and maps to a new
+`BusinessCategory.CREDIT_AGENCY`, which `is_financial_institution()` counts.
+
+The check sits last among the positive branches on purpose: it can only catch
+what would otherwise be called an Operating Company, so nothing that already
+matched a category can change. Measured over every SIC from 1000 to 9998 across
+three names and three entity types -- 107,988 combinations -- 93 answers change
+and all of them are on the ten codes below.
+"""
+
+import pytest
+
+from edgar.entity.categorization import (
+    SIC_CODES_BANK,
+    SIC_CODES_CREDIT_AGENCY,
+    BusinessCategory,
+    classify_business_category,
+)
+
+CREDIT_BAND = sorted(SIC_CODES_CREDIT_AGENCY)
+
+
+@pytest.mark.parametrize("sic", CREDIT_BAND)
+def test_the_non_depository_credit_band_is_not_an_operating_company(sic):
+    category = classify_business_category(
+        sic=sic, entity_type='operating', name='SOME LENDER INC', form_types=set()
+    )
+
+    assert category == BusinessCategory.CREDIT_AGENCY.value
+
+
+@pytest.mark.parametrize("name", [
+    "FEDERAL NATIONAL MORTGAGE ASSOCIATION FANNIE MAE",   # CIK 310522
+    "FEDERAL HOME LOAN MORTGAGE CORP",                    # CIK 1026214
+    "FEDERAL AGRICULTURAL MORTGAGE CORP",                 # CIK 845877
+])
+def test_the_three_gses_from_the_report(name):
+    """All three file under SIC 6111."""
+    category = classify_business_category(
+        sic=6111, entity_type='operating', name=name, form_types=set()
+    )
+
+    assert category == BusinessCategory.CREDIT_AGENCY.value
+
+
+def test_a_credit_agency_is_a_financial_institution():
+    """The wrapper is the only consumer that treats the label as a decision."""
+    financial = ['Bank', 'Credit Agency', 'Insurance Company', 'Investment Manager', 'BDC']
+
+    assert BusinessCategory.CREDIT_AGENCY.value in financial
+
+
+def test_savings_and_loan_associations_are_banks():
+    """6120 is a depository, like the 6035/6036 it now sits beside."""
+    assert 6120 in SIC_CODES_BANK
+    assert classify_business_category(
+        sic=6120, entity_type='operating', name='HOMETOWN SAVINGS', form_types=set()
+    ) == BusinessCategory.BANK.value
+
+
+def test_asset_backed_securities_are_left_alone():
+    """6189 is thousands of securitization trusts, not credit institutions."""
+    assert 6189 not in SIC_CODES_CREDIT_AGENCY
+    assert classify_business_category(
+        sic=6189, entity_type='operating', name='SOME 2024-1 TRUST', form_types=set()
+    ) == BusinessCategory.OPERATING_COMPANY.value
+
+
+@pytest.mark.parametrize("sic,expected", [
+    (6021, BusinessCategory.BANK.value),
+    (6798, BusinessCategory.REIT.value),
+    (6770, BusinessCategory.SPAC.value),
+    (6311, BusinessCategory.INSURANCE_COMPANY.value),
+    (6719, BusinessCategory.HOLDING_COMPANY.value),
+    (3711, BusinessCategory.OPERATING_COMPANY.value),
+])
+def test_the_categories_that_already_worked_are_untouched(sic, expected):
+    assert classify_business_category(
+        sic=sic, entity_type='operating', name='ACME CORP', form_types=set()
+    ) == expected

--- a/tests/issues/regression/test_issue_1146_bdc_report_union.py
+++ b/tests/issues/regression/test_issue_1146_bdc_report_union.py
@@ -1,0 +1,135 @@
+"""Regression test for issue #1146.
+
+GitHub Issue: https://github.com/dgunning/edgartools/issues/1146
+
+`get_bdc_list()` read a single year's BDC report, the one
+`get_latest_bdc_report_year()` picked by walking back until a CSV answered
+HTTP 200. A yearly CSV is a snapshot taken while that year is still running,
+not a complete register: the 2026 report dropped 15 registrants the 2025 one
+carried, Ares Capital -- the largest publicly traded BDC -- among them. So
+`is_bdc_cik(1287750)` answered False and `find_bdc("ARCC")` returned nothing.
+
+**The fix direction recorded on the bead would not have worked.** It proposed
+preferring the newer year only when its row count does not regress. The 2026
+report has *more* rows than 2025 (212 against 196) because it added 31
+registrants while dropping those 15, so a row-count guard still picks 2026 and
+still loses Ares. Presence in any recent report is the signal that survives, so
+`_combined_bdc_report` unions the last three years and keeps the most recent
+row per CIK.
+
+Per the standing rule that BDC tests must not hardcode a volatile issuer, the
+live check below asserts the year-selection property and anchors on MAIN, which
+is present across report years; Ares appears only in the offline fixtures, where
+its absence is the thing being simulated.
+"""
+
+import pandas as pd
+import pytest
+
+from edgar.bdc import reference
+from edgar.bdc.reference import get_active_bdc_ciks, get_bdc_list, is_bdc_cik
+
+ARCC = 1287750
+MAIN = 1396440
+
+
+def _report(rows):
+    return pd.DataFrame([
+        {'file_number': f'814-{cik:05d}'[:9], 'cik': cik, 'registrant_name': name,
+         'city': 'NEW YORK', 'state': 'NY', 'zip_code': '10019',
+         'last_filing_date': pd.Timestamp('2025-05-29'), 'last_filing_type': '10-K'}
+        for cik, name in rows
+    ])
+
+
+@pytest.fixture
+def snapshot_reports(monkeypatch):
+    """The shape of the reported failure: the newest year is bigger and still
+    drops a registrant."""
+    reports = {
+        2026: _report([(MAIN, 'MAIN STREET CAPITAL CORP')]
+                      + [(9_000_000 + n, f'NEW BDC {n}') for n in range(30)]),
+        2025: _report([(MAIN, 'MAIN STREET CAPITAL CORP'),
+                       (ARCC, 'ARES CAPITAL CORP'),
+                       (1143513, 'GLADSTONE CAPITAL CORP')]),
+        2024: _report([(MAIN, 'MAIN STREET CAPITAL CORP'),
+                       (ARCC, 'ARES CAPITAL CORP'),
+                       (1512931, 'MONROE CAPITAL Corp')]),
+    }
+
+    def fake_fetch(year=None):
+        if year is None:
+            year = 2026
+        if year not in reports:
+            raise ValueError(f"no BDC report for {year}")
+        return reports[year]
+
+    monkeypatch.setattr(reference, 'fetch_bdc_report', fake_fetch)
+    monkeypatch.setattr(reference, 'get_latest_bdc_report_year', lambda: 2026)
+    get_active_bdc_ciks.cache_clear()
+    yield reports
+    get_active_bdc_ciks.cache_clear()
+
+
+def test_the_newest_report_is_larger_and_still_loses_a_registrant(snapshot_reports):
+    """Guards the premise: a row-count check cannot detect this."""
+    assert len(snapshot_reports[2026]) > len(snapshot_reports[2025])
+    assert ARCC not in set(snapshot_reports[2026]['cik'])
+
+
+def test_a_registrant_missing_from_the_newest_report_is_still_a_bdc(snapshot_reports):
+    combined = reference._combined_bdc_report()
+    ciks = set(combined['cik'])
+
+    assert ARCC in ciks
+    assert MAIN in ciks
+    assert 1143513 in ciks    # dropped in 2026, present in 2025
+    assert 1512931 in ciks    # present only in 2024
+
+
+def test_the_combined_register_has_no_duplicate_registrants(snapshot_reports):
+    combined = reference._combined_bdc_report()
+
+    assert len(combined) == len(set(combined['cik']))
+    assert len(combined) == 34   # 31 from 2026, 2 more from 2025, 1 more from 2024
+
+
+def test_an_explicit_year_still_returns_that_year_exactly(snapshot_reports):
+    """The union is what you get when you ask for "the BDCs", not for a year."""
+    assert len(get_bdc_list(year=2026)) == 31
+    assert len(get_bdc_list(year=2025)) == 3
+    assert len(get_bdc_list()) == 34
+
+
+def test_the_public_lookups_follow(snapshot_reports):
+    assert is_bdc_cik(ARCC) is True
+    assert is_bdc_cik(MAIN) is True
+    assert ARCC in get_active_bdc_ciks(min_year=2023)
+
+
+def test_one_unavailable_year_does_not_empty_the_register(monkeypatch):
+    """Only the newest year exists -- the older probes must not be fatal."""
+    only_2026 = _report([(MAIN, 'MAIN STREET CAPITAL CORP')])
+
+    def fake_fetch(year=None):
+        if year in (None, 2026):
+            return only_2026
+        raise ValueError("404")
+
+    monkeypatch.setattr(reference, 'fetch_bdc_report', fake_fetch)
+    monkeypatch.setattr(reference, 'get_latest_bdc_report_year', lambda: 2026)
+
+    combined = reference._combined_bdc_report()
+    assert set(combined['cik']) == {MAIN}
+
+
+@pytest.mark.network
+def test_live_register_does_not_lose_registrants_the_prior_year_listed():
+    """The property, against the SEC's own data."""
+    latest = reference.get_latest_bdc_report_year()
+    previous = set(reference.fetch_bdc_report(latest - 1)['cik'].dropna().astype(int))
+    combined = {bdc.cik for bdc in get_bdc_list()}
+
+    missing = previous - combined
+    assert not missing, f"registrants listed in {latest - 1} are absent from the register: {sorted(missing)[:10]}"
+    assert MAIN in combined


### PR DESCRIPTION
Batch D of the open-issue triage — the two non-XBRL bugs.

## The BDC register drops companies whenever a new year's report appears (#1146, `edgartools-ykkg`)

`get_bdc_list()` read one year's CSV, the one `get_latest_bdc_report_year()` picked by walking back until a file answered HTTP 200. A yearly CSV is a snapshot taken while that year is still running, not a complete register. The 2026 report dropped 15 registrants the 2025 one carried — Ares Capital, the largest publicly traded BDC, along with Gladstone Capital, Monroe Capital, Great Elm and FS Specialty Lending. So `is_bdc_cik(1287750)` answered `False` and `find_bdc("ARCC")` returned an empty table.

**The fix direction recorded on the bead would not have worked, and the bead is corrected.** It proposed preferring the newer year only when its row count does not regress:

| report | rows | Ares Capital |
|---|---|---|
| 2026 | 212 | absent |
| 2025 | 196 | present |

2026 is *larger* — it added 31 registrants while dropping 15 — so a row-count guard still picks it and still loses Ares. Presence in any recent report is the signal that survives, so `_combined_bdc_report()` unions the last three reports and keeps the most recent row per CIK. Every consumer funnels through `get_bdc_list()`, so one edit covers `get_active_bdc_ciks`, `is_bdc_cik`, `find_bdc`, `BDCSearchIndex` and the MCP fund tool. `get_bdc_list(year=N)` still returns that year exactly as published.

Measured live: **234 registrants** against 212, no duplicate CIKs, Ares restored with its 2025 row, 193 active CIKs. `get_latest_bdc_report_year()` is unchanged — the union removes its load-bearing role rather than trying to make the probe smarter.

## The non-depository credit band had no category (#1120, `edgartools-xxbw`)

No SIC set covered it, so Fannie Mae, Freddie Mac and Farmer Mac — all SIC 6111 — missed every definitive branch and fell to the operating-company default. Ten codes now map to a new `BusinessCategory.CREDIT_AGENCY`, which `is_financial_institution()` counts, and 6120 joins the bank codes because a savings and loan association is a depository like the 6035/6036 beside it.

Two judgement calls worth flagging:

- **6189 (Asset-Backed Securities) is deliberately excluded.** Those filers are securitization trusts holding a static pool, not credit institutions, and thousands of them use the code — including it would relabel a large population on a guess.
- **The new check sits last among the positive branches**, immediately before the default, so it can only catch what would otherwise be called an Operating Company. Nothing that already matched a category can move.

Classifying every SIC from 1000 to 9998 across three names and three entity types — 107,988 combinations — **93 answers change, all on the ten intended codes**: 90 `Operating Company → Credit Agency`, and 3 `ETF → Bank` at SIC 6120 on a synthetic name containing "ETF", which is the definitive bank branch correctly preempting a name heuristic.

## Verification

`hatch run test-fast`: **7,236 passed**. BDC network tests against live SEC data: **236 passed**.

The #1146 regression pins the row-count trap as a test: offline fixtures reproduce the larger-but-lossier shape, so a future "just compare row counts" fix fails. Its one live check asserts the property — no registrant the prior year listed may be missing — and anchors on MAIN rather than a volatile issuer.

Fixes #1146
Fixes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)