### PR TITLE
docs: correct quickstart Python requirement and cash flow alias

### DIFF
--- a/changelog.d/installation-python-version.fixed.md
+++ b/changelog.d/installation-python-version.fixed.md
@@ -1,0 +1,1 @@
+**The installation guide's Python requirement was outdated.** `docs/installation.md` listed Python 3.8+ in two places (System Requirements and the venv setup section) while `pyproject.toml` requires `>=3.10`. Both now read 3.10, matching package metadata.

--- a/changelog.d/quickstart-requirements.fixed.md
+++ b/changelog.d/quickstart-requirements.fixed.md
@@ -1,0 +1,1 @@
+**Quickstart prerequisites and cash flow guidance were outdated.** The guide now requires Python 3.10, matching package metadata, and identifies `cashflow_statement()` as deprecated in favor of `cash_flow_statement()`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ Get started with edgartools in minutes. This guide covers all installation metho
 
 ## System Requirements
 
-- **Python**: 3.8 or higher
+- **Python**: 3.10 or higher
 
 ## Quick Installation
 
@@ -159,7 +159,7 @@ If you encounter issues:
 
 For isolated development, use virtual environments:
 
-### Using venv (Python 3.8+)
+### Using venv (Python 3.10+)
 
 ```bash
 # Create virtual environment

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Get up and running with EdgarTools in 5 minutes. By the end, you'll have a compa
 
 ## Prerequisites
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 - Internet connection
 - Basic familiarity with Python
 
@@ -73,7 +73,8 @@ cashflow  = financials.cash_flow_statement()
 That's it — three lines to get any company's income statement, balance sheet, or cash flow.
 
 !!! note "Common gotcha"
-    The canonical method is `cash_flow_statement()`, but `cash_flow_statement()` also works.
+    Use `cash_flow_statement()` for cash flow statements. The older alias
+    `cashflow_statement()` is deprecated and will be removed in v6.0.
     All three statements: `income_statement()`, `balance_sheet()`, `cash_flow_statement()`.
 
 ## Step 5: Get Specific Values


### PR DESCRIPTION
The quickstart lists Python 3.8 even though `pyproject.toml` requires Python >=3.10. Its cash-flow gotcha also repeats `cash_flow_statement()` as its own alternative, hiding the deprecated alias.

This updates the prerequisite to Python 3.10 and identifies `cashflow_statement()` as deprecated, with removal planned for v6.0, matching `Financials.cashflow_statement()` in `edgar/financials.py`. Includes a changelog fragment; executable examples and library code are unchanged.

Validation: checked both statements against current package metadata and the alias implementation; verified the committed quickstart matches the intended edit and all fenced code examples remain unchanged. Full Hatch lint/coverage and the documentation build have not been run, so this is submitted as a draft.

Prepared with OpenAI Codex assistance.